### PR TITLE
Add frontend placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ devcontainer dev --workspace-folder . --config .devcontainer/devcontainer.json
 
 Alternatively, you can run the Docker Compose setup directly.
 This starts the auth, bot, XP API, frontend, and database services using
-environment variables from `.env.dev`:
+environment variables from `.env.dev`.
+The `frontend/` directory currently contains only a placeholder README:
 
 ```bash
 docker compose -f docker-compose.dev.yaml --env-file .env.dev up

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be recorded in this file.
 - Added `docker-compose.ci.yaml` for the CI pipeline.
 - Added Postgres `db` service in the compose files and initial Alembic
   migrations for `users`, `contributions`, and `xp_events` tables.
+- Added placeholder `frontend/README.md` to reserve the upcoming UI directory.
 - Added authentication service with SQLAlchemy models and JWT-protected routes.
 - Documented running `devonboarder-auth` in the onboarding guide.
 - Added test ensuring the CLI prints the default greeting when no name is provided.

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ Welcome to **DevOnboarder**. This page explains how to get your environment runn
 2. Install the project in editable mode with `pip install -e .`.
 3. Start services with `docker compose -f docker-compose.dev.yaml --env-file .env.dev up -d`.
    This launches the auth, bot, XP API, frontend, and Postgres services.
+   The `frontend/` folder currently contains only a placeholder README.
 4. Run `alembic upgrade head` to apply the initial database migration.
 5. Alternatively, run `devonboarder-server` to start the app without Docker. Stop it with Ctrl+C.
 6. Visit `http://localhost:8000` to see the greeting server.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,3 @@
+# Frontend
+
+This directory holds placeholder files for the upcoming frontend.


### PR DESCRIPTION
## Summary
- add `frontend` directory with placeholder README
- document placeholder in local dev docs
- mention placeholder in root README
- note placeholder in changelog

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854297740ac8320aa86a9848bf92191