### PR TITLE
Add CLI default greeting test

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be recorded in this file.
 
 ## [Unreleased]
+- Added test ensuring the CLI prints the default greeting when no name is provided.
 - Documented how to propose issues and pull requests in `docs/README.md`.
 - Added an alpha phase roadmap under `docs/roadmap/` and linked it from the docs README.
 - Added a README section pointing to workflow docs under `docs/`.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,3 +9,11 @@ def test_cli_prints_greeting(capsys, monkeypatch):
     main()
     captured = capsys.readouterr()
     assert captured.out.strip() == "Hello, Codex!"
+
+
+def test_cli_prints_default_greeting(capsys, monkeypatch):
+    """devonboarder.cli.main prints default greeting when no name given."""
+    monkeypatch.setattr(sys, "argv", ["devonboarder"])
+    main()
+    captured = capsys.readouterr()
+    assert captured.out.strip() == "Hello, World!"


### PR DESCRIPTION
# Summary
- verify default name when invoking CLI without args

# Linked Issues

# Screenshots

# Testing Steps
```bash
ruff check .
pytest -q
```

------
https://chatgpt.com/codex/tasks/task_e_6853ef607abc832088723df4b0855f43