### PR TITLE
Add email templates for alpha and founders

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be recorded in this file.
 - Compose files start the server via `python -m devonboarder.server`.
 - Added onboarding templates for invite-only alpha testers and the founder's circle.
 - Moved onboarding docs into `docs/alpha/` and `docs/founders/` with new feedback and charter files.
+- Added invitation email templates under the `emails/` directory.
 
 ## [0.1.0] - 2025-06-14
 - Added `src/app.py` with `greet` function and updated smoke tests. [#21](https://github.com/theangrygamershowproductions/DevOnboarder/pull/21)

--- a/docs/alpha/README.md
+++ b/docs/alpha/README.md
@@ -16,3 +16,5 @@ This template outlines how to onboard early testers who receive special access.
 
 ## Thank You
 Invite-only testers help shape the stability of the project. Your feedback directly influences upcoming releases.
+
+For a sample invitation, see [emails/invite_alpha_email.md](../../emails/invite_alpha_email.md).

--- a/docs/founders/README.md
+++ b/docs/founders/README.md
@@ -16,3 +16,5 @@ Members of the Founder's Circle help guide the long-term vision of the project.
 1. Introduce yourself in the private Founder's Circle channel.
 2. Review [docs/README.md](../README.md) to set up your environment.
 3. Join scheduled feedback sessions or submit pull requests with improvements.
+
+Need a reference email? See [emails/founders_invite.md](../../emails/founders_invite.md) for a template you can adapt.

--- a/emails/founders_invite.md
+++ b/emails/founders_invite.md
@@ -1,0 +1,13 @@
+Hello <Name>,
+
+We're thrilled to have you as a Founder's Circle member. Your support shapes our roadmap.
+
+As thanks, you receive:
+- Priority access to new features
+- Recognition in our documentation
+- A direct line to the maintainers
+
+We look forward to building with you!
+
+Cheers,
+The DevOnboarder Team

--- a/emails/invite_alpha_email.md
+++ b/emails/invite_alpha_email.md
@@ -1,0 +1,11 @@
+Hello <Name>,
+
+Thank you for agreeing to test our early alpha release. To join:
+
+1. Accept the invite link to access the private channel.
+2. Follow the setup instructions in the repository.
+
+Please share feedback or issues so we can improve quickly.
+
+Thanks again,
+The DevOnboarder Team


### PR DESCRIPTION
## Summary
- provide invite email for alpha testers
- add a founders' circle invitation email
- reference the templates from onboarding docs
- log the addition in the changelog

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853be1510c48320a818ec4b9568902c