### PR TITLE
Add founder route permission test

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable changes to this project will be recorded in this file.
 - Added `docs/alpha/feedback-template.md` and linked it from the alpha README.
 - Added feedback dashboard PRD under `docs/prd/` and linked it from the docs README.
 - Refined email templates and added a style guide under `emails/`.
+- Added test ensuring the `/founder` route returns `403` unless `IS_FOUNDER` is set.
 
 ## [0.1.0] - 2025-06-14
 - Added `src/app.py` with `greet` function and updated smoke tests. [#21](https://github.com/theangrygamershowproductions/DevOnboarder/pull/21)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -57,6 +57,22 @@ def test_alpha_route_allowed_with_flag(monkeypatch):
         thread.join()
 
 
+def test_founder_route_denied_without_flag():
+    server, host, port, thread = _start_server()
+    try:
+        try:
+            urllib.request.urlopen(f"http://{host}:{port}/founder")
+        except urllib.error.HTTPError as exc:
+            body = exc.read().decode()
+            assert exc.code == 403
+            assert "Founders only." in body
+        else:
+            raise AssertionError("expected HTTPError")
+    finally:
+        server.shutdown()
+        thread.join()
+
+
 def test_founder_route_allowed_with_flag(monkeypatch):
     monkeypatch.setenv("IS_FOUNDER", "true")
     server, host, port, thread = _start_server()


### PR DESCRIPTION
## Summary
- add founder route permission regression test
- document the new test in changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853d53c5d108320ade300d22bf6e1fc