### PR TITLE
Introduce role helper module

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be recorded in this file.
 
 ## [Unreleased]
 - Added tests for Discord role resolution and `/api/user` flags.
+- Moved role flag logic to `utils.roles` and added `resolve_verification_type`.
 - Introduced Discord role resolution in the auth service and expanded `/api/user`
   to return Discord profile fields and resolved role flags.
 

--- a/src/devonboarder/auth_service.py
+++ b/src/devonboarder/auth_service.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from fastapi import FastAPI, Depends, HTTPException, status
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 
-from utils.discord import get_user_roles, resolve_user_flags, get_user_profile
+from utils.discord import get_user_roles, get_user_profile
+from utils.roles import resolve_user_flags
 from sqlalchemy import (
     Column,
     Integer,
@@ -105,7 +106,8 @@ def get_current_user(
 
     # Fetch Discord roles and resolve verification/admin flags
     roles = get_user_roles(str(user_id), token)
-    flags = resolve_user_flags(roles)
+    all_role_ids = {r for rs in roles.values() for r in rs}
+    flags = resolve_user_flags(all_role_ids)
 
     profile = get_user_profile(token)
 

--- a/src/utils/discord.py
+++ b/src/utils/discord.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import os
-
 import httpx
 
 
@@ -56,48 +54,5 @@ def get_user_profile(token: str) -> dict[str, str | None]:
     }
 
 
-def resolve_user_flags(user_roles: dict[str, list[str]]) -> dict[str, object]:
-    """Resolve admin and verification flags based on role IDs."""
-    env = os.environ
-    admin_guild = env.get("ADMIN_SERVER_GUILD_ID")
-    owner_role = env.get("OWNER_ROLE_ID")
-    admin_role = env.get("ADMINISTRATOR_ROLE_ID")
-    mod_role = env.get("MODERATOR_ROLE_ID")
-    verified_user_role = env.get("VERIFIED_USER_ROLE_ID")
-    verified_member_role = env.get("VERIFIED_MEMBER_ROLE_ID")
-    government_role = env.get("GOVERNMENT_ROLE_ID")
-    military_role = env.get("MILITARY_ROLE_ID")
-    education_role = env.get("EDUCATION_ROLE_ID")
 
-    all_roles = {r for roles in user_roles.values() for r in roles}
-
-    admin_roles = {owner_role, admin_role, mod_role} - {None}
-    is_admin = False
-    if admin_guild and admin_guild in user_roles:
-        is_admin = bool(set(user_roles[admin_guild]) & admin_roles)
-
-    verification_roles = {
-        verified_user_role,
-        verified_member_role,
-        government_role,
-        military_role,
-        education_role,
-    } - {None}
-    is_verified = bool(all_roles & verification_roles)
-
-    verification_type = None
-    if government_role in all_roles:
-        verification_type = "government"
-    elif military_role in all_roles:
-        verification_type = "military"
-    elif education_role in all_roles:
-        verification_type = "education"
-    elif verified_member_role in all_roles or verified_user_role in all_roles:
-        verification_type = "member"
-
-    return {
-        "isAdmin": is_admin,
-        "isVerified": is_verified,
-        "verificationType": verification_type,
-    }
 

--- a/src/utils/roles.py
+++ b/src/utils/roles.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import os
+from typing import Iterable, Optional
+
+
+def resolve_verification_type(role_ids: Iterable[str]) -> Optional[str]:
+    """Return the verification type for the given role IDs."""
+    env = os.environ
+    verified_member_role = env.get("VERIFIED_MEMBER_ROLE_ID")
+    verified_user_role = env.get("VERIFIED_USER_ROLE_ID")
+    government_role = env.get("GOVERNMENT_ROLE_ID")
+    military_role = env.get("MILITARY_ROLE_ID")
+    education_role = env.get("EDUCATION_ROLE_ID")
+
+    roles = set(role_ids)
+
+    if government_role in roles:
+        return "government"
+    if military_role in roles:
+        return "military"
+    if education_role in roles:
+        return "education"
+    if verified_member_role in roles or verified_user_role in roles:
+        return "member"
+    return None
+
+
+def resolve_user_flags(role_ids: Iterable[str]) -> dict[str, object]:
+    """Resolve admin and verification flags from role IDs."""
+    env = os.environ
+    owner_role = env.get("OWNER_ROLE_ID")
+    admin_role = env.get("ADMINISTRATOR_ROLE_ID")
+    mod_role = env.get("MODERATOR_ROLE_ID")
+
+    roles = set(role_ids)
+
+    admin_roles = {owner_role, admin_role, mod_role} - {None}
+    is_admin = bool(roles & admin_roles)
+
+    verification_type = resolve_verification_type(roles)
+
+    return {
+        "isAdmin": is_admin,
+        "isVerified": verification_type is not None,
+        "verificationType": verification_type,
+    }

--- a/tests/test_auth_service.py
+++ b/tests/test_auth_service.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 from devonboarder import auth_service
-from utils import discord as discord_utils
+from utils import roles as roles_utils
 
 
 def setup_function(function):
@@ -173,7 +173,7 @@ def test_user_endpoint_returns_flags(monkeypatch):
     monkeypatch.setattr(
         auth_service,
         "resolve_user_flags",
-        discord_utils.resolve_user_flags,
+        roles_utils.resolve_user_flags,
     )
 
     monkeypatch.setattr(

--- a/tests/test_discord_utils.py
+++ b/tests/test_discord_utils.py
@@ -1,6 +1,7 @@
 import httpx
 import pytest
-from utils.discord import get_user_roles, resolve_user_flags, get_user_profile
+from utils.discord import get_user_roles, get_user_profile
+from utils.roles import resolve_user_flags
 
 
 class StubResponse:
@@ -45,8 +46,7 @@ def test_resolve_user_flags(monkeypatch):
     monkeypatch.setenv("MILITARY_ROLE_ID", "mil")
     monkeypatch.setenv("EDUCATION_ROLE_ID", "edu")
 
-    roles = {"10": ["owner"], "20": ["gov"]}
-    flags = resolve_user_flags(roles)
+    flags = resolve_user_flags({"owner", "gov"})
     assert flags == {
         "isAdmin": True,
         "isVerified": True,
@@ -119,6 +119,6 @@ def test_resolve_user_flags_combinations(monkeypatch, roles, expected):
     monkeypatch.setenv("MILITARY_ROLE_ID", "mil")
     monkeypatch.setenv("EDUCATION_ROLE_ID", "edu")
 
-    flags = resolve_user_flags(roles)
+    flags = resolve_user_flags({r for rs in roles.values() for r in rs})
     assert flags == expected
 


### PR DESCRIPTION
# Summary
- centralize role flag helpers in `utils.roles`
- update auth service and tests to use new helpers
- document the change in the changelog

# Linked Issues

# Screenshots

# Testing Steps
```bash
ruff check .
pytest -q
```


------
https://chatgpt.com/codex/tasks/task_e_68544b8139448320b5299b64d7b23f4c