### PR TITLE
Add env example and update quickstart docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Environment configuration for DevOnboarder
+# Copy this file to .env.dev and update values as needed.
+
+# Application environment
+APP_ENV=development
+
+# Redis connection settings
+REDIS_URL=redis://localhost:6379/0
+
+# Logging level
+LOG_LEVEL=INFO

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ __pycache__/
 .venv/
 venv/
 .env*
+!.env.example
 
 # JS artifacts
 node_modules/

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ container setup used by Codex.
 - `docker-compose.codex.yml` – Compose file used when running in Codex.
 - `docker-compose.override.yaml` – Overrides for the base compose file.
 - `config/devonboarder.config.yml` – Config for the `devonboarder` tool.
+- `.env.example` – Sample environment variables for local development.
 
 ## Local Development
 
@@ -57,10 +58,10 @@ docker compose -f docker-compose.yml -f docker-compose.override.yaml up -d
 ```
 
 ## Quickstart
-1. cp .env.example .env.dev
-2. bash scripts/setup-env.sh
-3. docker-compose -f docker-compose.dev.yaml up -d
-4. pytest -q
+1. Copy `.env.example` to `.env.dev` and adjust values as needed.
+2. Run `bash scripts/setup-env.sh` to install dependencies.
+3. Start the services with `docker compose -f docker-compose.dev.yaml up -d`.
+4. Execute the tests using `pytest -q`.
 
 ## License
 This project is licensed under the MIT License. See LICENSE.md.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,3 +4,4 @@ All notable changes to this project will be recorded in this file.
 
 - Added `src/app.py` with `greet` function and updated smoke tests.
 - Added `requirements-dev.txt` and `pyproject.toml` with ruff configuration. Updated CI to run the linter.
+- Added `.env.example` and documented setup steps in the README.


### PR DESCRIPTION
## Summary
- add `.env.example` to document environment variables
- track the example env file in git
- update README directory overview and quickstart instructions
- note the new file in the changelog

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684d199596148320b3c0b7cec4aa69b3