### PR TITLE
Add FastAPI auth service

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ curl http://localhost:8001/api/user/onboarding-status
 curl http://localhost:8001/api/user/level
 ```
 
+For authentication and user management, run:
+
+```bash
+devonboarder-auth
+```
+
+The auth service listens on `http://localhost:8002`.
+
 The CI pipeline also relies on this compose file to start Redis during tests.
 
 ## Codex Runs

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be recorded in this file.
 
 ## [Unreleased]
+- Added authentication service with SQLAlchemy models and JWT-protected routes.
+- Documented running `devonboarder-auth` in the onboarding guide.
 - Added test ensuring the CLI prints the default greeting when no name is provided.
 - Documented how to propose issues and pull requests in `docs/README.md`.
 - Added an alpha phase roadmap under `docs/roadmap/` and linked it from the docs README.

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,12 +12,14 @@ Welcome to **DevOnboarder**. This page explains how to get your environment runn
 5. Visit `http://localhost:8000` to see the greeting server.
 6. Run `devonboarder-api` to start the user API at `http://localhost:8001`.
    This command requires `uvicorn`.
-7. Test the XP API with:
+7. Run `devonboarder-auth` to start the auth service at `http://localhost:8002`.
+   It stores data in a local SQLite database.
+8. Test the XP API with:
    `curl http://localhost:8001/api/user/onboarding-status`
    and `curl http://localhost:8001/api/user/level`.
-8. Stop services with `docker compose -f docker-compose.dev.yaml down`.
-9. Verify changes with `ruff check .` and `pytest -q` before committing.
-10. Install git hooks with `pre-commit install` so these checks run automatically.
+9. Stop services with `docker compose -f docker-compose.dev.yaml down`.
+10. Verify changes with `ruff check .` and `pytest -q` before committing.
+11. Install git hooks with `pre-commit install` so these checks run automatically.
 
 ## Key Documentation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,12 +15,16 @@ dependencies = [
     "httpx<0.28",
     "fastapi",
     "uvicorn",
+    "SQLAlchemy<2.0",
+    "passlib[bcrypt]",
+    "python-jose",
 ]
 
 [project.scripts]
 devonboarder = "devonboarder.cli:main"
 devonboarder-server = "devonboarder.server:main"
 devonboarder-api = "devonboarder.xp_api:main"
+devonboarder-auth = "devonboarder.auth_service:main"
 
 [build-system]
 requires = ["setuptools>=61"]

