### PR TITLE
Rename auth database env var

### DIFF
--- a/auth/.env.example
+++ b/auth/.env.example
@@ -1,3 +1,3 @@
 # Environment variables for the Auth service
 AUTH_SECRET_KEY=change-me
-AUTH_DATABASE_URL=sqlite:///./auth.db
+DATABASE_URL=sqlite:///./auth.db

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be recorded in this file.
 
 - Added `.env.example` files for individual services and documented how to copy
   them during setup.
+- Renamed `AUTH_DATABASE_URL` to `DATABASE_URL` for the auth service.
 
 - Added `docker-compose.dev.yaml` and `docker-compose.prod.yaml` with auth,
   bot, XP API, frontend, and Postgres services loading variables from

--- a/src/devonboarder/auth_service.py
+++ b/src/devonboarder/auth_service.py
@@ -23,7 +23,7 @@ ALGORITHM = "HS256"
 
 Base = declarative_base()
 engine = create_engine(
-    os.getenv("AUTH_DATABASE_URL", "sqlite:///./auth.db"),
+    os.getenv("DATABASE_URL", "sqlite:///./auth.db"),
     connect_args={"check_same_thread": False},
 )
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)


### PR DESCRIPTION
## Summary
- rename `AUTH_DATABASE_URL` to `DATABASE_URL`
- update auth environment example
- note variable rename in changelog

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68559ae23f2883208f235c16f4faf727