### PR TITLE
Add founders and alpha tester tracking docs

### DIFF
--- a/ALPHA_TESTERS.md
+++ b/ALPHA_TESTERS.md
@@ -1,0 +1,8 @@
+# Alpha Testers Log
+
+This file records everyone invited to private testing phases.
+
+| GitHub Username | Invitation Date | Feedback Status |
+| --------------- | --------------- | --------------- |
+| @tester | 2025-06-20 | pending |
+

--- a/FOUNDERS.md
+++ b/FOUNDERS.md
@@ -1,0 +1,8 @@
+# Founders Log
+
+This file tracks members of the Founder's Circle and their primary contributions.
+
+| GitHub Username | Name | Contribution Type |
+| --------------- | ---- | ----------------- |
+| @octocat | Jane Example | Advisor |
+

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Workflow documentation lives under the [docs/](docs/) directory. New contributor
 2. Follow [docs/git-guidelines.md](docs/git-guidelines.md) for branch and commit policies.
 3. Use [docs/pull_request_template.md](docs/pull_request_template.md) when opening a pull request.
 4. Verify merges with [docs/merge-checklist.md](docs/merge-checklist.md).
+5. Track community members in [FOUNDERS.md](FOUNDERS.md) and [ALPHA_TESTERS.md](ALPHA_TESTERS.md).
 
 These files expand on the steps listed in the Quickstart section.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to this project will be recorded in this file.
 - Added onboarding templates for invite-only alpha testers and the founder's circle.
 - Moved onboarding docs into `docs/alpha/` and `docs/founders/` with new feedback and charter files.
 - Added invitation email templates under the `emails/` directory.
+- Added `FOUNDERS.md` and `ALPHA_TESTERS.md` to track community members.
 
 ## [0.1.0] - 2025-06-14
 - Added `src/app.py` with `greet` function and updated smoke tests. [#21](https://github.com/theangrygamershowproductions/DevOnboarder/pull/21)

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,8 @@ Welcome to **DevOnboarder**. This page explains how to get your environment runn
 - [Changelog](CHANGELOG.md) &ndash; record notable updates for each release.
 - [Alpha tester onboarding](alpha/README.md) &ndash; guide for early testers.
 - [Founder's Circle onboarding](founders/README.md) &ndash; roles and perks for core supporters.
+- [Alpha testers log](../ALPHA_TESTERS.md) &ndash; track invitations and feedback status.
+- [Founders log](../FOUNDERS.md) &ndash; record core contributors and how they help.
 
 ## Configuration Helpers
 

--- a/docs/alpha/README.md
+++ b/docs/alpha/README.md
@@ -13,6 +13,7 @@ This template outlines how to onboard early testers who receive special access.
 3. Use the app and note any problems or confusing areas.
 4. Submit feedback through the issue tracker or provided survey link.
 5. Expect occasional downtime or breaking changes while we iterate.
+6. Update [../../ALPHA_TESTERS.md](../../ALPHA_TESTERS.md) with your feedback status.
 
 ## Thank You
 Invite-only testers help shape the stability of the project. Your feedback directly influences upcoming releases.

--- a/docs/founders/README.md
+++ b/docs/founders/README.md
@@ -16,5 +16,6 @@ Members of the Founder's Circle help guide the long-term vision of the project.
 1. Introduce yourself in the private Founder's Circle channel.
 2. Review [docs/README.md](../README.md) to set up your environment.
 3. Join scheduled feedback sessions or submit pull requests with improvements.
+4. Add yourself to [../../FOUNDERS.md](../../FOUNDERS.md) so we can track contributions.
 
 Need a reference email? See [emails/founders_invite.md](../../emails/founders_invite.md) for a template you can adapt.


### PR DESCRIPTION
## Summary
- add FOUNDERS.md and ALPHA_TESTERS.md
- reference the new tracking files in documentation
- record docs update in changelog

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853c0309f108320b8db6df16b93e143