### PR TITLE
Add README note for API server

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ along with a Redis container on port `6379`:
 docker compose -f docker-compose.dev.yaml up
 ```
 
+To experiment with the user-facing API outside Docker, run:
+
+```bash
+devonboarder-api
+```
+
+The API server listens on `http://localhost:8001`.
+
 The CI pipeline also relies on this compose file to start Redis during tests.
 
 ## Codex Runs

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be recorded in this file.
 - Added `httpx` as a project dependency and documented it in the README.
 - Added `uvicorn` as a project dependency and documented its usage in the
   API server instructions.
+- Documented running `devonboarder-api` on `http://localhost:8001` under Local Development in the README.
 - Linked `docs/founders/charter.md` from the founders README.
 - Added `.dockerignore` to reduce the Docker build context by excluding caches and tests.
 - Ignored `.pytest_cache/` and `.ruff_cache/` in `.gitignore` and `.dockerignore`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ description = "Sample trunk-based workflow project"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "httpx",
+    "httpx<0.28",
     "fastapi",
     "uvicorn",
 ]


### PR DESCRIPTION
## Summary
- show how to run the devonboarder-api server on port 8001
- document the API port note in the changelog
- pin `httpx` under 0.28 for test compatibility

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854043cd8dc8320953b6844c972265d