### PR TITLE
Add Redis service to docker-compose.dev

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -3,3 +3,7 @@ services:
   app:
     build: .
     command: ["echo", "dev environment"]
+  redis:
+    image: redis:latest
+    ports:
+      - "6379:6379"


### PR DESCRIPTION
## Summary
- add a redis service to `docker-compose.dev.yaml`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684cf5df394c8320b980bd6735b59d17