### PR TITLE
Add server console script

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ devcontainer dev --workspace-folder . --config .devcontainer/devcontainer.json
 ```
 
 Alternatively, you can run the Docker Compose setup directly.
-This will start the application (executed via `python -m devonboarder.server`)
+This will start the application (executed via `devonboarder-server`)
 along with a Redis container on port `6379`:
 
 ```bash
@@ -77,7 +77,7 @@ docker compose -f docker-compose.yml -f docker-compose.override.yaml up -d
 1. Run `bash scripts/bootstrap.sh` to copy `.env.example` to `.env.dev` and install dependencies.
 2. Install the project with `pip install -e .`.
 3. Start the services with `docker compose -f docker-compose.dev.yaml up -d`.
-   The app container launches via `python -m devonboarder.server`.
+   The app container launches via `devonboarder-server`.
 4. Execute the tests using `pytest -q`.
 
 ## License

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -2,7 +2,7 @@ version: "3.8"
 services:
   app:
     build: .
-    command: ["python", "-m", "devonboarder.server"]
+    command: ["devonboarder-server"]
   redis:
     image: redis:latest
     ports:

--- a/docker-compose.override.yaml
+++ b/docker-compose.override.yaml
@@ -1,4 +1,4 @@
 version: "3.8"
 services:
   app:
-    command: ["python", "-m", "devonboarder.server"]
+    command: ["devonboarder-server"]

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -31,7 +31,7 @@ All notable changes to this project will be recorded in this file.
 - Restructured source into a `devonboarder` package and updated tests to import modules by package path.
 - Dockerfile installs the package and uses the CLI entrypoint.
 - Added test that runs the CLI and verifies the greeting output.
-- Compose files start the server via `python -m devonboarder.server`.
+- Compose files start the server via `devonboarder-server`.
 - Added onboarding templates for invite-only alpha testers and the founder's circle.
 - Moved onboarding docs into `docs/alpha/` and `docs/founders/` with new feedback and charter files.
 - Added invitation email templates under the `emails/` directory.
@@ -50,6 +50,7 @@ All notable changes to this project will be recorded in this file.
   that new rows should be appended below it.
 - Added tests verifying that `/alpha` and `/founder` routes allow mixed-case
   feature flags.
+- Added `devonboarder-server` console script and updated compose files and docs.
 
 ## [0.1.0] - 2025-06-14
 - Added `src/app.py` with `greet` function and updated smoke tests. [#21](https://github.com/theangrygamershowproductions/DevOnboarder/pull/21)

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,9 +7,10 @@ Welcome to **DevOnboarder**. This page explains how to get your environment runn
 1. Run `bash scripts/bootstrap.sh` to create `.env.dev` and install dependencies.
 2. Install the project in editable mode with `pip install -e .`.
 3. Start services with `docker compose -f docker-compose.dev.yaml up -d`.
-4. Visit `http://localhost:8000` to see the greeting server.
-5. Verify changes with `ruff check .` and `pytest -q` before committing.
-6. Install git hooks with `pre-commit install` so these checks run automatically.
+4. Alternatively, run `devonboarder-server` to start the app without Docker.
+5. Visit `http://localhost:8000` to see the greeting server.
+6. Verify changes with `ruff check .` and `pytest -q` before committing.
+7. Install git hooks with `pre-commit install` so these checks run automatically.
 
 ## Key Documentation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = []
 
 [project.scripts]
 devonboarder = "devonboarder.cli:main"
+devonboarder-server = "devonboarder.server:main"
 
 [build-system]
 requires = ["setuptools>=61"]


### PR DESCRIPTION
## Summary
- expose server via `devonboarder-server` console script
- document running the script alongside local setup steps
- use new command in compose files and README
- note the update in the changelog

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6853f27d09cc83208b814a6aafd57062