### PR TITLE
v0.1.0 updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,17 +1,35 @@
-# General OS artifacts
+# OS files
 .DS_Store
 Thumbs.db
+.Trash-*
 
-# Editor directories and files
+# IDE folders
 .vscode/
 .idea/
-*~
-*.swp
-*.swo
+*.sublime-*
 
-# Dependency artifacts
-node_modules/
-venv/
+# Python artifacts
+__pycache__/
+*.py[cod]
 .venv/
-vendor/
-target/
+venv/
+.env*
+
+# JS artifacts
+node_modules/
+dist/
+coverage/
+.nyc_output/
+pnpm-lock.yaml
+
+# Local/Codex caches
+.codex/
+.vscode-integrations/
+logs/
+.env.dev
+
+# Misc
+.terraform/
+lcov-report/
+codeql-*
+

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2025 DevOnboarder
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # DevOnboarder
 
-This repository showcases a **trunk‑based** workflow and a minimal container setup used by Codex.
+This repository showcases a **trunk-based** workflow and a minimal
+container setup used by Codex.
 
 ## Trunk-Based Workflow
 
@@ -13,23 +14,24 @@ This repository showcases a **trunk‑based** workflow and a minimal container s
 
 - `config/` – Configuration files, including `devonboarder.config.yml`.
 - `scripts/` – Helper scripts for bootstrapping and environment setup.
-- `.devcontainer/` – Holds dev container configuration (tracked with `.gitkeep`).
+- `.devcontainer/` – Dev container configuration (tracked with `.gitkeep`).
 - `docker-compose.yml` – Base compose file for production deployments.
-- `docker-compose.dev.yaml` – Compose file used for local development and includes
-  a Redis service exposed on port `6379`.
+- `docker-compose.dev.yaml` – Compose file for local development.
+  Includes a Redis service exposed on port `6379`.
 - `docker-compose.codex.yml` – Compose file used when running in Codex.
-- `docker-compose.override.yaml` – Overrides applied on top of the base compose file.
-- `config/devonboarder.config.yml` – Configuration file consumed by the `devonboarder` tool.
+- `docker-compose.override.yaml` – Overrides for the base compose file.
+- `config/devonboarder.config.yml` – Config for the `devonboarder` tool.
 
 ## Local Development
 
-Build and start the development container defined in `.devcontainer/devcontainer.json`:
+Build the development container defined in `.devcontainer/devcontainer.json`:
 
 ```bash
 devcontainer dev --workspace-folder . --config .devcontainer/devcontainer.json
 ```
 
-Alternatively, you can run the Docker Compose setup directly. This will start the
+Alternatively, you can run the Docker Compose setup directly.
+This will start the
 application along with a Redis container on port `6379`:
 
 ```bash
@@ -53,3 +55,13 @@ Use the main compose file (with overrides) to deploy the application:
 ```bash
 docker compose -f docker-compose.yml -f docker-compose.override.yaml up -d
 ```
+
+## Quickstart
+1. cp .env.example .env.dev
+2. bash scripts/setup-env.sh
+3. docker-compose -f docker-compose.dev.yaml up -d
+4. pytest -q
+
+## License
+This project is licensed under the MIT License. See LICENSE.md.
+

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,3 @@
+# Infrastructure
+
+This directory contains infrastructure blueprints and deployment notes.

--- a/infra/blueprint-aurora.md
+++ b/infra/blueprint-aurora.md
@@ -1,0 +1,5 @@
+---
+title: Aurora Blueprint
+---
+
+TBD

--- a/infra/blueprint-laramie.md
+++ b/infra/blueprint-laramie.md
@@ -1,0 +1,5 @@
+---
+title: Laramie Blueprint
+---
+
+TBD

--- a/scripts/setup-env.sh
+++ b/scripts/setup-env.sh
@@ -1,4 +1,30 @@
 #!/usr/bin/env bash
-# Placeholder setup script
-# Add environment bootstrap commands here
-echo "Setting up environment..."
+# Bootstrap environment for local or Codex usage
+
+set -euo pipefail
+
+echo "Checking Docker availability..."
+if docker info >/dev/null 2>&1; then
+    echo "Docker is available ✅"
+    echo "Pulling Codex image..."
+    docker pull ghcr.io/openai/codex-universal
+    echo "Running universal setup..."
+    docker run --rm -v "$(pwd)":/workspace \
+        ghcr.io/openai/codex-universal /opt/codex/setup_universal.sh
+    echo "Docker-based setup complete ✅"
+else
+    echo "Docker not usable, falling back to local setup"
+    python3 -m venv venv
+    source venv/bin/activate
+    python -m pip install --upgrade pip
+    if [ -f requirements-dev.txt ]; then
+        pip install -r requirements-dev.txt
+    fi
+    if [ -d frontend ]; then
+        cd frontend
+        pnpm install
+        cd ..
+    fi
+    export PYTHONPATH="$(pwd)"
+    echo "Local environment ready ✅"
+fi


### PR DESCRIPTION
## Summary
- expand `.gitignore` coverage
- add Quickstart instructions and licensing to README
- include MIT `LICENSE.md`
- scaffold infrastructure directory
- flesh out environment setup script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d0cf3e1188320be9783e2ecf1e147