### PR TITLE
Organize onboarding docs into subfolders

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project will be recorded in this file.
 - Dockerfile installs the package and uses the CLI entrypoint.
 - Compose files start the server via `python -m devonboarder.server`.
 - Added onboarding templates for invite-only alpha testers and the founder's circle.
+- Moved onboarding docs into `docs/alpha/` and `docs/founders/` with new feedback and charter files.
 
 ## [0.1.0] - 2025-06-14
 - Added `src/app.py` with `greet` function and updated smoke tests. [#21](https://github.com/theangrygamershowproductions/DevOnboarder/pull/21)

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,8 +17,8 @@ Welcome to **DevOnboarder**. This page explains how to get your environment runn
 - [Pull request template](pull_request_template.md) &ndash; describe your changes and verify the checklist.
 - [Merge checklist](merge-checklist.md) &ndash; steps maintainers use before merging.
 - [Changelog](CHANGELOG.md) &ndash; record notable updates for each release.
-- [Invite-only alpha onboarding](invite-only-alpha.md) &ndash; guide for early testers.
-- [Founder's circle onboarding](founders-circle.md) &ndash; roles and perks for core supporters.
+- [Alpha tester onboarding](alpha/README.md) &ndash; guide for early testers.
+- [Founder's Circle onboarding](founders/README.md) &ndash; roles and perks for core supporters.
 
 ## Configuration Helpers
 

--- a/docs/alpha/README.md
+++ b/docs/alpha/README.md
@@ -9,7 +9,7 @@ This template outlines how to onboard early testers who receive special access.
 
 ## Steps for Participants
 1. Accept your invitation and join the private communication channel.
-2. Follow [docs/README.md](README.md) to set up the project locally.
+2. Follow [docs/README.md](../README.md) to set up the project locally.
 3. Use the app and note any problems or confusing areas.
 4. Submit feedback through the issue tracker or provided survey link.
 5. Expect occasional downtime or breaking changes while we iterate.

--- a/docs/alpha/feedback-form.md
+++ b/docs/alpha/feedback-form.md
@@ -1,0 +1,12 @@
+# Alpha Tester Feedback
+
+We value your input while the project is still in a limited invite-only phase.
+
+## How to Submit Feedback
+
+1. Open an issue in the private tracker with a clear title and description.
+2. Include reproduction steps or screenshots when applicable.
+3. If you prefer, fill out the anonymous survey link provided in your invitation email.
+4. For urgent issues, mention a maintainer in the chat channel so we can respond quickly.
+
+Thank you for helping us improve the project!

--- a/docs/founders/README.md
+++ b/docs/founders/README.md
@@ -14,5 +14,5 @@ Members of the Founder's Circle help guide the long-term vision of the project.
 
 ## Getting Started
 1. Introduce yourself in the private Founder's Circle channel.
-2. Review [docs/README.md](README.md) to set up your environment.
+2. Review [docs/README.md](../README.md) to set up your environment.
 3. Join scheduled feedback sessions or submit pull requests with improvements.

--- a/docs/founders/charter.md
+++ b/docs/founders/charter.md
@@ -1,0 +1,13 @@
+# Founder's Circle Charter
+
+This document outlines expectations for members of the Founder's Circle and clarifies the policy around the role.
+
+## Expectations
+
+- Participate in quarterly roadmap discussions and provide strategic guidance.
+- Test pre-release features and report issues early.
+- Uphold the community code of conduct at all times.
+
+## Role Policy
+
+Membership is by invitation only. Founder's Circle members may be listed as advisers but hold no legal authority over the project. The maintainers reserve the right to revoke membership if expectations are not met.


### PR DESCRIPTION
## Summary
- move invite-only alpha guide to `docs/alpha/README.md`
- add `docs/alpha/feedback-form.md`
- move founder docs to `docs/founders/README.md`
- add `docs/founders/charter.md`
- update links in documentation
- note changes in `CHANGELOG`

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6853bc6a57848320994e9c53ee10ff40