### PR TITLE
Add Discord bot scaffold

### DIFF
--- a/bot/.env.example
+++ b/bot/.env.example
@@ -1,4 +1,5 @@
 # Environment variables for the Discord bot
-DISCORD_TOKEN=your-discord-bot-token
-DISCORD_CLIENT_ID=your-discord-client-id
+DISCORD_BOT_TOKEN=changeme
+DISCORD_CLIENT_ID=changeme
+DISCORD_GUILD_IDS=comma,separated,ids
 API_BASE_URL=http://localhost:8001

--- a/bot/Dockerfile
+++ b/bot/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:18
+WORKDIR /usr/src/app
+COPY package.json package-lock.json* ./
+RUN npm install --production
+COPY tsconfig.json ./
+COPY src ./src
+RUN npm run build
+CMD ["node", "dist/main.js"]

--- a/bot/README.md
+++ b/bot/README.md
@@ -1,0 +1,49 @@
+# DevOnboarder Discord Bot
+
+This service implements a simple Discord bot using `discord.js` v14.
+It loads slash commands and events dynamically on startup and authenticates
+using the token provided in `.env`.
+
+## Setup
+
+1. Copy the example environment file and add your credentials:
+   ```bash
+   cp .env.example .env
+   ```
+   Fill in `DISCORD_BOT_TOKEN`, `DISCORD_CLIENT_ID`, and `DISCORD_GUILD_IDS`.
+2. Install dependencies and build the bot:
+   ```bash
+   npm install
+   npm run build
+   ```
+3. Run the bot locally:
+   ```bash
+   npm start
+   ```
+
+## Docker
+
+The `Dockerfile` builds the TypeScript source and runs `dist/main.js`.
+The development compose file mounts the source for hot reload:
+
+```yaml
+bot:
+  build: ./bot
+  env_file:
+    - ./bot/.env
+  volumes:
+    - ./bot:/usr/src/app
+  command: ["npm", "start"]
+```
+
+## Adding Commands
+
+Place new command modules in `src/commands`. Each module exports
+`data` (a `SlashCommandBuilder`) and an `execute` function. They are
+loaded automatically when the bot starts.
+
+## Future Work
+
+- Sync verified roles back to the auth database.
+- Award XP for community participation.
+- Log quiz completion via slash commands.

--- a/bot/src/commands/ping.ts
+++ b/bot/src/commands/ping.ts
@@ -1,0 +1,9 @@
+import { SlashCommandBuilder, ChatInputCommandInteraction } from 'discord.js';
+
+export const data = new SlashCommandBuilder()
+  .setName('ping')
+  .setDescription('Replies with pong.');
+
+export async function execute(interaction: ChatInputCommandInteraction) {
+  await interaction.reply('🏓 Pong!');
+}

--- a/bot/src/events/interactionCreate.ts
+++ b/bot/src/events/interactionCreate.ts
@@ -1,0 +1,12 @@
+import { Interaction } from 'discord.js';
+import { Commands } from '../utils/loadFiles';
+
+export const name = 'interactionCreate';
+export const once = false;
+
+export async function execute(interaction: Interaction, commands: Commands) {
+  if (!interaction.isChatInputCommand()) return;
+  const command = commands.get(interaction.commandName);
+  if (!command) return;
+  await command.execute(interaction);
+}

--- a/bot/src/events/ready.ts
+++ b/bot/src/events/ready.ts
@@ -1,0 +1,8 @@
+import { Client } from 'discord.js';
+
+export const name = 'ready';
+export const once = true;
+
+export function execute(client: Client) {
+  console.log(`🤖 Logged in as ${client.user?.tag}`);
+}

--- a/bot/src/main.ts
+++ b/bot/src/main.ts
@@ -1,0 +1,18 @@
+import { Client, GatewayIntentBits } from 'discord.js';
+import dotenv from 'dotenv';
+import path from 'path';
+import { loadCommands, loadEvents } from './utils/loadFiles';
+
+dotenv.config();
+
+const client = new Client({
+  intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMembers],
+});
+
+async function start() {
+  const commands = await loadCommands(path.join(__dirname, 'commands'));
+  await loadEvents(client, path.join(__dirname, 'events'), commands);
+  await client.login(process.env.DISCORD_BOT_TOKEN);
+}
+
+start();

--- a/bot/src/utils/loadFiles.ts
+++ b/bot/src/utils/loadFiles.ts
@@ -1,0 +1,32 @@
+import { Client, Collection } from 'discord.js';
+import { readdirSync } from 'fs';
+import path from 'path';
+
+export type CommandModule = {
+  data: { name: string };
+  execute: (interaction: any) => Promise<void>;
+};
+
+export type Commands = Collection<string, CommandModule>;
+
+export async function loadCommands(dir: string): Promise<Commands> {
+  const commands: Commands = new Collection();
+  const files = readdirSync(dir).filter((f) => f.endsWith('.js'));
+  for (const file of files) {
+    const mod = await import(path.join(dir, file));
+    commands.set(mod.data.name, mod as CommandModule);
+  }
+  return commands;
+}
+
+export async function loadEvents(client: Client, dir: string, commands: Commands) {
+  const files = readdirSync(dir).filter((f) => f.endsWith('.js'));
+  for (const file of files) {
+    const event = await import(path.join(dir, file));
+    if (event.once) {
+      client.once(event.name, (...args) => event.execute(...args, commands));
+    } else {
+      client.on(event.name, (...args) => event.execute(...args, commands));
+    }
+  }
+}

--- a/bot/tests/ping.test.ts
+++ b/bot/tests/ping.test.ts
@@ -1,0 +1,10 @@
+import { execute } from '../src/commands/ping';
+
+const interaction = {
+  reply: jest.fn(),
+};
+
+test('ping command replies with pong', async () => {
+  await execute(interaction as any);
+  expect(interaction.reply).toHaveBeenCalledWith('🏓 Pong!');
+});

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -26,10 +26,12 @@ services:
     command: ["devonboarder-auth"]
 
   bot:
-    <<: [*node-base, *env-dev]
-    working_dir: /bot
+    build: ./bot
+    env_file:
+      - ./bot/.env
     volumes:
-      - ./bot:/bot
+      - ./bot:/usr/src/app
+    command: ["npm", "start"]
 
   xp:
     <<: [*app-base, *env-dev]

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be recorded in this file.
 - Introduced Discord role resolution in the auth service and expanded `/api/user`
   to return Discord profile fields and resolved role flags.
 - Added `src/routes/user.py` router for `/api/user` and included it in the auth service.
+- Added Discord bot scaffolding with dynamic command loading and a `/ping` command.
 
 - Added `.env.example` files for individual services and documented how to copy
   them during setup.


### PR DESCRIPTION
## Summary
- scaffold Discord bot service
- add dynamic command/event loader
- expose `/ping` command
- containerize bot and update compose file
- document setup

## Testing
- `ruff check .`
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68545d6f564c8320a7af0825b2cbe559