### PR TITLE
Update README with structure and usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DevOnboarder
 
-This repository follows a **trunk-based** development workflow.
+This repository showcases a **trunk‑based** workflow and a minimal container setup used by Codex.
 
 ## Trunk-Based Workflow
 
@@ -9,3 +9,43 @@ This repository follows a **trunk-based** development workflow.
 - Changes are merged back into `main` via pull requests after review.
 - Feature branches are deleted after they are merged to keep history clean.
 
+## Directory Overview
+
+- `config/` – Optional configuration files. Empty by default.
+- `scripts/` – Helper scripts for bootstrapping and environment setup.
+- `.devcontainer/` – Holds dev container configuration (tracked with `.gitkeep`).
+- `docker-compose.yml` – Base compose file for production deployments.
+- `docker-compose.dev.yaml` – Compose file used for local development.
+- `docker-compose.codex.yml` – Compose file used when running in Codex.
+- `docker-compose.override.yaml` – Overrides applied on top of the base compose file.
+- `devonboarder.config.yml` – Configuration file consumed by the `devonboarder` tool.
+
+## Local Development
+
+Build and start the development container defined in `devcontainer.dev.json`:
+
+```bash
+devcontainer dev --workspace-folder . --config devcontainer.dev.json
+```
+
+Alternatively, you can run the Docker Compose setup directly:
+
+```bash
+docker compose -f docker-compose.dev.yaml up
+```
+
+## Codex Runs
+
+Codex uses its own compose file. To invoke it manually:
+
+```bash
+docker compose -f docker-compose.codex.yml up
+```
+
+## Production Deployment
+
+Use the main compose file (with overrides) to deploy the application:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.override.yaml up -d
+```


### PR DESCRIPTION
## Summary
- expand README with directory overview
- document devcontainer, Codex, and production commands

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684cd8f1c0a88320a87c0566fef3187b