### PR TITLE
Add early-user onboarding templates

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to this project will be recorded in this file.
 - Restructured source into a `devonboarder` package and updated tests to import modules by package path.
 - Dockerfile installs the package and uses the CLI entrypoint.
 - Compose files start the server via `python -m devonboarder.server`.
+- Added onboarding templates for invite-only alpha testers and the founder's circle.
 
 ## [0.1.0] - 2025-06-14
 - Added `src/app.py` with `greet` function and updated smoke tests. [#21](https://github.com/theangrygamershowproductions/DevOnboarder/pull/21)

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,8 @@ Welcome to **DevOnboarder**. This page explains how to get your environment runn
 - [Pull request template](pull_request_template.md) &ndash; describe your changes and verify the checklist.
 - [Merge checklist](merge-checklist.md) &ndash; steps maintainers use before merging.
 - [Changelog](CHANGELOG.md) &ndash; record notable updates for each release.
+- [Invite-only alpha onboarding](invite-only-alpha.md) &ndash; guide for early testers.
+- [Founder's circle onboarding](founders-circle.md) &ndash; roles and perks for core supporters.
 
 ## Configuration Helpers
 

--- a/docs/founders-circle.md
+++ b/docs/founders-circle.md
@@ -1,0 +1,18 @@
+# Founder's Circle Onboarding
+
+Members of the Founder's Circle help guide the long-term vision of the project.
+
+## What We Ask
+- Provide strategic feedback on features and roadmap direction.
+- Participate in invite-only alphas and share insight on usability.
+- Act as ambassadors and help spread the word once we launch.
+
+## Perks
+- Early or permanent access to new functionality.
+- Recognition in project documentation.
+- A direct line to the maintainers for major decisions.
+
+## Getting Started
+1. Introduce yourself in the private Founder's Circle channel.
+2. Review [docs/README.md](README.md) to set up your environment.
+3. Join scheduled feedback sessions or submit pull requests with improvements.

--- a/docs/invite-only-alpha.md
+++ b/docs/invite-only-alpha.md
@@ -1,0 +1,18 @@
+# Invite-Only Alpha Onboarding
+
+This template outlines how to onboard early testers who receive special access.
+
+## Objectives
+- Exercise the system in real conditions.
+- Gather bug reports and user experience feedback.
+- Prepare for a broader release after issues are addressed.
+
+## Steps for Participants
+1. Accept your invitation and join the private communication channel.
+2. Follow [docs/README.md](README.md) to set up the project locally.
+3. Use the app and note any problems or confusing areas.
+4. Submit feedback through the issue tracker or provided survey link.
+5. Expect occasional downtime or breaking changes while we iterate.
+
+## Thank You
+Invite-only testers help shape the stability of the project. Your feedback directly influences upcoming releases.


### PR DESCRIPTION
## Summary
- create templates for invite-only alpha testers and founder's circle members
- link the new docs from the main onboarding README
- note the additions in the changelog

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'devonboarder')*

------
https://chatgpt.com/codex/tasks/task_e_6853b5dc77c083209c08d28a11bb0f15