### PR TITLE
Add alpha wave rollout guide

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be recorded in this file.
 - Documented how to propose issues and pull requests in `docs/README.md`.
 - Added an alpha phase roadmap under `docs/roadmap/` and linked it from the docs README.
 - Added a README section pointing to workflow docs under `docs/`.
+- Documented the alpha wave rollout process in `docs/alpha/alpha-wave-rollout-guide.md` and linked it from the docs.
 - Added `DATABASE_URL` placeholder to `.env.example`.
 - Expanded `scripts/bootstrap.sh` to create `.env.dev` and run the environment setup script.
 - Linked `docs/founders/charter.md` from the founders README.

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ Welcome to **DevOnboarder**. This page explains how to get your environment runn
 - [Merge checklist](merge-checklist.md) &ndash; steps maintainers use before merging.
 - [Changelog](CHANGELOG.md) &ndash; record notable updates for each release.
 - [Alpha tester onboarding](alpha/README.md) &ndash; guide for early testers.
+- [Alpha wave rollout guide](alpha/alpha-wave-rollout-guide.md) &ndash; steps to prepare each invite wave.
 - [Founder's Circle onboarding](founders/README.md) &ndash; roles and perks for core supporters.
 - [Alpha phase roadmap](roadmap/alpha-phase.md) &ndash; pre- and post-launch milestones.
 - [Feedback dashboard PRD](prd/feedback-dashboard.md) &ndash; objectives and features for the feedback tool.

--- a/docs/alpha/README.md
+++ b/docs/alpha/README.md
@@ -27,6 +27,8 @@ Set `IS_ALPHA_USER=true` in your `.env.dev` file to enable access to routes mean
 ## Thank You
 Invite-only testers help shape the stability of the project. Your feedback directly influences upcoming releases.
 
+Maintainers should follow [alpha-wave-rollout-guide.md](alpha-wave-rollout-guide.md) when scheduling each invite wave.
+
 For a sample invitation, see [emails/invite_alpha_email.md](../../emails/invite_alpha_email.md).
 Refer to [emails/style-guide.md](../../emails/style-guide.md) for our email tone guidelines.
 

--- a/docs/alpha/alpha-wave-rollout-guide.md
+++ b/docs/alpha/alpha-wave-rollout-guide.md
@@ -1,0 +1,23 @@
+# Alpha Wave Rollout Guide
+
+This checklist helps maintainers prepare each invite wave and track progress.
+
+## Preparation
+- Ensure features marked for the wave are stable.
+- Verify environment variables in `.env.example` and the compose files.
+- Confirm the invite list in `ALPHA_TESTERS.md` and draft the email.
+
+## Invitation Flow
+1. Send the invite email and share the private chat link.
+2. Update `ALPHA_TESTERS.md` with the invitation date and status.
+3. Remind testers to set `IS_ALPHA_USER=true` in `.env.dev`.
+
+## Feedback Tracking
+- Ask testers to log reproducible bugs in the issue tracker.
+- Collect general impressions through [feedback-form.md](feedback-form.md).
+- Summarize reports in [feedback-template.md](feedback-template.md).
+
+## Monitoring
+- Watch server logs and analytics for errors or spikes.
+- Review feedback daily and prioritize fixes.
+- Close the wave when blocking issues are resolved.


### PR DESCRIPTION
## Summary
- document alpha wave rollout steps
- crosslink rollout guide from docs
- note the new guide in the changelog

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6853eaea14fc832086d46e785115ba3d