### PR TITLE
Update founders README with charter link

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be recorded in this file.
 - Added a README section pointing to workflow docs under `docs/`.
 - Added `DATABASE_URL` placeholder to `.env.example`.
 - Expanded `scripts/bootstrap.sh` to create `.env.dev` and run the environment setup script.
+- Linked `docs/founders/charter.md` from the founders README.
 - Added `.dockerignore` to reduce the Docker build context by excluding caches and tests.
 - Ignored `.pytest_cache/` and `.ruff_cache/` in `.gitignore` and `.dockerignore`.
 - Expanded infrastructure blueprints with usage notes.

--- a/docs/founders/README.md
+++ b/docs/founders/README.md
@@ -17,6 +17,7 @@ Members of the Founder's Circle help guide the long-term vision of the project.
 2. Review [docs/README.md](../README.md) to set up your environment.
 3. Join scheduled feedback sessions or submit pull requests with improvements.
 4. Add yourself to [../../FOUNDERS.md](../../FOUNDERS.md) so we can track contributions.
+5. Read the [Founder's Circle charter](charter.md) to understand expectations.
 
 ## Founder Feature Flag
 Set `IS_FOUNDER=true` in your `.env.dev` file to unlock founder-only routes. The `.env.example` file lists this variable for reference.


### PR DESCRIPTION
## Summary
- link to the charter from the founders README
- document the README change in the changelog

## Testing
- `pip install -q -r requirements-dev.txt`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853d9ee0b508320b0efa1ae15e51141