### PR TITLE
Add HTTP server entrypoint

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -2,7 +2,7 @@ version: "3.8"
 services:
   app:
     build: .
-    command: ["echo", "dev environment"]
+    command: ["python", "src/server.py"]
   redis:
     image: redis:latest
     ports:

--- a/docker-compose.override.yaml
+++ b/docker-compose.override.yaml
@@ -1,4 +1,4 @@
 version: "3.8"
 services:
   app:
-    command: ["echo", "override"]
+    command: ["python", "src/server.py"]

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be recorded in this file.
   service from CI.
 - Replaced the placeholder Docker image with a Python-based image and updated
   `docker-compose.yml` and tests accordingly.
+- Added a minimal HTTP server and configured the app service to run it.
 
 ## [0.1.0] - 2025-06-14
 - Added `src/app.py` with `greet` function and updated smoke tests. [#21](https://github.com/theangrygamershowproductions/DevOnboarder/pull/21)

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,8 +6,9 @@ Welcome to **DevOnboarder**. This page explains how to get your environment runn
 
 1. Run `bash scripts/bootstrap.sh` to create `.env.dev` and install dependencies.
 2. Start services with `docker compose -f docker-compose.dev.yaml up -d`.
-3. Verify changes with `ruff check .` and `pytest -q` before committing.
-4. Install git hooks with `pre-commit install` so these checks run automatically.
+3. Visit `http://localhost:8000` to see the greeting server.
+4. Verify changes with `ruff check .` and `pytest -q` before committing.
+5. Install git hooks with `pre-commit install` so these checks run automatically.
 
 ## Key Documentation
 

--- a/src/server.py
+++ b/src/server.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+from app import greet
+
+
+class GreetingHandler(BaseHTTPRequestHandler):
+    """HTTP request handler that greets the requested name."""
+
+    def do_GET(self) -> None:  # type: ignore[override]
+        name = self.path.lstrip("/") or "World"
+        message = greet(name)
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain; charset=utf-8")
+        self.end_headers()
+        self.wfile.write(message.encode("utf-8"))
+
+    def log_message(self, format: str, *args: object) -> None:  # noqa: D401
+        """Silence default logging output for cleaner tests."""
+        return
+
+
+def create_server(host: str = "0.0.0.0", port: int = 8000) -> HTTPServer:
+    """Create an HTTP server serving :class:`GreetingHandler`."""
+    return HTTPServer((host, port), GreetingHandler)
+
+
+def main() -> None:
+    """Run the greeting HTTP server until interrupted."""
+    server = create_server()
+    host, port = server.server_address
+    print(f"Serving on {host}:{port}")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import sys
+import threading
+import urllib.request
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from server import create_server
+
+
+def test_http_server_greets_name():
+    server = create_server("127.0.0.1", 0)
+    host, port = server.server_address
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        with urllib.request.urlopen(f"http://{host}:{port}/Codex") as resp:
+            body = resp.read().decode()
+        assert body == "Hello, Codex!"
+    finally:
+        server.shutdown()
+        thread.join()


### PR DESCRIPTION
# Summary
- run a small greeting web server instead of the echo command
- start the server from compose files
- document the new server and changelog entry
- test the HTTP server

# Testing Steps
```bash
ruff check .
pytest -q
```


------
https://chatgpt.com/codex/tasks/task_e_685117df8c808320860944162243d4de