### PR TITLE
Add API reference docs

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -78,6 +78,8 @@ All notable changes to this project will be recorded in this file.
   exposed via the `devonboarder-api` command.
 - Added Discord bot under `bot/` with verify, profile, and contribute commands.
 - CI workflow now installs bot dependencies and runs `npm test`.
+- Documented onboarding phases, XP milestones and contributor logs in `docs/README.md`.
+- Added `docs/endpoint-reference.md` with API routes and Discord command examples.
 
 ## [0.1.0] - 2025-06-14
 - Added `src/app.py` with `greet` function and updated smoke tests. [#21](https://github.com/theangrygamershowproductions/DevOnboarder/pull/21)

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,8 +42,27 @@ environment file overrides differences like `env_file` or exposed ports below th
 - [Alpha phase roadmap](roadmap/alpha-phase.md) &ndash; pre- and post-launch milestones.
 - [Feedback dashboard PRD](prd/feedback-dashboard.md) &ndash; objectives and features for the feedback tool.
 - [Discord message templates](discord/discord-message-templates.md) &ndash; sample posts for the community.
+- [Endpoint reference](endpoint-reference.md) &ndash; list of API routes and Discord command mappings.
 - [Alpha testers log](../ALPHA_TESTERS.md) &ndash; track invitations and feedback status.
 - [Founders log](../FOUNDERS.md) &ndash; record core contributors and how they help.
+
+## Onboarding Phases
+
+Our rollout begins with invite-only [alpha testing](alpha/README.md) followed by
+the **Founder's Circle** outlined in [founders/README.md](founders/README.md).
+These groups provide early feedback before the project opens to the public.
+
+## XP Milestones
+
+Each contribution grants experience points (XP). Every 100 XP increases your
+level, which you can check through the `/profile` command or the
+`/api/user/level` endpoint.
+
+## Contributor Logging
+
+Add yourself to [../ALPHA_TESTERS.md](../ALPHA_TESTERS.md) or
+[../FOUNDERS.md](../FOUNDERS.md) when you participate. These logs help us track
+who has contributed and when.
 
 ## Configuration Helpers
 

--- a/docs/endpoint-reference.md
+++ b/docs/endpoint-reference.md
@@ -1,0 +1,34 @@
+# API Endpoint Reference
+
+This document lists HTTP routes exposed by DevOnboarder services and how Discord commands interact with them.
+
+## XP API
+
+These endpoints provide onboarding and XP details without authentication.
+
+- `GET /api/user/onboarding-status` – return the current onboarding phase.
+- `GET /api/user/level` – return the calculated user level.
+
+## Auth Service
+
+Requests to these endpoints require a valid JWT unless otherwise noted.
+
+- `POST /api/register` – create a new account and return a token.
+- `POST /api/login` – obtain a token for an existing account.
+- `GET /api/user` – fetch account details.
+- `GET /api/user/onboarding-status` – onboarding status for the authenticated user.
+- `GET /api/user/level` – level derived from accumulated XP.
+- `GET /api/user/contributions` – list contribution descriptions.
+- `POST /api/user/promote` – admins only; mark another user as an admin.
+
+## Discord Command Mapping
+
+The bot in `bot/` calls these routes when users run slash commands:
+
+| Command | Endpoint |
+| ------- | -------- |
+| `/verify` | `GET /api/user/onboarding-status` |
+| `/profile` | `GET /api/user/level` |
+| `/contribute` | `GET /api/user/contributions` |
+
+For example, typing `/verify` in Discord triggers a request to `/api/user/onboarding-status` and echoes the resulting status back to the channel.


### PR DESCRIPTION
## Summary
- document onboarding phases and XP milestones in docs
- log how to track contributors
- add endpoint reference with Discord command examples
- record docs update in changelog

## Testing
- `ruff check .`
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685431bd32a8832082f3df030643daa1