### PR TITLE
Ignore pytest and ruff caches

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -24,6 +24,8 @@ pnpm-lock.yaml
 .vscode-integrations/
 .idea/
 logs/
+.pytest_cache/
+.ruff_cache/
 
 # Tests and coverage reports
 tests/

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,8 @@ pnpm-lock.yaml
 .vscode-integrations/
 logs/
 .env.dev
+.pytest_cache/
+.ruff_cache/
 
 # Misc
 .terraform/

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be recorded in this file.
 - Added `DATABASE_URL` placeholder to `.env.example`.
 - Expanded `scripts/bootstrap.sh` to create `.env.dev` and run the environment setup script.
 - Added `.dockerignore` to reduce the Docker build context by excluding caches and tests.
+- Ignored `.pytest_cache/` and `.ruff_cache/` in `.gitignore` and `.dockerignore`.
 - Expanded infrastructure blueprints with usage notes.
 - Clarified dev container usage in the README.
 - Replaced `docs/README.md` placeholder with onboarding instructions and local development steps.


### PR DESCRIPTION
## Summary
- ignore `.pytest_cache/` and `.ruff_cache/` in version control
- extend `.dockerignore` to exclude the same caches
- record change in `docs/CHANGELOG.md`

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684edda6f644832087eb198185467c3b