### PR TITLE
Add Postgres DB service and migrations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,7 @@ APP_ENV=development
 REDIS_URL=redis://localhost:6379/0
 
 # Database connection settings
-DATABASE_URL=postgres://user:pass@localhost:5432/db
+DATABASE_URL=postgresql://devuser:devpass@localhost:5432/devdb
 
 # Logging level
 LOG_LEVEL=INFO

--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ devcontainer dev --workspace-folder . --config .devcontainer/devcontainer.json
 
 Alternatively, you can run the Docker Compose setup directly.
 This will start the application (executed via `devonboarder-server`)
-along with a Redis container on port `6379`:
+along with a Redis container on port `6379` and a Postgres database on
+port `5432`:
 
 ```bash
 docker compose -f docker-compose.dev.yaml up
@@ -100,7 +101,8 @@ docker compose -f docker-compose.yml -f docker-compose.override.yaml up -d
 2. Install the project with `pip install -e .`.
 3. Start the services with `docker compose -f docker-compose.dev.yaml up -d`.
    The app container launches via `devonboarder-server`.
-4. Execute the tests using `pytest -q`.
+4. Run `alembic upgrade head` to create the initial tables.
+5. Execute the tests using `pytest -q`.
 
 ## License
 This project is licensed under the MIT License. See LICENSE.md.

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -3,7 +3,20 @@ services:
   app:
     build: .
     command: ["devonboarder-server"]
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: devuser
+      POSTGRES_PASSWORD: devpass
+      POSTGRES_DB: devdb
+    ports:
+      - "5432:5432"
+    volumes:
+      - db_data:/var/lib/postgresql/data
   redis:
     image: redis:latest
     ports:
       - "6379:6379"
+
+volumes:
+  db_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,3 +2,14 @@ version: "3.8"
 services:
   app:
     build: .
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: devuser
+      POSTGRES_PASSWORD: devpass
+      POSTGRES_DB: devdb
+    volumes:
+      - db_data:/var/lib/postgresql/data
+
+volumes:
+  db_data:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be recorded in this file.
 
 ## [Unreleased]
+- Added Postgres `db` service in the compose files and initial Alembic
+  migrations for `users`, `contributions`, and `xp_events` tables.
 - Added authentication service with SQLAlchemy models and JWT-protected routes.
 - Documented running `devonboarder-auth` in the onboarding guide.
 - Added test ensuring the CLI prints the default greeting when no name is provided.

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,20 +6,24 @@ Welcome to **DevOnboarder**. This page explains how to get your environment runn
 
 1. Run `bash scripts/bootstrap.sh` to create `.env.dev` and install dependencies
    (including `httpx` and `uvicorn`).
+   Update `DATABASE_URL` in `.env.dev` if you are not using the default
+   Postgres credentials.
 2. Install the project in editable mode with `pip install -e .`.
 3. Start services with `docker compose -f docker-compose.dev.yaml up -d`.
-4. Alternatively, run `devonboarder-server` to start the app without Docker. Stop it with Ctrl+C.
-5. Visit `http://localhost:8000` to see the greeting server.
-6. Run `devonboarder-api` to start the user API at `http://localhost:8001`.
+   This launches Postgres on port `5432` and Redis on `6379`.
+4. Run `alembic upgrade head` to apply the initial database migration.
+5. Alternatively, run `devonboarder-server` to start the app without Docker. Stop it with Ctrl+C.
+6. Visit `http://localhost:8000` to see the greeting server.
+7. Run `devonboarder-api` to start the user API at `http://localhost:8001`.
    This command requires `uvicorn`.
-7. Run `devonboarder-auth` to start the auth service at `http://localhost:8002`.
+8. Run `devonboarder-auth` to start the auth service at `http://localhost:8002`.
    It stores data in a local SQLite database.
-8. Test the XP API with:
+9. Test the XP API with:
    `curl http://localhost:8001/api/user/onboarding-status`
    and `curl http://localhost:8001/api/user/level`.
-9. Stop services with `docker compose -f docker-compose.dev.yaml down`.
-10. Verify changes with `ruff check .` and `pytest -q` before committing.
-11. Install git hooks with `pre-commit install` so these checks run automatically.
+10. Stop services with `docker compose -f docker-compose.dev.yaml down`.
+11. Verify changes with `ruff check .` and `pytest -q` before committing.
+12. Install git hooks with `pre-commit install` so these checks run automatically.
 
 ## Key Documentation
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -16,6 +16,7 @@ the repository. Deployments rely on environment variables provided via a
    ```bash
    # Local development
    docker compose -f docker-compose.dev.yaml --env-file .env.dev up -d
+   # This starts the application along with Postgres (service `db`) and Redis.
 
    # Production deployment
    docker compose -f docker-compose.yml -f docker-compose.override.yaml \

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import os
+from logging.config import fileConfig
+
+from sqlalchemy import engine_from_config, pool
+from alembic import context
+
+from devonboarder.auth_service import Base
+
+config = context.config
+
+config.set_main_option(
+    "sqlalchemy.url",
+    os.getenv("DATABASE_URL", "sqlite:///./dev.db"),
+)
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = Base.metadata
+
+
+def run_migrations_offline() -> None:
+    context.configure(
+        url=config.get_main_option("sqlalchemy.url"),
+        target_metadata=target_metadata,
+        literal_binds=True,
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/migrations/versions/0001_create_initial_tables.py
+++ b/migrations/versions/0001_create_initial_tables.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0001"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "users",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("username", sa.String, nullable=False, unique=True),
+        sa.Column("password_hash", sa.String, nullable=False),
+        sa.Column(
+            "is_admin",
+            sa.Boolean,
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+    op.create_table(
+        "contributions",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("user_id", sa.Integer, sa.ForeignKey("users.id")),
+        sa.Column("description", sa.String, nullable=False),
+    )
+    op.create_table(
+        "xp_events",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("user_id", sa.Integer, sa.ForeignKey("users.id")),
+        sa.Column("xp", sa.Integer, nullable=False, server_default="0"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("xp_events")
+    op.drop_table("contributions")
+    op.drop_table("users")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,8 @@ dependencies = [
     "SQLAlchemy<2.0",
     "passlib[bcrypt]",
     "python-jose",
+    "alembic",
+    "psycopg2-binary",
 ]
 
 [project.scripts]

--- a/tests/test_docker_compose.py
+++ b/tests/test_docker_compose.py
@@ -24,3 +24,13 @@ def test_base_compose_builds_image():
     service = compose["services"]["app"]
     assert "build" in service
     assert "command" not in service
+
+
+def test_compose_includes_postgres():
+    """Both compose files include a Postgres service."""
+    for fname in ["docker-compose.yml", "docker-compose.dev.yaml"]:
+        compose = load_compose(fname)
+        services = compose.get("services", {})
+        assert "db" in services
+        image = services["db"].get("image", "")
+        assert image.startswith("postgres")


### PR DESCRIPTION
## Summary
- add `db` service to compose files
- provide Alembic migrations for users, contributions, and xp events tables
- document database setup and migration steps
- update test for new compose service

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6854140abd1083209936e1be7e586289