### PR TITLE
Update onboarding docs with direct links

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ Workflow documentation lives under the [docs/](docs/) directory. New contributor
 3. Use [docs/pull_request_template.md](docs/pull_request_template.md) when opening a pull request.
 4. Verify merges with [docs/merge-checklist.md](docs/merge-checklist.md).
 5. Track community members in [FOUNDERS.md](FOUNDERS.md) and [ALPHA_TESTERS.md](ALPHA_TESTERS.md).
+6. Review [docs/alpha/README.md](docs/alpha/README.md) if you are an early tester.
+7. See [docs/founders/README.md](docs/founders/README.md) for Founder's Circle guidelines.
+8. Follow our [emails/style-guide.md](emails/style-guide.md) when crafting invitations.
 
 These files expand on the steps listed in the Quickstart section.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable changes to this project will be recorded in this file.
 - Added test ensuring the `/founder` route returns `403` unless `IS_FOUNDER` is set.
 - Documented when to use the feedback form versus filing issues in
   `docs/alpha/README.md` and linked the form.
+- Added README links to `docs/alpha/README.md`, `docs/founders/README.md`, and the email style guide for easier navigation.
 
 ## [0.1.0] - 2025-06-14
 - Added `src/app.py` with `greet` function and updated smoke tests. [#21](https://github.com/theangrygamershowproductions/DevOnboarder/pull/21)


### PR DESCRIPTION
## Summary
- link to more onboarding docs and the email style guide
- note the new pointers in the changelog

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6853dd7b77bc8320b33c674d479ee111