### PR TITLE
Update Docker start commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,6 @@ COPY requirements-dev.txt ./
 RUN pip install --no-cache-dir -r requirements-dev.txt
 
 COPY . ./
+RUN pip install --no-cache-dir .
 
-CMD ["python", "src/cli.py"]
+CMD ["devonboarder"]

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ devcontainer dev --workspace-folder . --config .devcontainer/devcontainer.json
 ```
 
 Alternatively, you can run the Docker Compose setup directly.
-This will start the
-application along with a Redis container on port `6379`:
+This will start the application (executed via `python -m devonboarder.server`)
+along with a Redis container on port `6379`:
 
 ```bash
 docker compose -f docker-compose.dev.yaml up
@@ -73,6 +73,7 @@ docker compose -f docker-compose.yml -f docker-compose.override.yaml up -d
 1. Run `bash scripts/bootstrap.sh` to copy `.env.example` to `.env.dev` and install dependencies.
 2. Install the project with `pip install -e .`.
 3. Start the services with `docker compose -f docker-compose.dev.yaml up -d`.
+   The app container launches via `python -m devonboarder.server`.
 4. Execute the tests using `pytest -q`.
 
 ## License

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -2,7 +2,7 @@ version: "3.8"
 services:
   app:
     build: .
-    command: ["python", "src/server.py"]
+    command: ["python", "-m", "devonboarder.server"]
   redis:
     image: redis:latest
     ports:

--- a/docker-compose.override.yaml
+++ b/docker-compose.override.yaml
@@ -1,4 +1,4 @@
 version: "3.8"
 services:
   app:
-    command: ["python", "src/server.py"]
+    command: ["python", "-m", "devonboarder.server"]

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,6 +25,8 @@ All notable changes to this project will be recorded in this file.
 - CI workflow now installs the package before running tests.
 - Defined project metadata in `pyproject.toml` and added a console script entry point.
 - Restructured source into a `devonboarder` package and updated tests to import modules by package path.
+- Dockerfile installs the package and uses the CLI entrypoint.
+- Compose files start the server via `python -m devonboarder.server`.
 
 ## [0.1.0] - 2025-06-14
 - Added `src/app.py` with `greet` function and updated smoke tests. [#21](https://github.com/theangrygamershowproductions/DevOnboarder/pull/21)


### PR DESCRIPTION
# Summary
- install the package in the Docker image and run it using the console script
- run the server via `python -m devonboarder.server` in compose files
- document the new commands in the README
- note the change in the changelog

# Testing Steps
```bash
ruff check .
pytest -q
```


------
https://chatgpt.com/codex/tasks/task_e_68513137bc408320b093df92cd28e30b