### PR TITLE
Add username param to bot API

### DIFF
--- a/bot/src/api.ts
+++ b/bot/src/api.ts
@@ -22,17 +22,35 @@ async function request<T>(path: string, token?: string): Promise<T> {
   return (await resp.json()) as T;
 }
 
-export async function getUserLevel(token?: string): Promise<number> {
-  const data = await request<{ level: number }>('/api/user/level', token);
+export async function getUserLevel(
+  username: string,
+  token?: string
+): Promise<number> {
+  const data = await request<{ level: number }>(
+    `/api/user/level?username=${encodeURIComponent(username)}`,
+    token
+  );
   return data.level;
 }
 
-export async function getUserContributions(token?: string): Promise<string[]> {
-  const data = await request<{ contributions: string[] }>('/api/user/contributions', token);
+export async function getUserContributions(
+  username: string,
+  token?: string
+): Promise<string[]> {
+  const data = await request<{ contributions: string[] }>(
+    `/api/user/contributions?username=${encodeURIComponent(username)}`,
+    token
+  );
   return data.contributions;
 }
 
-export async function getOnboardingStatus(token?: string): Promise<string> {
-  const data = await request<{ status: string }>('/api/user/onboarding-status', token);
+export async function getOnboardingStatus(
+  username: string,
+  token?: string
+): Promise<string> {
+  const data = await request<{ status: string }>(
+    `/api/user/onboarding-status?username=${encodeURIComponent(username)}`,
+    token
+  );
   return data.status;
 }

--- a/bot/src/commands/contribute.ts
+++ b/bot/src/commands/contribute.ts
@@ -1,0 +1,15 @@
+import { SlashCommandBuilder, ChatInputCommandInteraction } from 'discord.js';
+import { getUserContributions } from '../api';
+
+export const data = new SlashCommandBuilder()
+  .setName('contribute')
+  .setDescription('List your contributions');
+
+export async function execute(interaction: ChatInputCommandInteraction) {
+  const username = interaction.user?.username ?? interaction.user.id;
+  const contribs = await getUserContributions(username);
+  const message = contribs.length
+    ? contribs.join(', ')
+    : 'No contributions yet.';
+  await interaction.reply(message);
+}

--- a/bot/src/commands/profile.ts
+++ b/bot/src/commands/profile.ts
@@ -1,0 +1,12 @@
+import { SlashCommandBuilder, ChatInputCommandInteraction } from 'discord.js';
+import { getUserLevel } from '../api';
+
+export const data = new SlashCommandBuilder()
+  .setName('profile')
+  .setDescription('Show your XP level');
+
+export async function execute(interaction: ChatInputCommandInteraction) {
+  const username = interaction.user?.username ?? interaction.user.id;
+  const level = await getUserLevel(username);
+  await interaction.reply(`Current level: ${level}`);
+}

--- a/bot/src/commands/verify.ts
+++ b/bot/src/commands/verify.ts
@@ -1,0 +1,12 @@
+import { SlashCommandBuilder, ChatInputCommandInteraction } from 'discord.js';
+import { getOnboardingStatus } from '../api';
+
+export const data = new SlashCommandBuilder()
+  .setName('verify')
+  .setDescription('Check your onboarding status');
+
+export async function execute(interaction: ChatInputCommandInteraction) {
+  const username = interaction.user?.username ?? interaction.user.id;
+  const status = await getOnboardingStatus(username);
+  await interaction.reply(`Onboarding status: ${status}`);
+}

--- a/bot/tests/api.test.ts
+++ b/bot/tests/api.test.ts
@@ -22,31 +22,31 @@ afterEach(() => {
   jest.restoreAllMocks();
 });
 
-test('getUserLevel sends auth header', async () => {
+test('getUserLevel sends auth header and username', async () => {
   mockedFetch.mockResolvedValue(mockResponse({ level: 3 }));
-  const level = await getUserLevel('tok');
+  const level = await getUserLevel('alice', 'tok');
   expect(mockedFetch).toHaveBeenCalledWith(
-    expect.stringContaining('/api/user/level'),
+    expect.stringContaining('/api/user/level?username=alice'),
     expect.objectContaining({ headers: { Authorization: 'Bearer tok' } })
   );
   expect(level).toBe(3);
 });
 
-test('getUserContributions sends auth header', async () => {
+test('getUserContributions sends auth header and username', async () => {
   mockedFetch.mockResolvedValue(mockResponse({ contributions: ['fix1'] }));
-  const contribs = await getUserContributions('tok');
+  const contribs = await getUserContributions('bob', 'tok');
   expect(mockedFetch).toHaveBeenCalledWith(
-    expect.stringContaining('/api/user/contributions'),
+    expect.stringContaining('/api/user/contributions?username=bob'),
     expect.objectContaining({ headers: { Authorization: 'Bearer tok' } })
   );
   expect(contribs).toEqual(['fix1']);
 });
 
-test('getOnboardingStatus sends auth header', async () => {
+test('getOnboardingStatus sends auth header and username', async () => {
   mockedFetch.mockResolvedValue(mockResponse({ status: 'complete' }));
-  const status = await getOnboardingStatus('tok');
+  const status = await getOnboardingStatus('charlie', 'tok');
   expect(mockedFetch).toHaveBeenCalledWith(
-    expect.stringContaining('/api/user/onboarding-status'),
+    expect.stringContaining('/api/user/onboarding-status?username=charlie'),
     expect.objectContaining({ headers: { Authorization: 'Bearer tok' } })
   );
   expect(status).toBe('complete');
@@ -55,9 +55,9 @@ test('getOnboardingStatus sends auth header', async () => {
 test('token is read from BOT_JWT env var', async () => {
   mockedFetch.mockResolvedValue(mockResponse({ status: 'ok' }));
   process.env.BOT_JWT = 'envtoken';
-  await getOnboardingStatus();
+  await getOnboardingStatus('dave');
   expect(mockedFetch).toHaveBeenCalledWith(
-    expect.any(String),
+    expect.stringContaining('/api/user/onboarding-status?username=dave'),
     expect.objectContaining({ headers: { Authorization: 'Bearer envtoken' } })
   );
 });
@@ -68,6 +68,6 @@ test('errors are thrown for non-ok responses', async () => {
   mockedFetch.mockResolvedValue(
     Promise.resolve({ ok: false, status: 500, json: jsonMock } as any)
   );
-  await expect(getUserLevel('tok')).rejects.toThrow('500');
+  await expect(getUserLevel('erin', 'tok')).rejects.toThrow('500');
   expect(jsonMock).not.toHaveBeenCalled();
 });

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,8 @@ All notable changes to this project will be recorded in this file.
   failure responses.
 - Auth service now filters Discord roles to the admin guild when resolving
   user flags. Updated docs to clarify guild-based role filtering.
+- Bot API helpers now accept a `username` argument and bot commands send the
+  caller's name in each request.
 - Clarified the purpose of `VERIFIED_GOVERNMENT_ROLE_ID`,
   `VERIFIED_MILITARY_ROLE_ID`, and `VERIFIED_EDUCATION_ROLE_ID` in
   `docs/env.md`.


### PR DESCRIPTION
# Summary
- send username when calling bot API helpers
- create verify, profile and contribute commands that pass the user name
- update tests for new URL parameters
- document change in CHANGELOG

# Testing Steps
```bash
ruff check .
pytest -q
cd bot && npx jest --runInBand --verbose
```

# Checklist
- [x] Updated `docs/CHANGELOG.md`
- [x] Updated relevant documentation in `docs/`
- [x] Lint and tests pass

------
https://chatgpt.com/codex/tasks/task_e_68562e64ed248320b2f67a9dad000f98