### PR TITLE
Document BOT_JWT variable

### DIFF
--- a/bot/README.md
+++ b/bot/README.md
@@ -12,7 +12,8 @@ using the token provided in `.env`.
    ```
    Fill in `DISCORD_BOT_TOKEN`, `DISCORD_CLIENT_ID`, `DISCORD_GUILD_IDS`,
    and `BOT_JWT`. The bot sends this token in an `Authorization` header
-   when calling the API.
+   when calling the API. See [docs/env.md](../docs/env.md) for details
+   about this variable.
 2. Install dependencies and build the bot:
    ```bash
    npm install

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be recorded in this file.
 - Consolidated bot entrypoint to `main.ts` and standardized `DISCORD_BOT_TOKEN`.
 - Bot API helpers accept a token parameter or `BOT_JWT` and send
   `Authorization` headers.
+- Documented `BOT_JWT` in `docs/env.md` and referenced it from `bot/README.md`.
 - Added Discord OAuth login with `/login/discord` and `/login/discord/callback`.
 - Auth service now passes `check_same_thread` only when `DATABASE_URL` starts
   with `sqlite`.
@@ -20,6 +21,8 @@ All notable changes to this project will be recorded in this file.
 - Auth service now filters Discord roles to the admin guild when resolving
   user flags. Updated docs to clarify guild-based role filtering.
 - Auth tokens now include `iat` and `exp` claims. Set `TOKEN_EXPIRE_SECONDS` to configure expiry.
+- Auth tokens now use integer timestamps for `iat` and `exp` to avoid race
+  conditions when checking expiry.
 - Bot API helpers now accept a `username` argument and bot commands send the
   caller's name in each request.
 - Clarified the purpose of `VERIFIED_GOVERNMENT_ROLE_ID`,

--- a/docs/env.md
+++ b/docs/env.md
@@ -33,6 +33,8 @@ the repository. Provide them through your build or deployment secret store:
 - `DISCORD_GUILD_IDS` &ndash; comma-separated guilds where the bot operates.
 - `DISCORD_REDIRECT_URI` &ndash; callback URL for Discord OAuth. Defaults to
   `http://localhost:8002/login/discord/callback`.
+- `BOT_JWT` &ndash; fallback token used by the bot when calling the API. Bot
+  API helpers send this JWT when no other token is provided.
 
 ## Discord role-based permissions
 

--- a/src/devonboarder/auth_service.py
+++ b/src/devonboarder/auth_service.py
@@ -88,8 +88,9 @@ def get_db() -> Session:
 
 
 def create_token(user: User) -> str:
-    now = time.time()
-    payload = {"sub": str(user.id), "iat": now, "exp": now + TOKEN_EXPIRE_SECONDS}
+    """Return a signed JWT for the given user."""
+    iat = int(time.time())
+    payload = {"sub": str(user.id), "iat": iat, "exp": iat + TOKEN_EXPIRE_SECONDS}
     return jwt.encode(payload, SECRET_KEY, algorithm=ALGORITHM)
 
 

--- a/tests/test_auth_service.py
+++ b/tests/test_auth_service.py
@@ -446,6 +446,6 @@ def test_expired_token_rejected(monkeypatch):
 
     client.post("/api/register", json={"username": "tim", "password": "pw"})
     token = _get_token(client, "tim", "pw")
-    time.sleep(1.1)
+    time.sleep(2.1)
     resp = client.get("/api/user", headers={"Authorization": f"Bearer {token}"})
     assert resp.status_code == 401


### PR DESCRIPTION
## Summary
- document BOT_JWT in docs/env.md
- cross-reference BOT_JWT in bot README
- log update in changelog
- use integer timestamps in JWTs and adjust expiration test

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68564d410a708320b8e6b5b1f128134c