### PR TITLE
Add feature flags for alpha and founder access

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,7 @@ DATABASE_URL=postgres://user:pass@localhost:5432/db
 
 # Logging level
 LOG_LEVEL=INFO
+
+# Feature flags
+IS_ALPHA_USER=false
+IS_FOUNDER=false

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to this project will be recorded in this file.
 - Moved onboarding docs into `docs/alpha/` and `docs/founders/` with new feedback and charter files.
 - Added invitation email templates under the `emails/` directory.
 - Added `FOUNDERS.md` and `ALPHA_TESTERS.md` to track community members.
+- Added `IS_ALPHA_USER` and `IS_FOUNDER` flags to `.env.example` with server routes and documentation.
 
 ## [0.1.0] - 2025-06-14
 - Added `src/app.py` with `greet` function and updated smoke tests. [#21](https://github.com/theangrygamershowproductions/DevOnboarder/pull/21)

--- a/docs/alpha/README.md
+++ b/docs/alpha/README.md
@@ -15,6 +15,9 @@ This template outlines how to onboard early testers who receive special access.
 5. Expect occasional downtime or breaking changes while we iterate.
 6. Update [../../ALPHA_TESTERS.md](../../ALPHA_TESTERS.md) with your feedback status.
 
+## Alpha Feature Flag
+Set `IS_ALPHA_USER=true` in your `.env.dev` file to enable access to routes meant only for testers. See `.env.example` for the default value.
+
 ## Thank You
 Invite-only testers help shape the stability of the project. Your feedback directly influences upcoming releases.
 

--- a/docs/founders/README.md
+++ b/docs/founders/README.md
@@ -18,4 +18,7 @@ Members of the Founder's Circle help guide the long-term vision of the project.
 3. Join scheduled feedback sessions or submit pull requests with improvements.
 4. Add yourself to [../../FOUNDERS.md](../../FOUNDERS.md) so we can track contributions.
 
+## Founder Feature Flag
+Set `IS_FOUNDER=true` in your `.env.dev` file to unlock founder-only routes. The `.env.example` file lists this variable for reference.
+
 Need a reference email? See [emails/founders_invite.md](../../emails/founders_invite.md) for a template you can adapt.

--- a/src/devonboarder/server.py
+++ b/src/devonboarder/server.py
@@ -1,17 +1,43 @@
 from __future__ import annotations
 
 from http.server import BaseHTTPRequestHandler, HTTPServer
+import os
 
 from .app import greet
+
+
+def is_alpha_user() -> bool:
+    """Return ``True`` if the alpha feature flag is enabled."""
+    return os.getenv("IS_ALPHA_USER", "false").lower() == "true"
+
+
+def is_founder() -> bool:
+    """Return ``True`` if the founder feature flag is enabled."""
+    return os.getenv("IS_FOUNDER", "false").lower() == "true"
 
 
 class GreetingHandler(BaseHTTPRequestHandler):
     """HTTP request handler that greets the requested name."""
 
     def do_GET(self) -> None:  # type: ignore[override]
-        name = self.path.lstrip("/") or "World"
-        message = greet(name)
-        self.send_response(200)
+        path = self.path.lstrip("/") or "World"
+        status = 200
+        if path == "alpha":
+            if is_alpha_user():
+                message = "Welcome to the alpha program!"
+            else:
+                status = 403
+                message = "Alpha access required."
+        elif path == "founder":
+            if is_founder():
+                message = "Founder access granted."
+            else:
+                status = 403
+                message = "Founders only."
+        else:
+            message = greet(path)
+
+        self.send_response(status)
         self.send_header("Content-Type", "text/plain; charset=utf-8")
         self.end_headers()
         self.wfile.write(message.encode("utf-8"))

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import threading
+import urllib.error
 import urllib.request
 
 from devonboarder.server import create_server
@@ -15,6 +16,54 @@ def test_http_server_greets_name():
         with urllib.request.urlopen(f"http://{host}:{port}/Codex") as resp:
             body = resp.read().decode()
         assert body == "Hello, Codex!"
+    finally:
+        server.shutdown()
+        thread.join()
+
+
+def _start_server():
+    server = create_server("127.0.0.1", 0)
+    host, port = server.server_address
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, host, port, thread
+
+
+def test_alpha_route_denied_without_flag():
+    server, host, port, thread = _start_server()
+    try:
+        try:
+            urllib.request.urlopen(f"http://{host}:{port}/alpha")
+        except urllib.error.HTTPError as exc:
+            body = exc.read().decode()
+            assert exc.code == 403
+            assert "Alpha access required." in body
+        else:
+            raise AssertionError("expected HTTPError")
+    finally:
+        server.shutdown()
+        thread.join()
+
+
+def test_alpha_route_allowed_with_flag(monkeypatch):
+    monkeypatch.setenv("IS_ALPHA_USER", "true")
+    server, host, port, thread = _start_server()
+    try:
+        with urllib.request.urlopen(f"http://{host}:{port}/alpha") as resp:
+            body = resp.read().decode()
+        assert body == "Welcome to the alpha program!"
+    finally:
+        server.shutdown()
+        thread.join()
+
+
+def test_founder_route_allowed_with_flag(monkeypatch):
+    monkeypatch.setenv("IS_FOUNDER", "true")
+    server, host, port, thread = _start_server()
+    try:
+        with urllib.request.urlopen(f"http://{host}:{port}/founder") as resp:
+            body = resp.read().decode()
+        assert body == "Founder access granted."
     finally:
         server.shutdown()
         thread.join()


### PR DESCRIPTION
## Summary
- add `IS_ALPHA_USER` and `IS_FOUNDER` variables to `.env.example`
- gate new `/alpha` and `/founder` routes in the HTTP server using the flags
- test alpha/founder feature flag behaviour
- document the flags in alpha and founder onboarding guides
- log the change in the changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853c2647aa48320a239cb85ecc8e17c