### PR TITLE
Add email style guide and update templates

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -35,6 +35,7 @@ All notable changes to this project will be recorded in this file.
 - Added `IS_ALPHA_USER` and `IS_FOUNDER` flags to `.env.example` with server routes and documentation.
 - Added `docs/alpha/feedback-template.md` and linked it from the alpha README.
 - Added feedback dashboard PRD under `docs/prd/` and linked it from the docs README.
+- Refined email templates and added a style guide under `emails/`.
 
 ## [0.1.0] - 2025-06-14
 - Added `src/app.py` with `greet` function and updated smoke tests. [#21](https://github.com/theangrygamershowproductions/DevOnboarder/pull/21)

--- a/docs/alpha/README.md
+++ b/docs/alpha/README.md
@@ -23,4 +23,5 @@ Set `IS_ALPHA_USER=true` in your `.env.dev` file to enable access to routes mean
 Invite-only testers help shape the stability of the project. Your feedback directly influences upcoming releases.
 
 For a sample invitation, see [emails/invite_alpha_email.md](../../emails/invite_alpha_email.md).
+Refer to [emails/style-guide.md](../../emails/style-guide.md) for our email tone guidelines.
 

--- a/docs/founders/README.md
+++ b/docs/founders/README.md
@@ -22,3 +22,4 @@ Members of the Founder's Circle help guide the long-term vision of the project.
 Set `IS_FOUNDER=true` in your `.env.dev` file to unlock founder-only routes. The `.env.example` file lists this variable for reference.
 
 Need a reference email? See [emails/founders_invite.md](../../emails/founders_invite.md) for a template you can adapt.
+Refer to [emails/style-guide.md](../../emails/style-guide.md) for tone guidelines when you reach out.

--- a/emails/founders_invite.md
+++ b/emails/founders_invite.md
@@ -1,13 +1,12 @@
 Hello <Name>,
 
-We're thrilled to have you as a Founder's Circle member. Your support shapes our roadmap.
+Welcome to the Founder's Circle! Your insight will help steer our roadmap.
 
-As thanks, you receive:
 - Priority access to new features
 - Recognition in our documentation
 - A direct line to the maintainers
 
-We look forward to building with you!
+We look forward to building with you, so feel free to share ideas anytime.
 
 Cheers,
 The DevOnboarder Team

--- a/emails/invite_alpha_email.md
+++ b/emails/invite_alpha_email.md
@@ -1,11 +1,11 @@
 Hello <Name>,
 
-Thank you for agreeing to test our early alpha release. To join:
+Thanks for joining our alpha! We're excited to hear what you think.
 
-1. Accept the invite link to access the private channel.
+1. Accept the invite to our private channel.
 2. Follow the setup instructions in the repository.
 
-Please share feedback or issues so we can improve quickly.
+Your feedback will directly shape our launch, so please send any questions or ideas our way.
 
-Thanks again,
+Cheers,
 The DevOnboarder Team

--- a/emails/style-guide.md
+++ b/emails/style-guide.md
@@ -1,0 +1,9 @@
+# Email Style Guide
+
+These guidelines ensure our emails are consistent and friendly.
+
+- Write in an upbeat, welcoming tone.
+- Keep messages brief and actionable.
+- Mention the value to the recipient.
+- Invite questions or feedback.
+- Close with "The DevOnboarder Team."


### PR DESCRIPTION
## Summary
- create style guide for our email tone
- rewrite invitation templates to match the guide
- link style guide from the alpha and founders onboarding docs
- note email refinements in the changelog

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853d25208248320ad5a83e64129fa99