### PR TITLE
Add auth service to CI compose

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
             - name: Check CORS & security headers
               run: |
                 pip install requests
+                for i in {1..10}; do nc -z localhost 8002 && break || sleep 1; done
                 python scripts/check_headers.py
               env:
                 CHECK_HEADERS_URL: http://localhost:8002/api/user

--- a/docker-compose.ci.yaml
+++ b/docker-compose.ci.yaml
@@ -1,5 +1,8 @@
 version: "3.8"
 
+x-app-base: &app-base
+  build: .
+
 x-db-base: &db-base
   image: postgres:15
   environment:
@@ -14,6 +17,9 @@ x-env-dev: &env-dev
     - .env.dev
 
 services:
+  auth:
+    <<: [*app-base, *env-dev]
+    command: ["devonboarder-auth"]
   db:
     <<: [*db-base, *env-dev]
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be recorded in this file.
   header smoke test.
 - Header smoke test now queries `CHECK_HEADERS_URL` (defaults to
   `http://localhost:8002/api/user`).
+- CI compose now includes the auth service and the workflow waits for it to start.
 - `init_db()` no longer drops existing tables. Tests now clean up the database
   themselves.
 - Consolidated bot entrypoint to `main.ts` and standardized `DISCORD_BOT_TOKEN`.

--- a/tests/test_docker_compose.py
+++ b/tests/test_docker_compose.py
@@ -68,7 +68,7 @@ def test_db_volume_persisted():
 
 
 def test_ci_compose_minimal():
-    """CI compose file only defines the db service."""
+    """CI compose file defines only the auth and db services."""
     compose = load_compose("docker-compose.ci.yaml")
     services = compose.get("services", {})
-    assert set(services) == {"db"}
+    assert set(services) == {"auth", "db"}


### PR DESCRIPTION
## Summary
- launch auth service in CI
- wait for auth to be reachable before running header checks
- update the docker compose test
- document auth service in CI compose

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685674d2a3088320b73a5ecc08d2fc4c