### PR TITLE
Add per-service env examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,10 @@ __pycache__/
 .venv/
 venv/
 .env*
-!.env.example
+!*.env.example
+!*/.env.example
+!*.env.*.example
+!*/.env.*.example
 
 # JS artifacts
 node_modules/

--- a/README.md
+++ b/README.md
@@ -22,9 +22,12 @@ container setup used by Codex.
   - `docker-compose.yml` – Base compose file for generic deployments.
   - `docker-compose.codex.yml` – Compose file used when running in Codex.
   - `docker-compose.override.yaml` – Overrides for the base compose file.
-- `bot/` – Discord bot written in TypeScript.
-- `config/devonboarder.config.yml` – Config for the `devonboarder` tool.
-- `.env.example` – Sample environment variables for local development.
+  - `bot/` – Discord bot written in TypeScript.
+  - `frontend/` – Placeholder directory for the upcoming web UI.
+  - `auth/` – Environment files for the authentication service.
+  - `xp/` – Environment files for the XP API.
+  - `config/devonboarder.config.yml` – Config for the `devonboarder` tool.
+  - `.env.example` – Sample variables shared across services.
 
 ## Documentation and Onboarding
 
@@ -52,6 +55,7 @@ devcontainer dev --workspace-folder . --config .devcontainer/devcontainer.json
 Alternatively, you can run the Docker Compose setup directly.
 This starts the auth, bot, XP API, frontend, and database services using
 environment variables from `.env.dev`.
+Copy each `*.env.example` to `.env` inside its service directory before starting.
 The `frontend/` directory currently contains only a placeholder README:
 
 ```bash
@@ -100,11 +104,16 @@ docker compose -f docker-compose.prod.yaml --env-file .env.prod up -d
 
 ## Quickstart
 1. Run `bash scripts/bootstrap.sh` to copy `.env.example` to `.env.dev` and install dependencies.
-2. Install the project with `pip install -e .`.
-3. Start the services with `docker compose -f docker-compose.dev.yaml --env-file .env.dev up -d`.
+2. Copy each service example file to `.env`:
+   `cp auth/.env.example auth/.env`
+   `cp bot/.env.example bot/.env`
+   `cp xp/.env.example xp/.env`
+   `cp frontend/.env.example frontend/.env`
+3. Install the project with `pip install -e .`.
+4. Start the services with `docker compose -f docker-compose.dev.yaml --env-file .env.dev up -d`.
    The services launch using the commands defined in the compose file.
-4. Run `alembic upgrade head` to create the initial tables.
-5. Execute the tests using `pytest -q`.
+5. Run `alembic upgrade head` to create the initial tables.
+6. Execute the tests using `pytest -q`.
 
 ## License
 This project is licensed under the MIT License. See LICENSE.md.

--- a/auth/.env.example
+++ b/auth/.env.example
@@ -1,0 +1,3 @@
+# Environment variables for the Auth service
+AUTH_SECRET_KEY=change-me
+AUTH_DATABASE_URL=sqlite:///./auth.db

--- a/bot/.env.example
+++ b/bot/.env.example
@@ -1,0 +1,4 @@
+# Environment variables for the Discord bot
+DISCORD_TOKEN=your-discord-bot-token
+DISCORD_CLIENT_ID=your-discord-client-id
+API_BASE_URL=http://localhost:8001

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be recorded in this file.
 
 ## [Unreleased]
 
+- Added `.env.example` files for individual services and documented how to copy
+  them during setup.
+
 - Added `docker-compose.dev.yaml` and `docker-compose.prod.yaml` with auth,
   bot, XP API, frontend, and Postgres services loading variables from
   `.env.dev` and `.env.prod`.

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,3 @@
+# Environment variables for the frontend
+VITE_API_URL=http://localhost:8001
+VITE_AUTH_URL=http://localhost:8002

--- a/xp/.env.example
+++ b/xp/.env.example
@@ -1,0 +1,5 @@
+# Environment variables for the XP API
+APP_ENV=development
+REDIS_URL=redis://localhost:6379/0
+DATABASE_URL=postgresql://devuser:devpass@localhost:5432/devdb
+LOG_LEVEL=INFO


### PR DESCRIPTION
## Summary
- create `.env.example` files for auth, bot, xp and frontend services
- ignore `.env` files anywhere in the repo
- document service env setup in README
- record change in changelog

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68542f3e21a48320bf204f7b6c70de55