### PR TITLE
Add Python-based Dockerfile and CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,10 @@
-FROM alpine:latest
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements-dev.txt ./
+RUN pip install --no-cache-dir -r requirements-dev.txt
+
+COPY . ./
+
+CMD ["python", "src/cli.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,4 @@
 version: "3.8"
 services:
   app:
-    image: alpine:latest
-    command: ["echo", "hello world"]
+    build: .

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,8 @@ All notable changes to this project will be recorded in this file.
 - Added configuration helper files and documented their usage.
 - Added test for the bootstrap script and removed the unused Postgres
   service from CI.
+- Replaced the placeholder Docker image with a Python-based image and updated
+  `docker-compose.yml` and tests accordingly.
 
 ## [0.1.0] - 2025-06-14
 - Added `src/app.py` with `greet` function and updated smoke tests. [#21](https://github.com/theangrygamershowproductions/DevOnboarder/pull/21)

--- a/src/cli.py
+++ b/src/cli.py
@@ -1,0 +1,13 @@
+import argparse
+from app import greet
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="DevOnboarder CLI")
+    parser.add_argument("name", nargs="?", default="World", help="Name to greet")
+    args = parser.parse_args()
+    print(greet(args.name))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_docker_compose.py
+++ b/tests/test_docker_compose.py
@@ -18,8 +18,9 @@ def test_dev_compose_has_redis_service():
     assert "6379:6379" in ports
 
 
-def test_base_compose_app_command():
-    """Base compose file has the expected app command."""
+def test_base_compose_builds_image():
+    """Base compose file builds the application image."""
     compose = load_compose("docker-compose.yml")
-    command = compose["services"]["app"].get("command")
-    assert command == ["echo", "hello world"]
+    service = compose["services"]["app"]
+    assert "build" in service
+    assert "command" not in service


### PR DESCRIPTION
# Summary
- build Docker image from `python:3.11-slim`
- run a small CLI script
- update compose file to build the image
- adjust docker-compose test
- document the change in the changelog

# Linked Issues

# Screenshots

# Testing Steps
```bash
ruff check .
pytest -q
```

# Checklist
- [x] Updated `docs/CHANGELOG.md`
- [x] Updated relevant documentation in `docs/`
- [x] Lint and tests pass

# Reviewer Sign-Off
- [ ] I, the reviewer, confirm the checklist above is complete.

------
https://chatgpt.com/codex/tasks/task_e_6850ee6bd03c83209ba52cc69234bc2b