### PR TITLE
Add test for setup-env fallback logic

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be recorded in this file.
 - Added configuration helper files and documented their usage.
 - Added test for the bootstrap script and removed the unused Postgres
   service from CI.
+- Added test for `setup-env.sh` that verifies virtual environment creation when Docker is unavailable.
 - Replaced the placeholder Docker image with a Python-based image and updated
   `docker-compose.yml` and tests accordingly.
 - Added a minimal HTTP server and configured the app service to run it.

--- a/tests/test_setup_env.py
+++ b/tests/test_setup_env.py
@@ -1,0 +1,33 @@
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+
+def test_setup_env_without_docker(tmp_path):
+    """setup-env.sh should create a venv and install deps when Docker is unavailable."""
+    repo_root = Path(__file__).resolve().parents[1]
+    shutil.copy(repo_root / "scripts" / "setup-env.sh", tmp_path / "setup-env.sh")
+    shutil.copy(repo_root / "requirements-dev.txt", tmp_path / "requirements-dev.txt")
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    docker_stub = bin_dir / "docker"
+    docker_stub.write_text("#!/bin/sh\nexit 1\n")
+    docker_stub.chmod(0o755)
+
+    env = os.environ.copy()
+    env["PATH"] = str(bin_dir) + os.pathsep + env.get("PATH", "")
+
+    subprocess.run(
+        ["bash", str(tmp_path / "setup-env.sh")],
+        cwd=tmp_path,
+        env=env,
+        check=True,
+    )
+
+    venv_dir = tmp_path / "venv"
+    assert (venv_dir / "bin" / "python").exists()
+
+    result = subprocess.check_output([venv_dir / "bin" / "pip", "list"], text=True)
+    assert "PyYAML" in result


### PR DESCRIPTION
## Summary
- ensure `setup-env.sh` creates a venv when Docker isn't available
- document the new test in the changelog

## Testing Steps
```bash
ruff check .
pytest -q
```


------
https://chatgpt.com/codex/tasks/task_e_68512152d3288320b5d2999391efeac1