### PR TITLE
Add alpha feedback tracking template

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable changes to this project will be recorded in this file.
 - Added invitation email templates under the `emails/` directory.
 - Added `FOUNDERS.md` and `ALPHA_TESTERS.md` to track community members.
 - Added `IS_ALPHA_USER` and `IS_FOUNDER` flags to `.env.example` with server routes and documentation.
+- Added `docs/alpha/feedback-template.md` and linked it from the alpha README.
 
 ## [0.1.0] - 2025-06-14
 - Added `src/app.py` with `greet` function and updated smoke tests. [#21](https://github.com/theangrygamershowproductions/DevOnboarder/pull/21)

--- a/docs/alpha/README.md
+++ b/docs/alpha/README.md
@@ -14,6 +14,7 @@ This template outlines how to onboard early testers who receive special access.
 4. Submit feedback through the issue tracker or provided survey link.
 5. Expect occasional downtime or breaking changes while we iterate.
 6. Update [../../ALPHA_TESTERS.md](../../ALPHA_TESTERS.md) with your feedback status.
+7. Track progress in [feedback-template.md](feedback-template.md) as issues are addressed.
 
 ## Alpha Feature Flag
 Set `IS_ALPHA_USER=true` in your `.env.dev` file to enable access to routes meant only for testers. See `.env.example` for the default value.
@@ -22,3 +23,4 @@ Set `IS_ALPHA_USER=true` in your `.env.dev` file to enable access to routes mean
 Invite-only testers help shape the stability of the project. Your feedback directly influences upcoming releases.
 
 For a sample invitation, see [emails/invite_alpha_email.md](../../emails/invite_alpha_email.md).
+

--- a/docs/alpha/feedback-template.md
+++ b/docs/alpha/feedback-template.md
@@ -1,0 +1,8 @@
+# Alpha Feedback Tracker
+
+Use this table to track incoming feedback from invite-only testers.
+
+| User ID | Date Invited | Feedback | Resolution Status |
+|---------|--------------|---------|-------------------|
+|         |              |         |                   |
+


### PR DESCRIPTION
## Summary
- add feedback log template for invite-only testers
- reference it from the alpha onboarding guide
- record the addition in the changelog

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6853c5cc259483209fa9233ae959e78d