### PR TITLE
Connect XP API to database

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to this project will be recorded in this file.
 - Clarified the purpose of `VERIFIED_GOVERNMENT_ROLE_ID`,
   `VERIFIED_MILITARY_ROLE_ID`, and `VERIFIED_EDUCATION_ROLE_ID` in
   `docs/env.md`.
+- XP API now reads `Contribution` and `XPEvent` data to return onboarding
+  status and level for the requested user.
 - Moved role flag logic to `utils.roles` and added `resolve_verification_type`.
 - Introduced Discord role resolution in the auth service and expanded `/api/user`
   to return Discord profile fields and resolved role flags.

--- a/docs/endpoint-reference.md
+++ b/docs/endpoint-reference.md
@@ -4,10 +4,11 @@ This document lists HTTP routes exposed by DevOnboarder services and how Discord
 
 ## XP API
 
-These endpoints provide onboarding and XP details without authentication.
+These endpoints provide onboarding and XP details without authentication. Pass a
+`username` query parameter to look up records for that user.
 
-- `GET /api/user/onboarding-status` – return the current onboarding phase.
-- `GET /api/user/level` – return the calculated user level.
+- `GET /api/user/onboarding-status?username=<name>` – current onboarding phase.
+- `GET /api/user/level?username=<name>` – calculated user level.
 
 ## Auth Service
 

--- a/src/devonboarder/xp_api.py
+++ b/src/devonboarder/xp_api.py
@@ -1,20 +1,36 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, FastAPI
+from fastapi import APIRouter, FastAPI, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from devonboarder import auth_service
 
 router = APIRouter()
 
 
 @router.get("/api/user/onboarding-status")
-def onboarding_status() -> dict[str, str]:
-    """Return a placeholder onboarding status."""
-    return {"status": "pending"}
+def onboarding_status(
+    username: str, db: Session = Depends(auth_service.get_db)
+) -> dict[str, str]:
+    """Return the user's onboarding status."""
+    user = db.query(auth_service.User).filter_by(username=username).first()
+    if user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+    status_str = "complete" if user.contributions else "pending"
+    return {"status": status_str}
 
 
 @router.get("/api/user/level")
-def user_level() -> dict[str, int]:
-    """Return a placeholder user level."""
-    return {"level": 1}
+def user_level(
+    username: str, db: Session = Depends(auth_service.get_db)
+) -> dict[str, int]:
+    """Return the user's current level."""
+    user = db.query(auth_service.User).filter_by(username=username).first()
+    if user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+    xp_total = sum(evt.xp for evt in user.events)
+    level = xp_total // 100 + 1
+    return {"level": level}
 
 
 def create_app() -> FastAPI:

--- a/tests/test_xp_api.py
+++ b/tests/test_xp_api.py
@@ -1,19 +1,36 @@
 from devonboarder.xp_api import create_app
+from devonboarder import auth_service
 from fastapi.testclient import TestClient
 
 
-def test_onboarding_status():
+def setup_function(function):
+    auth_service.Base.metadata.drop_all(bind=auth_service.engine)
+    auth_service.init_db()
+
+
+def _seed_data():
+    with auth_service.SessionLocal() as db:
+        user = auth_service.User(username="alice", password_hash="x")
+        db.add(user)
+        db.commit()
+        db.refresh(user)
+        db.add(auth_service.Contribution(user_id=user.id, description="first"))
+        db.add_all([
+            auth_service.XPEvent(user_id=user.id, xp=120),
+            auth_service.XPEvent(user_id=user.id, xp=70),
+        ])
+        db.commit()
+
+
+def test_onboarding_status_and_level():
+    _seed_data()
     app = create_app()
     client = TestClient(app)
-    response = client.get("/api/user/onboarding-status")
-    assert response.status_code == 200
-    assert response.json() == {"status": "pending"}
 
+    resp = client.get("/api/user/onboarding-status", params={"username": "alice"})
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "complete"}
 
-def test_user_level():
-    app = create_app()
-    client = TestClient(app)
-    response = client.get("/api/user/level")
-    assert response.status_code == 200
-    assert response.json() == {"level": 1}
-
+    resp = client.get("/api/user/level", params={"username": "alice"})
+    assert resp.status_code == 200
+    assert resp.json() == {"level": 2}


### PR DESCRIPTION
## Summary
- wire XP API to auth database models
- compute onboarding status and level from stored records
- clarify query parameters in the endpoint reference
- add test for the new XP API logic

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855a2ba3ca88320a8651906c61bece6