### PR TITLE
Add database URL placeholder

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,5 +7,8 @@ APP_ENV=development
 # Redis connection settings
 REDIS_URL=redis://localhost:6379/0
 
+# Database connection settings
+DATABASE_URL=postgres://user:pass@localhost:5432/db
+
 # Logging level
 LOG_LEVEL=INFO

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be recorded in this file.
 ## [Unreleased]
 - Documented how to propose issues and pull requests in `docs/README.md`.
 - Added a README section pointing to workflow docs under `docs/`.
+- Added `DATABASE_URL` placeholder to `.env.example`.
 
 ## [0.1.0] - 2025-06-14
 - Added `src/app.py` with `greet` function and updated smoke tests. [#21](https://github.com/theangrygamershowproductions/DevOnboarder/pull/21)


### PR DESCRIPTION
## Summary
- update `.env.example` with a `DATABASE_URL` placeholder
- document the new variable in the changelog

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684d2c80ebe083209a3d4e8b78dc5517