### PR TITLE
Update docs for stopping services

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -51,6 +51,7 @@ All notable changes to this project will be recorded in this file.
 - Added tests verifying that `/alpha` and `/founder` routes allow mixed-case
   feature flags.
 - Added `devonboarder-server` console script and updated compose files and docs.
+- Documented how to stop running services in `docs/README.md`.
 
 ## [0.1.0] - 2025-06-14
 - Added `src/app.py` with `greet` function and updated smoke tests. [#21](https://github.com/theangrygamershowproductions/DevOnboarder/pull/21)

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,10 +7,11 @@ Welcome to **DevOnboarder**. This page explains how to get your environment runn
 1. Run `bash scripts/bootstrap.sh` to create `.env.dev` and install dependencies.
 2. Install the project in editable mode with `pip install -e .`.
 3. Start services with `docker compose -f docker-compose.dev.yaml up -d`.
-4. Alternatively, run `devonboarder-server` to start the app without Docker.
+4. Alternatively, run `devonboarder-server` to start the app without Docker. Stop it with Ctrl+C.
 5. Visit `http://localhost:8000` to see the greeting server.
-6. Verify changes with `ruff check .` and `pytest -q` before committing.
-7. Install git hooks with `pre-commit install` so these checks run automatically.
+6. Stop services with `docker compose -f docker-compose.dev.yaml down`.
+7. Verify changes with `ruff check .` and `pytest -q` before committing.
+8. Install git hooks with `pre-commit install` so these checks run automatically.
 
 ## Key Documentation
 


### PR DESCRIPTION
## Summary
- explain how to stop Docker Compose services and devonboarder-server
- add note in changelog about updated docs

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6853f445ee388320a184c00657e757f3