### PR TITLE
Add pre-PR checklist and reviewer sign-off

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,3 +8,5 @@ All notable changes to this project will be recorded in this file.
 - Documented branch naming, commit messages, and rebase policy in the Git guidelines.
 - Expanded `docs/pull_request_template.md` with sections for summary, linked issues,
   screenshots, testing steps, and a checklist referencing documentation and changelog updates.
+- Documented the requirement to pass lint and tests, update documentation and the changelog,
+  and added a reviewer sign-off section to the pull request template.

--- a/docs/git-guidelines.md
+++ b/docs/git-guidelines.md
@@ -42,3 +42,17 @@ git pull --rebase origin main
 
 Pull requests are merged using **Squash and merge** to keep history linear.
 Delete the feature branch after the merge completes.
+
+## Pre-PR Checklist
+
+Before opening a pull request, make sure to:
+
+- Rebase your branch on the latest `main`.
+- Run the linter and tests to confirm they pass:
+
+```bash
+ruff check .
+pytest -q
+```
+- Update `docs/CHANGELOG.md` with a short summary of your change.
+- Update any other relevant documentation under `docs/`.

--- a/docs/merge-checklist.md
+++ b/docs/merge-checklist.md
@@ -1,3 +1,8 @@
-# Merge Checklist Placeholder
+# Maintainer Merge Checklist
 
-Steps maintainers must complete before merging a pull request will be documented here.
+Reviewers must verify the following before merging a pull request:
+
+- [ ] All tests and lint checks pass.
+- [ ] `docs/CHANGELOG.md` includes an entry for the change.
+- [ ] Documentation in `docs/` is updated as needed.
+- [ ] The pull request contains a completed reviewer sign-off section.

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -24,3 +24,7 @@ pytest -q
 - [ ] Updated `docs/CHANGELOG.md`
 - [ ] Updated relevant documentation in `docs/`
 - [ ] Lint and tests pass
+
+# Reviewer Sign-Off
+
+- [ ] I, the reviewer, confirm the checklist above is complete.


### PR DESCRIPTION
## Summary
- document lint and test requirements in Git guidelines
- expand maintainer merge checklist
- add Reviewer Sign-Off section to PR template
- record changes in the changelog

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684d22987e70832090b6a275c89e9cd8