### PR TITLE
Add mixed-case flag tests

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -48,6 +48,8 @@ All notable changes to this project will be recorded in this file.
 - Added Discord message templates and linked them from the docs README.
 - Added example feedback row with notes column in `ALPHA_TESTERS.md` and noted
   that new rows should be appended below it.
+- Added tests verifying that `/alpha` and `/founder` routes allow mixed-case
+  feature flags.
 
 ## [0.1.0] - 2025-06-14
 - Added `src/app.py` with `greet` function and updated smoke tests. [#21](https://github.com/theangrygamershowproductions/DevOnboarder/pull/21)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -83,3 +83,27 @@ def test_founder_route_allowed_with_flag(monkeypatch):
     finally:
         server.shutdown()
         thread.join()
+
+
+def test_alpha_route_allowed_with_mixed_case_flag(monkeypatch):
+    monkeypatch.setenv("IS_ALPHA_USER", "True")
+    server, host, port, thread = _start_server()
+    try:
+        with urllib.request.urlopen(f"http://{host}:{port}/alpha") as resp:
+            body = resp.read().decode()
+        assert body == "Welcome to the alpha program!"
+    finally:
+        server.shutdown()
+        thread.join()
+
+
+def test_founder_route_allowed_with_mixed_case_flag(monkeypatch):
+    monkeypatch.setenv("IS_FOUNDER", "True")
+    server, host, port, thread = _start_server()
+    try:
+        with urllib.request.urlopen(f"http://{host}:{port}/founder") as resp:
+            body = resp.read().decode()
+        assert body == "Founder access granted."
+    finally:
+        server.shutdown()
+        thread.join()


### PR DESCRIPTION
# Summary
- allow 'True' values for alpha and founder checks
- test server routes using mixed-case env vars
- document new coverage

# Testing Steps
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6853f0f0a97c8320ab10ecf6dac7f18f