### PR TITLE
Allow docstring check path override

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
             - name: Alembic migration lint
               run: ./scripts/alembic_migration_check.sh
             - name: Doc coverage check
-              run: python scripts/check_docstrings.py
+              run: python scripts/check_docstrings.py src/devonboarder
             - name: Run linter
               run: ruff check .
             - name: Prepare environment file

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,16 @@ jobs:
               run: cp .env.example .env.dev
             - name: Start docker compose
               run: docker compose -f docker-compose.ci.yaml --env-file .env.dev up -d
+            - name: Wait for auth service
+              run: |
+                for i in {1..30}; do
+                  if nc -z localhost 8002; then
+                    echo "Service is up!";
+                    break
+                  fi
+                  echo "Waiting for service...";
+                  sleep 2
+                done
             - name: Run tests with coverage
               run: pytest --cov=src --cov-fail-under=85
             - name: Upload coverage to Codecov

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be recorded in this file.
 
 ## [Unreleased]
+- `scripts/check_docstrings.py` now accepts an optional directory argument and
+  CI passes `src/devonboarder` explicitly.
 - Dropped unused `user_id` argument from `utils.discord.get_user_roles`.
 - Pinned Prettier pre-commit hook to `v3.1.0`.
 - Verified Prettier hook installation with `pre-commit autoupdate`.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable changes to this project will be recorded in this file.
   header smoke test.
 - Header smoke test now queries `CHECK_HEADERS_URL` (defaults to
   `http://localhost:8002/api/user`).
-- CI compose now includes the auth service and the workflow waits for it to start.
+- CI compose now includes the auth service and waits for it before tests and header checks.
 - `init_db()` no longer drops existing tables. Tests now clean up the database
   themselves.
 - Consolidated bot entrypoint to `main.ts` and standardized `DISCORD_BOT_TOKEN`.

--- a/scripts/check_docstrings.py
+++ b/scripts/check_docstrings.py
@@ -1,9 +1,13 @@
-"""
-Checks that all FastAPI endpoints have docstrings.
-Usage: python scripts/check_docstrings.py
+"""Checks that all FastAPI endpoints have docstrings.
+
+Usage: ``python scripts/check_docstrings.py [PATH]``
+
+Provide an optional ``PATH`` to scan a different directory. The default path is
+``src/devonboarder``.
 """
 import ast
 import os
+import sys
 
 
 def has_docstring(node: ast.AST) -> bool:
@@ -11,7 +15,7 @@ def has_docstring(node: ast.AST) -> bool:
 
 
 def main() -> None:
-    api_path = "src/devonboarder"  # Adjust if needed
+    api_path = sys.argv[1] if len(sys.argv) > 1 else "src/devonboarder"
     errors: list[str] = []
     for dirpath, _, filenames in os.walk(api_path):
         for filename in filenames:


### PR DESCRIPTION
## Summary
- parameterize `check_docstrings.py` with optional path argument
- pass default path explicitly in CI
- document the change in `CHANGELOG`

## Testing
- `pip install -e .`
- `pip install -r requirements-dev.txt`
- `pytest -q`
- `ruff check .`
- `python scripts/check_docstrings.py src/devonboarder`
- `python scripts/check_docstrings.py`


------
https://chatgpt.com/codex/tasks/task_e_685676d2c3a48320b7b568d6db03ca6f