### PR TITLE
Add router for user info

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be recorded in this file.
 - Moved role flag logic to `utils.roles` and added `resolve_verification_type`.
 - Introduced Discord role resolution in the auth service and expanded `/api/user`
   to return Discord profile fields and resolved role flags.
+- Added `src/routes/user.py` router for `/api/user` and included it in the auth service.
 
 - Added `.env.example` files for individual services and documented how to copy
   them during setup.

--- a/src/devonboarder/auth_service.py
+++ b/src/devonboarder/auth_service.py
@@ -149,17 +149,6 @@ def login(data: dict, db: Session = Depends(get_db)) -> dict[str, str]:
     return {"token": create_token(user)}
 
 
-@app.get("/api/user")
-def user_info(current_user: User = Depends(get_current_user)) -> dict[str, object]:
-    return {
-        "id": current_user.discord_id,
-        "username": current_user.discord_username,
-        "avatar": current_user.avatar,
-        "isAdmin": current_user.isAdmin,
-        "isVerified": current_user.isVerified,
-        "verificationType": current_user.verificationType,
-        "roles": current_user.roles,
-    }
 
 
 @app.get("/api/user/onboarding-status")
@@ -202,6 +191,8 @@ def promote(
 
 def create_app() -> FastAPI:
     init_db()
+    from routes.user import router as user_router
+    app.include_router(user_router)
     return app
 
 

--- a/src/routes/user.py
+++ b/src/routes/user.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+
+from devonboarder import auth_service
+
+router = APIRouter()
+
+
+@router.get("/api/user")
+def user_info(
+    current_user: auth_service.User = Depends(auth_service.get_current_user),
+) -> dict[str, object]:
+    """Return the current user's Discord profile and role flags."""
+    roles = getattr(current_user, "roles", {})
+    all_role_ids = {r for rs in roles.values() for r in rs}
+    flags = auth_service.resolve_user_flags(all_role_ids)
+    return {
+        "id": getattr(current_user, "discord_id", None),
+        "username": getattr(current_user, "discord_username", None),
+        "avatar": getattr(current_user, "avatar", None),
+        "isAdmin": flags["isAdmin"],
+        "isVerified": flags["isVerified"],
+        "verificationType": flags["verificationType"],
+        "roles": roles,
+    }


### PR DESCRIPTION
## Summary
- create `src/routes/user.py` router for `/api/user`
- remove inline route from auth service and include router during app creation
- document the new router in `docs/CHANGELOG.md`

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68544eab61f48320b4f6d4a384532d33