--- a/src/devonboarder/auth_service.py
+++ b/src/devonboarder/auth_service.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+from fastapi import FastAPI, Depends, HTTPException, status
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+from sqlalchemy import (
+    Column,
+    Integer,
+    String,
+    Boolean,
+    ForeignKey,
+    create_engine,
+)
+from sqlalchemy.orm import sessionmaker, declarative_base, relationship, Session
+from passlib.context import CryptContext
+from jose import jwt, JWTError
+import os
+
+SECRET_KEY = os.getenv("AUTH_SECRET_KEY", "secret")
+ALGORITHM = "HS256"
+
+Base = declarative_base()
+engine = create_engine(
+    os.getenv("AUTH_DATABASE_URL", "sqlite:///./auth.db"),
+    connect_args={"check_same_thread": False},
+)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True)
+    username = Column(String, unique=True, nullable=False)
+    password_hash = Column(String, nullable=False)
+    is_admin = Column(Boolean, default=False)
+
+    contributions = relationship("Contribution", back_populates="user")
+    events = relationship("XPEvent", back_populates="user")
+
+
+class Contribution(Base):
+    __tablename__ = "contributions"
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer, ForeignKey("users.id"))
+    description = Column(String, nullable=False)
+
+    user = relationship("User", back_populates="contributions")
+
+
+class XPEvent(Base):
+    __tablename__ = "xp_events"
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer, ForeignKey("users.id"))
+    xp = Column(Integer, default=0)
+
+    user = relationship("User", back_populates="events")
+
+
+def init_db() -> None:
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+
+def get_db() -> Session:
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def create_token(user: User) -> str:
+    return jwt.encode({"sub": str(user.id)}, SECRET_KEY, algorithm=ALGORITHM)
+
+
+security = HTTPBearer()
+
+
+def get_current_user(
+    creds: HTTPAuthorizationCredentials = Depends(security),
+    db: Session = Depends(get_db),
+) -> User:
+    token = creds.credentials
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        user_id = int(payload["sub"])
+    except (JWTError, KeyError, ValueError):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid token",
+        )
+
+    user = db.get(User, user_id)
+    if user is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="User not found",
+        )
+    return user
+
+
+app = FastAPI()
+
+
+@app.post("/api/register")
+def register(data: dict, db: Session = Depends(get_db)) -> dict[str, str]:
+    username = data["username"]
+    password = data["password"]
+    if db.query(User).filter_by(username=username).first():
+        raise HTTPException(status_code=400, detail="Username exists")
+    user = User(username=username, password_hash=pwd_context.hash(password))
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return {"token": create_token(user)}
+
+
+@app.post("/api/login")
+def login(data: dict, db: Session = Depends(get_db)) -> dict[str, str]:
+    username = data["username"]
+    password = data["password"]
+    user = db.query(User).filter_by(username=username).first()
+    if not user or not pwd_context.verify(password, user.password_hash):
+        raise HTTPException(status_code=400, detail="Invalid credentials")
+    return {"token": create_token(user)}
+
+
+@app.get("/api/user")
+def user_info(current_user: User = Depends(get_current_user)) -> dict[str, object]:
+    return {"username": current_user.username, "is_admin": current_user.is_admin}
+
+
+@app.get("/api/user/onboarding-status")
+def onboarding_status(current_user: User = Depends(get_current_user)) -> dict[str, str]:
+    status_str = "complete" if current_user.contributions else "pending"
+    return {"status": status_str}
+
+
+@app.get("/api/user/level")
+def user_level(current_user: User = Depends(get_current_user)) -> dict[str, int]:
+    xp_total = sum(evt.xp for evt in current_user.events)
+    level = xp_total // 100 + 1
+    return {"level": level}
+
+
+@app.get("/api/user/contributions")
+def user_contributions(
+    current_user: User = Depends(get_current_user),
+) -> dict[str, list[str]]:
+    return {
+        "contributions": [c.description for c in current_user.contributions]
+    }
+
+
+@app.post("/api/user/promote")
+def promote(
+    data: dict,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> dict[str, str]:
+    if not current_user.is_admin:
+        raise HTTPException(status_code=403, detail="Admin required")
+    target = db.query(User).filter_by(username=data["username"]).first()
+    if not target:
+        raise HTTPException(status_code=404, detail="User not found")
+    target.is_admin = True
+    db.commit()
+    return {"promoted": target.username}
+
+
+def create_app() -> FastAPI:
+    init_db()
+    return app
+
+
+def main() -> None:
+    import uvicorn
+
+    uvicorn.run(create_app(), host="0.0.0.0", port=8002)
+

--- a/tests/test_auth_service.py
+++ b/tests/test_auth_service.py
@@ -1,0 +1,87 @@
+from fastapi.testclient import TestClient
+from devonboarder import auth_service
+
+
+def setup_function(function):
+    auth_service.init_db()
+
+
+def _get_token(client: TestClient, username: str, password: str) -> str:
+    resp = client.post("/api/login", json={"username": username, "password": password})
+    assert resp.status_code == 200
+    return resp.json()["token"]
+
+
+def test_register_login_and_user_info():
+    app = auth_service.create_app()
+    client = TestClient(app)
+
+    resp = client.post(
+        "/api/register",
+        json={"username": "alice", "password": "secret"},
+    )
+    assert resp.status_code == 200
+    token = resp.json()["token"]
+
+    resp = client.get(
+        "/api/user",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["username"] == "alice"
+    assert resp.json()["is_admin"] is False
+
+    # login works
+    token2 = _get_token(client, "alice", "secret")
+    assert token2
+
+
+def test_user_levels_and_promote():
+    app = auth_service.create_app()
+    client = TestClient(app)
+
+    # register two users
+    client.post("/api/register", json={"username": "admin", "password": "adm"})
+    client.post("/api/register", json={"username": "bob", "password": "pwd"})
+
+    # make admin user an admin
+    with auth_service.SessionLocal() as db:
+        admin = db.query(auth_service.User).filter_by(username="admin").first()
+        admin.is_admin = True
+        bob = db.query(auth_service.User).filter_by(username="bob").first()
+        db.add(auth_service.Contribution(user_id=bob.id, description="initial"))
+        db.add(auth_service.XPEvent(user_id=bob.id, xp=150))
+        db.commit()
+
+    admin_token = _get_token(client, "admin", "adm")
+    bob_token = _get_token(client, "bob", "pwd")
+
+    resp = client.get(
+        "/api/user/contributions",
+        headers={"Authorization": f"Bearer {bob_token}"},
+    )
+    assert resp.json() == {"contributions": ["initial"]}
+
+    resp = client.get(
+        "/api/user/onboarding-status",
+        headers={"Authorization": f"Bearer {bob_token}"},
+    )
+    assert resp.json() == {"status": "complete"}
+
+    resp = client.get(
+        "/api/user/level",
+        headers={"Authorization": f"Bearer {bob_token}"},
+    )
+    assert resp.json() == {"level": 2}
+
+    resp = client.post(
+        "/api/user/promote",
+        json={"username": "bob"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"promoted": "bob"}
+
+    with auth_service.SessionLocal() as db:
+        bob = db.query(auth_service.User).filter_by(username="bob").first()
+        assert bob.is_admin


### PR DESCRIPTION
# Summary
- create authentication FastAPI service with SQLAlchemy models
- provide register, login and user management routes protected by JWT
- document how to run `devonboarder-auth`
- add tests for the new service

# Linked Issues

# Screenshots

# Testing Steps
```bash
ruff check .
pytest -q
```


------
https://chatgpt.com/codex/tasks/task_e_6854111a9a1c8320865b43e874bd1cc5