### PR TITLE
Add bot command modules and loader test

### DIFF
--- a/bot/README.md
+++ b/bot/README.md
@@ -44,6 +44,13 @@ Place new command modules in `src/commands`. Each module exports
 `data` (a `SlashCommandBuilder`) and an `execute` function. They are
 loaded automatically when the bot starts.
 
+The repository provides the following built-in commands:
+
+- `/ping` – simple health check returning `Pong!`.
+- `/verify` – show your onboarding status from the XP API.
+- `/profile` – display your current XP level.
+- `/contribute` – record a contribution description.
+
 ## Future Work
 
 - Sync verified roles back to the auth database.

--- a/bot/src/utils/loadFiles.ts
+++ b/bot/src/utils/loadFiles.ts
@@ -11,7 +11,7 @@ export type Commands = Collection<string, CommandModule>;
 
 export async function loadCommands(dir: string): Promise<Commands> {
   const commands: Commands = new Collection();
-  const files = readdirSync(dir).filter((f) => f.endsWith('.js'));
+  const files = readdirSync(dir).filter((f) => f.endsWith('.js') || f.endsWith('.ts'));
   for (const file of files) {
     const mod = await import(path.join(dir, file));
     commands.set(mod.data.name, mod as CommandModule);

--- a/bot/tests/interaction.test.ts
+++ b/bot/tests/interaction.test.ts
@@ -1,20 +1,39 @@
+import path from 'path';
 import { execute } from '../src/events/interactionCreate';
-import { CommandModule, Commands } from '../src/utils/loadFiles';
+import { loadCommands } from '../src/utils/loadFiles';
+
+jest.mock('../src/api', () => ({
+  getOnboardingStatus: jest.fn().mockResolvedValue('complete'),
+  getUserLevel: jest.fn().mockResolvedValue(42),
+  submitContribution: jest.fn().mockResolvedValue(undefined),
+}));
 
 function makeInteraction(commandName: string) {
   return {
     isChatInputCommand: () => true,
     commandName,
+    reply: jest.fn(),
+    options: { getString: jest.fn().mockReturnValue('fix bug') },
+    user: { id: '1', username: 'alice' },
   } as any;
 }
 
-test('interaction handler executes matching command', async () => {
-  const cmd: CommandModule = {
-    data: { name: 'verify' },
-    execute: jest.fn(),
-  };
-  const commands = new Map([[cmd.data.name, cmd]]) as unknown as Commands;
-  const interaction = makeInteraction('verify');
-  await execute(interaction, commands);
-  expect(cmd.execute).toHaveBeenCalledWith(interaction);
+test('interaction handler executes commands loaded from disk', async () => {
+  const commands = await loadCommands(path.join(__dirname, '..', 'src', 'commands'));
+
+  const ping = makeInteraction('ping');
+  await execute(ping, commands);
+  expect(ping.reply).toHaveBeenCalledWith('🏓 Pong!');
+
+  const verify = makeInteraction('verify');
+  await execute(verify, commands);
+  expect(verify.reply).toHaveBeenCalledWith('Onboarding status: complete');
+
+  const profile = makeInteraction('profile');
+  await execute(profile, commands);
+  expect(profile.reply).toHaveBeenCalledWith('Current level: 42');
+
+  const contribute = makeInteraction('contribute');
+  await execute(contribute, commands);
+  expect(contribute.reply).toHaveBeenCalledWith('Recorded contribution: fix bug');
 });

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable changes to this project will be recorded in this file.
 - Added `src/routes/user.py` router for `/api/user` and included it in the auth service.
 - Added Discord bot scaffolding with dynamic command loading and a `/ping` command.
 - Added `POST /api/user/contributions` endpoint and updated the `/contribute` bot command to record contributions.
+- Added `/verify`, `/profile`, and `/contribute` command modules to the bot and tests loading them via `loadCommands`.
 
 - Added `.env.example` files for individual services and documented how to copy
   them during setup.


### PR DESCRIPTION
## Summary
- load `.ts` command files in the Discord bot
- exercise command loader in interaction handler tests
- document available commands in the bot README
- note new command modules in the changelog

## Testing
- `npm test --prefix bot`
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685633757f488320be9d9ce03eb6d220