### PR TITLE
Document secret environment variables

### DIFF
--- a/.env.bot.example
+++ b/.env.bot.example
@@ -1,4 +1,9 @@
 # Sample environment for the Discord bot
+# These values are secrets. Store real credentials in your deployment's
+# secret manager and keep them out of version control.
 DISCORD_TOKEN=your-discord-bot-token
+DISCORD_BOT_TOKEN=your-discord-bot-token
 DISCORD_CLIENT_ID=your-discord-client-id
+DISCORD_CLIENT_SECRET=
+DISCORD_GUILD_IDS=comma,separated,ids
 API_BASE_URL=http://localhost:8001

--- a/.env.example
+++ b/.env.example
@@ -30,3 +30,13 @@ EDUCATION_ROLE_ID=
 VERIFIED_GOVERNMENT_ROLE_ID=
 VERIFIED_MILITARY_ROLE_ID=
 VERIFIED_EDUCATION_ROLE_ID=
+
+# Secrets
+# These credentials should be supplied through your deployment's secret store
+# and never committed to version control.
+DISCORD_CLIENT_ID=
+DISCORD_CLIENT_SECRET=
+AUTH_SECRET_KEY=
+DISCORD_TOKEN=
+DISCORD_BOT_TOKEN=
+DISCORD_GUILD_IDS=

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -98,6 +98,7 @@ All notable changes to this project will be recorded in this file.
 - Added Discord utilities for fetching user roles and resolving admin flags.
 - Documented role and guild ID placeholders in `.env.example` and created `docs/env.md` with details on the role-based permission system.
 - Added verified role ID placeholders to `.env.example` and documented them in `docs/env.md`.
+- Added a "Secrets" section in `docs/env.md` covering Discord OAuth and bot tokens, with matching placeholders in `.env.example` and `.env.bot.example`.
 - Added `tests/test_roles.py` verifying admin and verified role flags.
 
 ## [0.1.0] - 2025-06-14

--- a/docs/env.md
+++ b/docs/env.md
@@ -2,7 +2,10 @@
 
 This document lists important variables used by DevOnboarder. Copy
 `.env.example` to `.env.dev` and fill in values before running the
-services. The CI pipeline also copies this file during tests.
+services. The CI pipeline also copies this file during tests. The auth and
+Discord bot services each provide their own examples &ndash; copy
+`auth/.env.example` to `auth/.env` and `bot/.env.example` to `bot/.env`
+when working with those packages directly.
 
 ## Core settings
 
@@ -15,6 +18,19 @@ services. The CI pipeline also copies this file during tests.
 
 - `IS_ALPHA_USER` &ndash; enable routes restricted to early testers.
 - `IS_FOUNDER` &ndash; enable routes and perks for Founder's Circle members.
+
+## Secrets
+
+The following tokens and keys are required but **must not** be committed to
+the repository. Provide them through your build or deployment secret store:
+
+- `DISCORD_CLIENT_ID` and `DISCORD_CLIENT_SECRET` &ndash; OAuth credentials for
+  authenticating with Discord.
+- `AUTH_SECRET_KEY` &ndash; signing key used by the auth service (sometimes
+  referred to as `JWT_SECRET`).
+- `DISCORD_TOKEN` &ndash; bot token used when running the Discord bot.
+- `DISCORD_BOT_TOKEN` &ndash; alternative variable name for the bot token.
+- `DISCORD_GUILD_IDS` &ndash; comma-separated guilds where the bot operates.
 
 ## Discord role-based permissions
 


### PR DESCRIPTION
## Summary
- describe Discord & auth secrets in docs/env.md
- reference bot/.env.example and auth/.env.example
- add secret placeholders to .env.example and .env.bot.example
- update the changelog

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855945843788320a33ba79d18a068cd