### PR TITLE
Add FastAPI user API

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be recorded in this file.
 - Linked `docs/founders/charter.md` from the founders README.
 - Added `.dockerignore` to reduce the Docker build context by excluding caches and tests.
 - Ignored `.pytest_cache/` and `.ruff_cache/` in `.gitignore` and `.dockerignore`.
+- Added FastAPI user API with `/api/user/onboarding-status` and `/api/user/level` routes.
 - Expanded infrastructure blueprints with usage notes.
 - Expanded `infra/README.md` and blueprint docs with compose examples and
   environment variable instructions.

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,9 +9,10 @@ Welcome to **DevOnboarder**. This page explains how to get your environment runn
 3. Start services with `docker compose -f docker-compose.dev.yaml up -d`.
 4. Alternatively, run `devonboarder-server` to start the app without Docker. Stop it with Ctrl+C.
 5. Visit `http://localhost:8000` to see the greeting server.
-6. Stop services with `docker compose -f docker-compose.dev.yaml down`.
-7. Verify changes with `ruff check .` and `pytest -q` before committing.
-8. Install git hooks with `pre-commit install` so these checks run automatically.
+6. Run `devonboarder-api` to start the user API at `http://localhost:8001`.
+7. Stop services with `docker compose -f docker-compose.dev.yaml down`.
+8. Verify changes with `ruff check .` and `pytest -q` before committing.
+9. Install git hooks with `pre-commit install` so these checks run automatically.
 
 ## Key Documentation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,11 +11,12 @@ version = "0.1.0"
 description = "Sample trunk-based workflow project"
 readme = "README.md"
 requires-python = ">=3.11"
-dependencies = []
+dependencies = ["fastapi"]
 
 [project.scripts]
 devonboarder = "devonboarder.cli:main"
 devonboarder-server = "devonboarder.server:main"
+devonboarder-api = "devonboarder.xp_api:main"
 
 [build-system]
 requires = ["setuptools>=61"]

--- a/src/devonboarder/xp_api.py
+++ b/src/devonboarder/xp_api.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, FastAPI
+
+router = APIRouter()
+
+
+@router.get("/api/user/onboarding-status")
+def onboarding_status() -> dict[str, str]:
+    """Return a placeholder onboarding status."""
+    return {"status": "pending"}
+
+
+@router.get("/api/user/level")
+def user_level() -> dict[str, int]:
+    """Return a placeholder user level."""
+    return {"level": 1}
+
+
+def create_app() -> FastAPI:
+    """Create a FastAPI application with the XP router."""
+    app = FastAPI()
+    app.include_router(router)
+    return app
+
+
+def main() -> None:
+    """Run the FastAPI application."""
+    import uvicorn
+
+    uvicorn.run(create_app(), host="0.0.0.0", port=8001)
+

--- a/tests/test_xp_api.py
+++ b/tests/test_xp_api.py
@@ -1,0 +1,19 @@
+from devonboarder.xp_api import create_app
+from fastapi.testclient import TestClient
+
+
+def test_onboarding_status():
+    app = create_app()
+    client = TestClient(app)
+    response = client.get("/api/user/onboarding-status")
+    assert response.status_code == 200
+    assert response.json() == {"status": "pending"}
+
+
+def test_user_level():
+    app = create_app()
+    client = TestClient(app)
+    response = client.get("/api/user/level")
+    assert response.status_code == 200
+    assert response.json() == {"level": 1}
+


### PR DESCRIPTION
# Summary

Adds a small FastAPI application exposing `/api/user/onboarding-status` and `/api/user/level` routes. A console script `devonboarder-api` runs this app. Documentation now covers how to start the API and the changelog notes the addition.

# Linked Issues

# Screenshots

# Testing Steps
```bash
ruff check .
pytest -q
```

# Checklist
- [x] Updated `docs/CHANGELOG.md`
- [x] Updated relevant documentation in `docs/`
- [x] Lint and tests pass

# Reviewer Sign-Off
- [ ] I, the reviewer, confirm the checklist above is complete.

------
https://chatgpt.com/codex/tasks/task_e_6853fad01e7483209402a6eb1cdfbe8c