### PR TITLE
Add dedicated compose files for dev and prod

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,8 @@ jobs:
       - name: Run linter
         run: ruff check .
       - name: Start docker compose
-        run: docker compose -f docker-compose.dev.yaml up -d
+        run: docker compose -f docker-compose.dev.yaml --env-file .env.dev up -d
       - name: Run tests
         run: pytest -q
       - name: Stop compose
-        run: docker compose -f docker-compose.dev.yaml down
+        run: docker compose -f docker-compose.dev.yaml --env-file .env.dev down

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ logs/
 .terraform/
 lcov-report/
 codeql-*
+auth.db

--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ container setup used by Codex.
 - `scripts/` – Helper scripts for bootstrapping and environment setup.
 - `.devcontainer/` – Contains `devcontainer.json` which builds the VS Code
   development container, forwards port `3000`, and runs `scripts/setup-env.sh`.
-- `docker-compose.yml` – Base compose file for production deployments.
-- `docker-compose.dev.yaml` – Compose file for local development.
-  Includes a Redis service exposed on port `6379`.
-- `docker-compose.codex.yml` – Compose file used when running in Codex.
-- `docker-compose.override.yaml` – Overrides for the base compose file.
+  - `docker-compose.dev.yaml` – Compose file for local development using `.env.dev`.
+  - `docker-compose.prod.yaml` – Compose file for production using `.env.prod`.
+  - `docker-compose.yml` – Base compose file for generic deployments.
+  - `docker-compose.codex.yml` – Compose file used when running in Codex.
+  - `docker-compose.override.yaml` – Overrides for the base compose file.
 - `bot/` – Discord bot written in TypeScript.
 - `config/devonboarder.config.yml` – Config for the `devonboarder` tool.
 - `.env.example` – Sample environment variables for local development.
@@ -49,12 +49,11 @@ devcontainer dev --workspace-folder . --config .devcontainer/devcontainer.json
 ```
 
 Alternatively, you can run the Docker Compose setup directly.
-This will start the application (executed via `devonboarder-server`)
-along with a Redis container on port `6379` and a Postgres database on
-port `5432`:
+This starts the auth, bot, XP API, frontend, and database services using
+environment variables from `.env.dev`:
 
 ```bash
-docker compose -f docker-compose.dev.yaml up
+docker compose -f docker-compose.dev.yaml --env-file .env.dev up
 ```
 
 To experiment with the user-facing API outside Docker, run:
@@ -91,17 +90,17 @@ docker compose -f docker-compose.codex.yml up
 
 ## Production Deployment
 
-Use the main compose file (with overrides) to deploy the application:
+Deploy the production stack with the dedicated compose file and `.env.prod`:
 
 ```bash
-docker compose -f docker-compose.yml -f docker-compose.override.yaml up -d
+docker compose -f docker-compose.prod.yaml --env-file .env.prod up -d
 ```
 
 ## Quickstart
 1. Run `bash scripts/bootstrap.sh` to copy `.env.example` to `.env.dev` and install dependencies.
 2. Install the project with `pip install -e .`.
-3. Start the services with `docker compose -f docker-compose.dev.yaml up -d`.
-   The app container launches via `devonboarder-server`.
+3. Start the services with `docker compose -f docker-compose.dev.yaml --env-file .env.dev up -d`.
+   The services launch using the commands defined in the compose file.
 4. Run `alembic upgrade head` to create the initial tables.
 5. Execute the tests using `pytest -q`.
 

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -4,7 +4,7 @@ services:
     build: .
     command: ["devonboarder-auth"]
     env_file:
-      - .env.dev
+      - .env.prod
   bot:
     image: node:18
     working_dir: /bot
@@ -12,12 +12,12 @@ services:
       - ./bot:/bot
     command: ["npm", "start"]
     env_file:
-      - .env.dev
+      - .env.prod
   xp:
     build: .
     command: ["devonboarder-api"]
     env_file:
-      - .env.dev
+      - .env.prod
   frontend:
     image: node:18
     working_dir: /frontend
@@ -25,7 +25,7 @@ services:
       - ./frontend:/frontend
     command: ["npm", "start"]
     env_file:
-      - .env.dev
+      - .env.prod
   db:
     image: postgres:15
     environment:
@@ -33,9 +33,7 @@ services:
       POSTGRES_PASSWORD: devpass
       POSTGRES_DB: devdb
     env_file:
-      - .env.dev
-    ports:
-      - "5432:5432"
+      - .env.prod
     volumes:
       - db_data:/var/lib/postgresql/data
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be recorded in this file.
 
 ## [Unreleased]
+- Added `docker-compose.dev.yaml` and `docker-compose.prod.yaml` with auth,
+  bot, XP API, frontend, and Postgres services loading variables from
+  `.env.dev` and `.env.prod`.
 - Added Postgres `db` service in the compose files and initial Alembic
   migrations for `users`, `contributions`, and `xp_events` tables.
 - Added authentication service with SQLAlchemy models and JWT-protected routes.

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,8 +9,8 @@ Welcome to **DevOnboarder**. This page explains how to get your environment runn
    Update `DATABASE_URL` in `.env.dev` if you are not using the default
    Postgres credentials.
 2. Install the project in editable mode with `pip install -e .`.
-3. Start services with `docker compose -f docker-compose.dev.yaml up -d`.
-   This launches Postgres on port `5432` and Redis on `6379`.
+3. Start services with `docker compose -f docker-compose.dev.yaml --env-file .env.dev up -d`.
+   This launches the auth, bot, XP API, frontend, and Postgres services.
 4. Run `alembic upgrade head` to apply the initial database migration.
 5. Alternatively, run `devonboarder-server` to start the app without Docker. Stop it with Ctrl+C.
 6. Visit `http://localhost:8000` to see the greeting server.
