### PR TITLE
Add Discord message templates

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -43,6 +43,7 @@ All notable changes to this project will be recorded in this file.
   `docs/alpha/README.md` and linked the form.
 - Added README links to `docs/alpha/README.md`, `docs/founders/README.md`, and the email style guide for easier navigation.
 - Removed `Potato.md` from `.gitignore`.
+- Added Discord message templates and linked them from the docs README.
 
 ## [0.1.0] - 2025-06-14
 - Added `src/app.py` with `greet` function and updated smoke tests. [#21](https://github.com/theangrygamershowproductions/DevOnboarder/pull/21)

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,7 @@ Welcome to **DevOnboarder**. This page explains how to get your environment runn
 - [Founder's Circle onboarding](founders/README.md) &ndash; roles and perks for core supporters.
 - [Alpha phase roadmap](roadmap/alpha-phase.md) &ndash; pre- and post-launch milestones.
 - [Feedback dashboard PRD](prd/feedback-dashboard.md) &ndash; objectives and features for the feedback tool.
+- [Discord message templates](discord/discord-message-templates.md) &ndash; sample posts for the community.
 - [Alpha testers log](../ALPHA_TESTERS.md) &ndash; track invitations and feedback status.
 - [Founders log](../FOUNDERS.md) &ndash; record core contributors and how they help.
 

--- a/docs/discord/discord-message-templates.md
+++ b/docs/discord/discord-message-templates.md
@@ -1,0 +1,48 @@
+# Discord Message Templates
+
+Use these predefined messages to communicate consistently in the community server.
+
+## 1. Welcome
+```
+Hey everyone, welcome to the DevOnboarder Discord! We're glad to have you here.
+```
+
+## 2. Getting Started
+```
+If you're new, check out the docs repo and follow the setup instructions in docs/README.md.
+```
+
+## 3. Release Announcement
+```
+The latest version is live! See the changelog for details and let us know what you think.
+```
+
+## 4. Community Guidelines
+```
+Please keep conversations friendly and on topic. Refer to the code of conduct for full rules.
+```
+
+## 5. Bug Reporting
+```
+Found a bug? Open an issue on GitHub with steps to reproduce so we can investigate.
+```
+
+## 6. Support Request
+```
+Need help? Drop your question here and someone from the team will respond as soon as possible.
+```
+
+## 7. Contribution Call
+```
+We're looking for contributors to help with upcoming features. Ping us if you're interested!
+```
+
+## 8. Event Reminder
+```
+Don't forget our community call this Friday. Check the calendar for the meeting link.
+```
+
+## 9. Farewell
+```
+Thanks for being part of the community. See you next time!
+```


### PR DESCRIPTION
## Summary
- add Discord message templates
- link the new templates from `docs/README.md`
- note the addition in the changelog

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6853e62befb8832097b44b7384fd32a8