### PR TITLE
Add project metadata and editable install

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,9 @@ docker compose -f docker-compose.yml -f docker-compose.override.yaml up -d
 
 ## Quickstart
 1. Run `bash scripts/bootstrap.sh` to copy `.env.example` to `.env.dev` and install dependencies.
-2. Start the services with `docker compose -f docker-compose.dev.yaml up -d`.
-3. Execute the tests using `pytest -q`.
+2. Install the project with `pip install -e .`.
+3. Start the services with `docker compose -f docker-compose.dev.yaml up -d`.
+4. Execute the tests using `pytest -q`.
 
 ## License
 This project is licensed under the MIT License. See LICENSE.md.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be recorded in this file.
 - Replaced the placeholder Docker image with a Python-based image and updated
   `docker-compose.yml` and tests accordingly.
 - Added a minimal HTTP server and configured the app service to run it.
+- Defined project metadata in `pyproject.toml` and added a console script entry point.
 
 ## [0.1.0] - 2025-06-14
 - Added `src/app.py` with `greet` function and updated smoke tests. [#21](https://github.com/theangrygamershowproductions/DevOnboarder/pull/21)

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,10 +5,11 @@ Welcome to **DevOnboarder**. This page explains how to get your environment runn
 ## Local Development
 
 1. Run `bash scripts/bootstrap.sh` to create `.env.dev` and install dependencies.
-2. Start services with `docker compose -f docker-compose.dev.yaml up -d`.
-3. Visit `http://localhost:8000` to see the greeting server.
-4. Verify changes with `ruff check .` and `pytest -q` before committing.
-5. Install git hooks with `pre-commit install` so these checks run automatically.
+2. Install the project in editable mode with `pip install -e .`.
+3. Start services with `docker compose -f docker-compose.dev.yaml up -d`.
+4. Visit `http://localhost:8000` to see the greeting server.
+5. Verify changes with `ruff check .` and `pytest -q` before committing.
+6. Install git hooks with `pre-commit install` so these checks run automatically.
 
 ## Key Documentation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,14 @@ target-version = "py311"
 [tool.ruff.lint]
 select = ["E", "F"]
 
+[project]
+name = "devonboarder"
+version = "0.1.0"
+description = "Sample trunk-based workflow project"
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = []
+
+[project.scripts]
+devonboarder = "cli:main"
+

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,8 +1,3 @@
-from pathlib import Path
-import sys
-
-sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
-
 from app import greet
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,11 +1,7 @@
 from __future__ import annotations
 
-import sys
 import threading
 import urllib.request
-from pathlib import Path
-
-sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
 
 from server import create_server
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,10 +1,5 @@
 """Smoke tests for the DevOnboarder project."""
 
-from pathlib import Path
-import sys
-
-sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
-
 from app import greet
 
 


### PR DESCRIPTION
# Summary
- define project metadata in `pyproject.toml`
- expose `devonboarder` CLI entry point
- remove `sys.path` hacks from tests
- document editable installs in README files
- record change in changelog

# Testing Steps
```bash
pip install -r requirements-dev.txt
pip install -e .
ruff check .
pytest -q
```


------
https://chatgpt.com/codex/tasks/task_e_685119f47264832080dbbbe0e746f532