### PR TITLE
Add uvicorn dependency

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to this project will be recorded in this file.
 - Added `DATABASE_URL` placeholder to `.env.example`.
 - Expanded `scripts/bootstrap.sh` to create `.env.dev` and run the environment setup script.
 - Added `httpx` as a project dependency and documented it in the README.
+- Added `uvicorn` as a project dependency and documented its usage in the
+  API server instructions.
 - Linked `docs/founders/charter.md` from the founders README.
 - Added `.dockerignore` to reduce the Docker build context by excluding caches and tests.
 - Ignored `.pytest_cache/` and `.ruff_cache/` in `.gitignore` and `.dockerignore`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,12 +5,13 @@ Welcome to **DevOnboarder**. This page explains how to get your environment runn
 ## Local Development
 
 1. Run `bash scripts/bootstrap.sh` to create `.env.dev` and install dependencies
-   (including `httpx`).
+   (including `httpx` and `uvicorn`).
 2. Install the project in editable mode with `pip install -e .`.
 3. Start services with `docker compose -f docker-compose.dev.yaml up -d`.
 4. Alternatively, run `devonboarder-server` to start the app without Docker. Stop it with Ctrl+C.
 5. Visit `http://localhost:8000` to see the greeting server.
 6. Run `devonboarder-api` to start the user API at `http://localhost:8001`.
+   This command requires `uvicorn`.
 7. Stop services with `docker compose -f docker-compose.dev.yaml down`.
 8. Verify changes with `ruff check .` and `pytest -q` before committing.
 9. Install git hooks with `pre-commit install` so these checks run automatically.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ requires-python = ">=3.11"
 dependencies = [
     "httpx",
     "fastapi",
+    "uvicorn",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- append uvicorn to project dependencies
- document uvicorn usage for API server
- note uvicorn requirement in changelog

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854010952588320b511c28881849d4c