### PR TITLE
Add Discord role resolution to auth service

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,8 @@ All notable changes to this project will be recorded in this file.
 - Added authentication service with SQLAlchemy models and JWT-protected routes.
 - Documented running `devonboarder-auth` in the onboarding guide.
 - Added test ensuring the CLI prints the default greeting when no name is provided.
+- Authentication middleware now resolves Discord roles after JWT validation and
+  `/api/user` includes `isAdmin`, `isVerified`, `verificationType`, and `roles`.
 - Documented how to propose issues and pull requests in `docs/README.md`.
 - Added an alpha phase roadmap under `docs/roadmap/` and linked it from the docs README.
 - Added a README section pointing to workflow docs under `docs/`.

--- a/docs/endpoint-reference.md
+++ b/docs/endpoint-reference.md
@@ -15,7 +15,7 @@ Requests to these endpoints require a valid JWT unless otherwise noted.
 
 - `POST /api/register` – create a new account and return a token.
 - `POST /api/login` – obtain a token for an existing account.
-- `GET /api/user` – fetch account details.
+- `GET /api/user` – fetch account details including admin and verification flags.
 - `GET /api/user/onboarding-status` – onboarding status for the authenticated user.
 - `GET /api/user/level` – level derived from accumulated XP.
 - `GET /api/user/contributions` – list contribution descriptions.


### PR DESCRIPTION
## Summary
- enrich `get_current_user` with Discord role lookup and flag resolution
- expose `roles`, `isAdmin`, `isVerified`, and `verificationType` in `/api/user`
- document new fields in endpoint reference
- note middleware update in the changelog
- adjust tests for the new behavior

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68543a4caeb083209ae87fd9ff55915a