### PR TITLE
Modify DB initialization

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be recorded in this file.
 
 ## [Unreleased]
+- `init_db()` no longer drops existing tables. Tests now clean up the database
+  themselves.
 - Introduced `utils/roles.py` and expanded `/api/user` to return role flags;
   documented `GOVERNMENT_ROLE_ID`, `MILITARY_ROLE_ID`, and `EDUCATION_ROLE_ID`.
 - Added tests for Discord role resolution and `/api/user` flags.

--- a/src/devonboarder/auth_service.py
+++ b/src/devonboarder/auth_service.py
@@ -64,7 +64,7 @@ class XPEvent(Base):
 
 
 def init_db() -> None:
-    Base.metadata.drop_all(bind=engine)
+    """Create database tables if they do not exist."""
     Base.metadata.create_all(bind=engine)
 
 
@@ -195,7 +195,8 @@ def promote(
 
 
 def create_app() -> FastAPI:
-    init_db()
+    if os.getenv("INIT_DB_ON_STARTUP"):
+        init_db()
     from routes.user import router as user_router
     app.include_router(user_router)
     return app

--- a/tests/test_auth_service.py
+++ b/tests/test_auth_service.py
@@ -4,6 +4,7 @@ from utils import roles as roles_utils
 
 
 def setup_function(function):
+    auth_service.Base.metadata.drop_all(bind=auth_service.engine)
     auth_service.init_db()
     auth_service.get_user_roles = lambda user_id, token: {}
     auth_service.resolve_user_flags = (


### PR DESCRIPTION
## Summary
- ensure `init_db()` only creates tables
- initialize the DB on startup only when `INIT_DB_ON_STARTUP` is set
- adapt auth service tests to drop tables directly
- document database change in the changelog

## Testing
- `pip install -e .`
- `pip install -r requirements-dev.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6855a0ffe2b083209ff76d5a4a7beefa