### PR TITLE
Add Discord OAuth login

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be recorded in this file.
 - Consolidated bot entrypoint to `main.ts` and standardized `DISCORD_BOT_TOKEN`.
 - Bot API helpers accept a token parameter or `BOT_JWT` and send
   `Authorization` headers.
+- Added Discord OAuth login with `/login/discord` and `/login/discord/callback`.
 - Auth service now passes `check_same_thread` only when `DATABASE_URL` starts
   with `sqlite`.
 - Introduced `utils/roles.py` and expanded `/api/user` to return role flags;

--- a/docs/endpoint-reference.md
+++ b/docs/endpoint-reference.md
@@ -16,6 +16,8 @@ Requests to these endpoints require a valid JWT unless otherwise noted.
 
 - `POST /api/register` – create a new account and return a token.
 - `POST /api/login` – obtain a token for an existing account.
+- `GET /login/discord` – redirect to Discord OAuth (no auth required).
+- `GET /login/discord/callback` – handle the OAuth code and return a JWT.
 - `GET /api/user` – fetch the Discord ID, username, avatar, roles, and admin/verification flags.
 - `GET /api/user/onboarding-status` – onboarding status for the authenticated user.
 - `GET /api/user/level` – level derived from accumulated XP.

--- a/docs/env.md
+++ b/docs/env.md
@@ -30,6 +30,8 @@ the repository. Provide them through your build or deployment secret store:
   referred to as `JWT_SECRET`).
 - `DISCORD_BOT_TOKEN` &ndash; bot token used when running the Discord bot.
 - `DISCORD_GUILD_IDS` &ndash; comma-separated guilds where the bot operates.
+- `DISCORD_REDIRECT_URI` &ndash; callback URL for Discord OAuth. Defaults to
+  `http://localhost:8002/login/discord/callback`.
 
 ## Discord role-based permissions
 
@@ -66,3 +68,11 @@ access to certain commands and pages.
   duty or veteran status.
 - `VERIFIED_EDUCATION_ROLE_ID` &ndash; role assigned when a school or
   university affiliation is verified.
+
+### Discord OAuth login
+
+Users sign in by visiting `/login/discord`, which redirects to Discord's consent
+screen. After granting permissions, Discord redirects back to
+`DISCORD_REDIRECT_URI`. The auth service exchanges the provided code for an
+access token, creates or looks up the user, then returns a JWT from
+`/login/discord/callback`.


### PR DESCRIPTION
## Summary
- implement `/login/discord` and `/login/discord/callback` routes in the auth service
- document OAuth environment variables and flow
- describe new auth endpoints
- add changelog entry
- test OAuth callback and JWT issuance

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68562c14c8cc8320ac6d452792eb3645