### PR TITLE
Add CI workflow using setup script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup environment
+        run: ./scripts/setup-env.sh
+      - name: Run tests
+        run: echo "Running tests..."


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow
- run scripts/setup-env.sh before running placeholder tests

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684cdaa70484832092023394765f52e0