@@ -21,7 +21,7 @@ Welcome to **DevOnboarder**. This page explains how to get your environment runn
 9. Test the XP API with:
    `curl http://localhost:8001/api/user/onboarding-status`
    and `curl http://localhost:8001/api/user/level`.
-10. Stop services with `docker compose -f docker-compose.dev.yaml down`.
+10. Stop services with `docker compose -f docker-compose.dev.yaml --env-file .env.dev down`.
 11. Verify changes with `ruff check .` and `pytest -q` before committing.
 12. Install git hooks with `pre-commit install` so these checks run automatically.
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -16,11 +16,9 @@ the repository. Deployments rely on environment variables provided via a
    ```bash
    # Local development
    docker compose -f docker-compose.dev.yaml --env-file .env.dev up -d
-   # This starts the application along with Postgres (service `db`) and Redis.
 
    # Production deployment
-   docker compose -f docker-compose.yml -f docker-compose.override.yaml \
-     --env-file .env.prod up -d
+   docker compose -f docker-compose.prod.yaml --env-file .env.prod up -d
    ```
 
 4. When finished, shut down the stack with `docker compose down`.

--- a/infra/blueprint-aurora.md
+++ b/infra/blueprint-aurora.md
@@ -3,11 +3,10 @@ title: Aurora Blueprint
 ---
 
 This blueprint describes the production deployment that relies on
-**AWS Aurora** for the backing database. Use the `docker-compose.yml`
-file together with `docker-compose.override.yaml` when deploying this
-environment. Ensure the application containers can reach the Aurora
-cluster through the configured security groups and that backups are
-enabled for disaster recovery.
+**AWS Aurora** for the backing database. Use `docker-compose.prod.yaml`
+when deploying this environment. Ensure the application containers can
+reach the Aurora cluster through the configured security groups and that
+backups are enabled for disaster recovery.
 
 1. Create a `.env.prod` file and set `DATABASE_URL` to the writer
    endpoint for your Aurora cluster:
@@ -20,8 +19,7 @@ enabled for disaster recovery.
 2. Deploy with:
 
    ```bash
-   docker compose -f docker-compose.yml -f docker-compose.override.yaml \
-     --env-file .env.prod up -d
+   docker compose -f docker-compose.prod.yaml --env-file .env.prod up -d
    ```
 
 The service expects the `DATABASE_URL` environment variable to point to

--- a/infra/blueprint-laramie.md
+++ b/infra/blueprint-laramie.md
@@ -20,8 +20,7 @@ This blueprint sets up a local development stack.
    docker compose -f docker-compose.dev.yaml --env-file .env.dev up -d
    ```
 
-   Redis will be available on port `6379` and the application listens on
-   port `8000`.
+   The stack exposes Postgres on port `5432` and serves the frontend on port `3000`.
 
 Application data is stored in local volumes under the `./data` directory.
 Stop everything with `docker compose down` when finished.

--- a/tests/test_docker_compose.py
+++ b/tests/test_docker_compose.py
@@ -9,13 +9,24 @@ def load_compose(file_name: str) -> dict:
         return yaml.safe_load(fh)
 
 
-def test_dev_compose_has_redis_service():
-    """docker-compose.dev.yaml defines a redis service."""
+def test_dev_compose_has_expected_services():
+    """docker-compose.dev.yaml defines all core services."""
     compose = load_compose("docker-compose.dev.yaml")
     services = compose.get("services", {})
-    assert "redis" in services
-    ports = services["redis"].get("ports", [])
-    assert "6379:6379" in ports
+    expected = {"auth", "bot", "xp", "frontend", "db"}
+    assert expected.issubset(services)
+
+
+def test_compose_uses_env_files():
+    """Both compose files load environment variables from env files."""
+    for fname, env in [
+        ("docker-compose.dev.yaml", ".env.dev"),
+        ("docker-compose.prod.yaml", ".env.prod"),
+    ]:
+        compose = load_compose(fname)
+        service = compose["services"]["auth"]
+        env_file = service.get("env_file")
+        assert env_file == [env] or env_file == env
 
 
 def test_base_compose_builds_image():
@@ -28,9 +39,19 @@ def test_base_compose_builds_image():
 
 def test_compose_includes_postgres():
     """Both compose files include a Postgres service."""
-    for fname in ["docker-compose.yml", "docker-compose.dev.yaml"]:
+    for fname in ["docker-compose.dev.yaml", "docker-compose.prod.yaml"]:
         compose = load_compose(fname)
         services = compose.get("services", {})
         assert "db" in services
         image = services["db"].get("image", "")
         assert image.startswith("postgres")
+
+
+def test_db_volume_persisted():
+    """Postgres service uses a named volume for data."""
+    for fname in ["docker-compose.dev.yaml", "docker-compose.prod.yaml"]:
+        compose = load_compose(fname)
+        db_service = compose["services"]["db"]
+        volumes = db_service.get("volumes", [])
+        assert any(v.startswith("db_data:") for v in volumes)
+        assert "db_data" in compose.get("volumes", {})


### PR DESCRIPTION
## Summary
- define docker-compose.dev.yaml with auth, bot, xp, frontend, and db services
- add docker-compose.prod.yaml for production deployments
- update tests for new compose files
- refresh docs and CI to use env files
- ignore local auth.db files

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685418c3ad708320b6d84fb660080483