### PR TITLE
Add feedback dashboard PRD

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -34,6 +34,7 @@ All notable changes to this project will be recorded in this file.
 - Added `FOUNDERS.md` and `ALPHA_TESTERS.md` to track community members.
 - Added `IS_ALPHA_USER` and `IS_FOUNDER` flags to `.env.example` with server routes and documentation.
 - Added `docs/alpha/feedback-template.md` and linked it from the alpha README.
+- Added feedback dashboard PRD under `docs/prd/` and linked it from the docs README.
 
 ## [0.1.0] - 2025-06-14
 - Added `src/app.py` with `greet` function and updated smoke tests. [#21](https://github.com/theangrygamershowproductions/DevOnboarder/pull/21)

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,7 @@ Welcome to **DevOnboarder**. This page explains how to get your environment runn
 - [Alpha tester onboarding](alpha/README.md) &ndash; guide for early testers.
 - [Founder's Circle onboarding](founders/README.md) &ndash; roles and perks for core supporters.
 - [Alpha phase roadmap](roadmap/alpha-phase.md) &ndash; pre- and post-launch milestones.
+- [Feedback dashboard PRD](prd/feedback-dashboard.md) &ndash; objectives and features for the feedback tool.
 - [Alpha testers log](../ALPHA_TESTERS.md) &ndash; track invitations and feedback status.
 - [Founders log](../FOUNDERS.md) &ndash; record core contributors and how they help.
 

--- a/docs/prd/feedback-dashboard.md
+++ b/docs/prd/feedback-dashboard.md
@@ -1,0 +1,23 @@
+# Feedback Dashboard PRD
+
+This document defines the requirements for an internal dashboard that collects and surfaces community feedback.
+
+## Objectives
+- Centralize incoming reports from testers and founders.
+- Provide maintainers with a clear view of bug reports and feature requests.
+- Encourage transparency by showing progress on submitted items.
+
+## Personas
+- **Maintainer** – triages feedback and updates item status.
+- **Alpha tester** – submits issues and monitors resolutions.
+- **Founder** – reviews overall trends to steer the roadmap.
+
+## Major Features
+1. **Submission form** connected to the existing issue tracker.
+2. **Status tracking** with states like "open", "in progress", and "closed".
+3. **Analytics snapshot** summarizing the volume and type of feedback.
+
+## Stretch Goals
+- Real-time updates via WebSockets.
+- OAuth login so testers can view their personal history.
+- CSV export of all feedback metrics.


### PR DESCRIPTION
## Summary
- document feedback dashboard requirements under `docs/prd/`
- link the new PRD from the docs README
- note the new document in the changelog

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853d059798483209c4e87ee48799ca0