### PR TITLE
Update header smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,8 @@ jobs:
               run: |
                 pip install requests
                 python scripts/check_headers.py
+              env:
+                CHECK_HEADERS_URL: http://localhost:8002/api/user
             - name: Stop docker compose
               run: docker compose -f docker-compose.ci.yaml --env-file .env.dev down
             - name: Label Codex PR

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to this project will be recorded in this file.
 - Added `pytest-cov` to development requirements.
 - Added CORS and security middleware to the auth and XP services and updated the
   header smoke test.
+- Header smoke test now queries `CHECK_HEADERS_URL` (defaults to
+  `http://localhost:8002/api/user`).
 - `init_db()` no longer drops existing tables. Tests now clean up the database
   themselves.
 - Consolidated bot entrypoint to `main.ts` and standardized `DISCORD_BOT_TOKEN`.

--- a/scripts/check_headers.py
+++ b/scripts/check_headers.py
@@ -1,11 +1,16 @@
-from fastapi.testclient import TestClient
-from devonboarder.auth_service import create_app
+"""Smoke test that verifies CORS and security headers are present."""
+
+import os
+
+import requests
+
+
+SERVICE_URL = os.getenv("CHECK_HEADERS_URL", "http://localhost:8002/api/user")
 
 
 def main() -> None:
     """Verify basic CORS and security headers."""
-    client = TestClient(create_app())
-    resp = client.get("/api/user")
+    resp = requests.get(SERVICE_URL, timeout=5)
     assert "Access-Control-Allow-Origin" in resp.headers, "CORS header missing"
     assert resp.headers.get("X-Content-Type-Options") == "nosniff"
     print("CORS and security headers OK")


### PR DESCRIPTION
## Summary
- check security headers using requests
- allow overriding the auth endpoint via `CHECK_HEADERS_URL`
- run the updated header check in CI
- document the new env var in CHANGELOG

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68566bfec11c8320aab12300029373bc