### PR TITLE
Update verified role env docs

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be recorded in this file.
 
 ## [Unreleased]
 - Added tests for Discord role resolution and `/api/user` flags.
+- Clarified the purpose of `VERIFIED_GOVERNMENT_ROLE_ID`,
+  `VERIFIED_MILITARY_ROLE_ID`, and `VERIFIED_EDUCATION_ROLE_ID` in
+  `docs/env.md`.
 - Moved role flag logic to `utils.roles` and added `resolve_verification_type`.
 - Introduced Discord role resolution in the auth service and expanded `/api/user`
   to return Discord profile fields and resolved role flags.

--- a/docs/env.md
+++ b/docs/env.md
@@ -42,3 +42,10 @@ moderator role inside the admin guild. Verification types (`government`,
 `military`, `education` or `member`) are resolved in the same way. These
 flags appear in the `/api/user` response and control access to certain
 commands and pages.
+
+- `VERIFIED_GOVERNMENT_ROLE_ID` &ndash; role granted after confirming a
+  government employee's credentials.
+- `VERIFIED_MILITARY_ROLE_ID` &ndash; role granted once a user proves active
+  duty or veteran status.
+- `VERIFIED_EDUCATION_ROLE_ID` &ndash; role assigned when a school or
+  university affiliation is verified.


### PR DESCRIPTION
## Summary
Clarified the purpose of the three verified Discord role IDs in `docs/env.md`.

## Testing
- `ruff check .`
- `pytest -q`
- `npm test` (from `bot/`)


------
https://chatgpt.com/codex/tasks/task_e_685452aca8f48320b2934d5b0df688c8