### PR TITLE
Fail CI if auth service isn't reachable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,14 +48,18 @@ jobs:
             - name: Run bot tests
               run: npm test
               working-directory: bot
+            - name: Wait for auth service
+              run: |
+                for i in {1..30}; do
+                  nc -z localhost 8002 && exit 0
+                  echo "Waiting for service..."
+                  sleep 2
+                done
+                echo "Auth service failed to start"
+                exit 1
             - name: Check CORS & security headers
               run: |
                 pip install requests
-                for i in {1..10}; do nc -z localhost 8002 && break || sleep 1; done
-                nc -z localhost 8002 || {
-                  echo "Auth service failed to start"
-                  exit 1
-                }
                 python scripts/check_headers.py
               env:
                 CHECK_HEADERS_URL: http://localhost:8002/api/user

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,10 @@ jobs:
               run: |
                 pip install requests
                 for i in {1..10}; do nc -z localhost 8002 && break || sleep 1; done
+                nc -z localhost 8002 || {
+                  echo "Auth service failed to start"
+                  exit 1
+                }
                 python scripts/check_headers.py
               env:
                 CHECK_HEADERS_URL: http://localhost:8002/api/user

--- a/bot/Dockerfile
+++ b/bot/Dockerfile
@@ -1,8 +1,9 @@
 FROM node:18
 WORKDIR /usr/src/app
 COPY package.json package-lock.json* ./
-RUN npm install --production
+RUN npm install
 COPY tsconfig.json ./
 COPY src ./src
 RUN npm run build
+RUN npm prune --production
 CMD ["node", "dist/main.js"]

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to this project will be recorded in this file.
 - Header smoke test now queries `CHECK_HEADERS_URL` (defaults to
   `http://localhost:8002/api/user`).
 - CI compose now includes the auth service and the workflow waits for it to start.
-- Auth service wait step now fails if the port check doesn't succeed.
+- Auth service wait step now retries the port check up to 30 times and fails if the service isn't reachable.
 - `init_db()` no longer drops existing tables. Tests now clean up the database
   themselves.
 - Consolidated bot entrypoint to `main.ts` and standardized `DISCORD_BOT_TOKEN`.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be recorded in this file.
   `http://localhost:8002/api/user`).
 - CI compose now includes the auth service and the workflow waits for it to start.
 - Auth service wait step now retries the port check up to 30 times and fails if the service isn't reachable.
+- Bot Dockerfile installs dev dependencies for the TypeScript build and prunes them for runtime.
 - `init_db()` no longer drops existing tables. Tests now clean up the database
   themselves.
 - Consolidated bot entrypoint to `main.ts` and standardized `DISCORD_BOT_TOKEN`.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be recorded in this file.
 - Header smoke test now queries `CHECK_HEADERS_URL` (defaults to
   `http://localhost:8002/api/user`).
 - CI compose now includes the auth service and the workflow waits for it to start.
+- Auth service wait step now fails if the port check doesn't succeed.
 - `init_db()` no longer drops existing tables. Tests now clean up the database
   themselves.
 - Consolidated bot entrypoint to `main.ts` and standardized `DISCORD_BOT_TOKEN`.


### PR DESCRIPTION
# Summary
Add a port check after waiting for the auth service so CI fails when the service does not start.

# Linked Issues

# Screenshots

# Testing Steps
```bash
ruff check .
pytest -q
```

# Checklist
- [x] Updated `docs/CHANGELOG.md`
- [ ] Updated relevant documentation in `docs/`
- [x] Lint and tests pass

# Reviewer Sign-Off
- [ ] I, the reviewer, confirm the checklist above is complete.

------
https://chatgpt.com/codex/tasks/task_e_68567aabed18832098349287a2c61da4