### PR TITLE
Add DevSecOps automation scaffolding

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+# PR Review Checklist
+
+- [ ] All code passes automated lint, type, test, and security checks
+- [ ] OpenAPI/contract and migration checks pass
+- [ ] All FastAPI endpoints have docstrings and are documented
+- [ ] CORS and security headers validated
+- [ ] No secrets or sensitive data are present in commits
+- [ ] Did Codex introduce any direct commit to main?
+- [ ] Are all Codex changes covered by tests and docs?
+- [ ] Coverage does not decrease (see Codecov status)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,19 +24,39 @@ jobs:
               run: ./scripts/setup-env.sh
             - name: Install package
               run: pip install -e .
+            - name: Validate OpenAPI contract
+              run: |
+                pip install openapi-spec-validator
+                openapi-spec-validator --enable-format-check src/devonboarder/openapi.json
+            - name: Alembic migration lint
+              run: ./scripts/alembic_migration_check.sh
+            - name: Doc coverage check
+              run: python scripts/check_docstrings.py
             - name: Run linter
               run: ruff check .
             - name: Prepare environment file
               run: cp .env.example .env.dev
             - name: Start docker compose
               run: docker compose -f docker-compose.ci.yaml --env-file .env.dev up -d
-            - name: Run tests
-              run: pytest -q
+            - name: Run tests with coverage
+              run: pytest --cov=src --cov-fail-under=85
+            - name: Upload coverage to Codecov
+              uses: codecov/codecov-action@v3
             - name: Install bot dependencies
               run: npm ci
               working-directory: bot
             - name: Run bot tests
               run: npm test
               working-directory: bot
+            - name: Check CORS & security headers
+              run: |
+                pip install requests
+                python scripts/check_headers.py
             - name: Stop docker compose
               run: docker compose -f docker-compose.ci.yaml --env-file .env.dev down
+            - name: Label Codex PR
+              if: github.actor == 'codex[bot]'
+              uses: actions-ecosystem/action-add-labels@v1
+              with:
+                labels: |
+                  🚧 Codex

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,16 @@
 repos:
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.4
+  - repo: https://github.com/psf/black
+    rev: 24.3.0
+    hooks:
+      - id: black
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.4.1
     hooks:
       - id: ruff
-        args: ["."]
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v3.2.4
+    hooks:
+      - id: prettier
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,9 @@ All notable changes to this project will be recorded in this file.
 - Added Discord OAuth login with `/login/discord` and `/login/discord/callback`.
 - Auth service now passes `check_same_thread` only when `DATABASE_URL` starts
   with `sqlite`.
+- Added DevSecOps scaffolding with OpenAPI validation, migration linting,
+  header smoke tests, docstring coverage, pre-commit hooks, Dependabot,
+  and Codecov integration.
 - Introduced `utils/roles.py` and expanded `/api/user` to return role flags;
   documented `GOVERNMENT_ROLE_ID`, `MILITARY_ROLE_ID`, and `EDUCATION_ROLE_ID`.
 - Added tests for Discord role resolution and `/api/user` flags.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,5 @@ ruff
 pytest
 pyyaml
 pre-commit
+openapi-spec-validator
+requests

--- a/scripts/alembic_migration_check.sh
+++ b/scripts/alembic_migration_check.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+if grep -q "sqlite" <<< "$DATABASE_URL"; then
+  alembic upgrade --sql head
+else
+  echo "Non-SQLite DB; skipping SQLite-only migration check."
+fi

--- a/scripts/check_docstrings.py
+++ b/scripts/check_docstrings.py
@@ -1,0 +1,34 @@
+"""
+Checks that all FastAPI endpoints have docstrings.
+Usage: python scripts/check_docstrings.py
+"""
+import ast
+import os
+
+
+def has_docstring(node: ast.AST) -> bool:
+    return bool(ast.get_docstring(node))
+
+
+def main() -> None:
+    api_path = "src/devonboarder"  # Adjust if needed
+    errors: list[str] = []
+    for dirpath, _, filenames in os.walk(api_path):
+        for filename in filenames:
+            if filename.endswith(".py"):
+                with open(os.path.join(dirpath, filename), "r") as f:
+                    tree = ast.parse(f.read())
+                    for node in ast.walk(tree):
+                        if isinstance(node, ast.FunctionDef):
+                            if node.name.startswith("api_") and not has_docstring(node):
+                                errors.append(
+                                    f"{filename}:{node.lineno} missing docstring"
+                                )
+    if errors:
+        print("Missing docstrings:\n" + "\n".join(errors))
+        exit(1)
+    print("All endpoint docstrings present.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check_headers.py
+++ b/scripts/check_headers.py
@@ -1,0 +1,12 @@
+import requests
+
+
+def main():
+    resp = requests.get("http://localhost:4000/api/user")
+    assert "Access-Control-Allow-Origin" in resp.headers, "CORS header missing"
+    assert resp.headers.get("X-Content-Type-Options") == "nosniff"
+    print("CORS and security headers OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/devonboarder/openapi.json
+++ b/src/devonboarder/openapi.json
@@ -1,0 +1,5 @@
+{
+  "openapi": "3.0.0",
+  "info": {"title": "DevOnboarder API", "version": "1.0.0"},
+  "paths": {}
+}


### PR DESCRIPTION
## Summary
- set up pre-commit hooks with Black, Ruff, Prettier, and basic cleanup hooks
- integrate Dependabot for pip and npm updates
- enforce OpenAPI, Alembic, docstring, coverage and security header checks in CI
- add scripts for docstring validation, header testing and Alembic linting
- track minimal OpenAPI schema
- document the DevSecOps additions in the changelog

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68565790216c8320beedfa42a81bb3b6