### PR TITLE
Add devcontainer configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,10 @@
+{
+  "name": "DevOnboarder Container",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "forwardPorts": [3000],
+  "postCreateCommand": "scripts/setup-env.sh",
+  "settings": {
+    "terminal.integrated.defaultProfile.linux": "bash",
+    "terminal.integrated.shell.linux": "/bin/bash"
+  }
+}


### PR DESCRIPTION
## Summary
- add `.devcontainer/devcontainer.json` referencing a base image
- forward default dev port and run setup script on container creation
- configure default shell profile

## Testing
- `./scripts/setup-env.sh`

------
https://chatgpt.com/codex/tasks/task_e_684cf10cbf6c832099764f5707540938