### PR TITLE
Add Ruff linter and dev requirements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,12 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.11'
-      - name: Install test dependencies
-        run: pip install pytest
+      - name: Install dev dependencies
+        run: pip install -r requirements-dev.txt
       - name: Setup environment
         run: ./scripts/setup-env.sh
+      - name: Run linter
+        run: ruff check .
       - name: Start docker compose
         run: docker compose -f docker-compose.dev.yaml up -d
       - name: Run tests

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,3 +3,4 @@
 All notable changes to this project will be recorded in this file.
 
 - Added `src/app.py` with `greet` function and updated smoke tests.
+- Added `requirements-dev.txt` and `pyproject.toml` with ruff configuration. Updated CI to run the linter.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,18 @@
 # Documentation Placeholder
 
 This file will contain onboarding instructions and an overview of project documentation.
+
+## Development Tips
+
+Install development dependencies:
+
+```bash
+pip install -r requirements-dev.txt
+```
+
+Run the linter before committing changes:
+
+```bash
+ruff check .
+```
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[tool.ruff]
+line-length = 88
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "F"]
+

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+ruff
+pytest


### PR DESCRIPTION
## Summary
- configure Ruff linter via `pyproject.toml`
- add `requirements-dev.txt` for development dependencies
- document development tips for installing deps and running the linter
- update changelog
- run Ruff in CI before tests

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d17e7b5188320ac15232fbc9f002b