### PR TITLE
Clean up auth service tests

### DIFF
--- a/tests/test_auth_service.py
+++ b/tests/test_auth_service.py
@@ -1,25 +1,21 @@
-"""Test suite for devonboarder.auth_service."""
-
 import importlib
-import time
-import sqlalchemy
-import httpx
 from fastapi.testclient import TestClient
 from devonboarder import auth_service
 from utils import roles as roles_utils
+import time
+import sqlalchemy
+import httpx
 
 
-def setup_function(_):
-    """Reset the database and monkeypatch user-related functions."""
+def setup_function(function):
     auth_service.Base.metadata.drop_all(bind=auth_service.engine)
     auth_service.init_db()
-    auth_service.get_user_roles = lambda _token: {}
+    auth_service.get_user_roles = lambda token: {}
     auth_service.resolve_user_flags = (
-        lambda _roles: {"isAdmin": False,
-                        "isVerified": False, "verificationType": None}
+        lambda roles: {"isAdmin": False, "isVerified": False, "verificationType": None}
     )
     auth_service.get_user_profile = (
-        lambda _token: {"id": "0", "username": "", "avatar": None}
+        lambda token: {"id": "0", "username": "", "avatar": None}
     )
 
 
@@ -47,45 +43,6 @@ def test_engine_initializes_for_sqlite(monkeypatch):
     orig_create = sqlalchemy.create_engine
     recorded: dict[str, dict] = {}
 
-    def fake_create_engine(_url, **kwargs):
-        recorded["kwargs"] = kwargs
-        return orig_create("sqlite:///:memory:", **kwargs)
-
-    monkeypatch.setattr(sqlalchemy, "create_engine", fake_create_engine)
-    monkeypatch.setenv("DATABASE_URL", "sqlite:///:memory:")
-    importlib.reload(auth_service)
-    assert recorded["kwargs"].get("connect_args") == {
-        "check_same_thread": False}
-    monkeypatch.setattr(sqlalchemy, "create_engine", orig_create)
-    monkeypatch.delenv("DATABASE_URL", raising=False)
-    importlib.reload(auth_service)
-    importlib.reload(auth_service)
-
-
-def test_engine_initializes_without_sqlite_args(monkeypatch):
-    """Engine omits connect_args for non-SQLite URLs."""
-    orig_create = sqlalchemy.create_engine
-    recorded: dict[str, dict] = {}
-
-    def fake_create_engine(_url, **kwargs):
-        recorded["kwargs"] = kwargs
-        return orig_create("sqlite:///:memory:", **kwargs)
-
-    monkeypatch.setattr(sqlalchemy, "create_engine", fake_create_engine)
-    monkeypatch.setenv("DATABASE_URL", "postgresql://db")
-    importlib.reload(auth_service)
-    assert "connect_args" not in recorded["kwargs"]
-    monkeypatch.setattr(sqlalchemy, "create_engine", orig_create)
-    monkeypatch.delenv("DATABASE_URL", raising=False)
-    importlib.reload(auth_service)
-    importlib.reload(auth_service)
-
-
-def test_engine_initializes_for_sqlite(monkeypatch):
-    """Engine passes check_same_thread when DATABASE_URL is SQLite."""
-    orig_create = sqlalchemy.create_engine
-    recorded: dict[str, dict] = {}
-
     def fake_create_engine(url, **kwargs):
         recorded["kwargs"] = kwargs
         return orig_create("sqlite:///:memory:", **kwargs)
@@ -93,8 +50,7 @@ def test_engine_initializes_for_sqlite(monkeypatch):
     monkeypatch.setattr(sqlalchemy, "create_engine", fake_create_engine)
     monkeypatch.setenv("DATABASE_URL", "sqlite:///:memory:")
     importlib.reload(auth_service)
-    assert recorded["kwargs"].get("connect_args") == {
-        "check_same_thread": False}
+    assert recorded["kwargs"].get("connect_args") == {"check_same_thread": False}
     monkeypatch.setattr(sqlalchemy, "create_engine", orig_create)
     monkeypatch.delenv("DATABASE_URL", raising=False)
     importlib.reload(auth_service)
@@ -119,7 +75,6 @@ def test_engine_initializes_without_sqlite_args(monkeypatch):
 
 
 def test_register_login_and_user_info(monkeypatch):
-    """Test user registration, login, and user info retrieval."""
     app = auth_service.create_app()
     client = TestClient(app)
 
@@ -132,8 +87,7 @@ def test_register_login_and_user_info(monkeypatch):
     monkeypatch.setattr(
         auth_service,
         "resolve_user_flags",
-        lambda _roles: {"isAdmin": True,
-                        "isVerified": False, "verificationType": None},
+        lambda roles: {"isAdmin": True, "isVerified": False, "verificationType": None},
     )
 
     def fake_profile(token: str):
@@ -144,8 +98,7 @@ def test_register_login_and_user_info(monkeypatch):
 
     resp = client.post(
         "/api/register",
-        json={"username": "alice", "password": "secret",
-              "discord_token": "oauth-reg"},
+        json={"username": "alice", "password": "secret", "discord_token": "oauth-reg"},
     )
     assert resp.status_code == 200
     token = resp.json()["token"]
@@ -169,7 +122,6 @@ def test_register_login_and_user_info(monkeypatch):
     # login works
     token2 = _get_token(client, "alice", "secret")
     assert token2
-    assert token2
 
 
 def test_oauth_token_updated_on_login(monkeypatch):
@@ -189,13 +141,11 @@ def test_oauth_token_updated_on_login(monkeypatch):
     monkeypatch.setattr(auth_service, "get_user_roles", lambda token: {})
 
     token = _get_token(client, "dan", "pw", discord_token="new")
-    resp = client.get(
-        "/api/user", headers={"Authorization": f"Bearer {token}"})
+    resp = client.get("/api/user", headers={"Authorization": f"Bearer {token}"})
     assert resp.status_code == 200
 
 
 def test_user_levels_and_promote():
-    """Test user levels and promotion to admin."""
     app = auth_service.create_app()
     client = TestClient(app)
 
@@ -206,13 +156,10 @@ def test_user_levels_and_promote():
     # make admin user an admin
     with auth_service.SessionLocal() as db:
         admin = db.query(auth_service.User).filter_by(username="admin").first()
-        if admin is not None:
-            admin.is_admin = True
+        admin.is_admin = True
         bob = db.query(auth_service.User).filter_by(username="bob").first()
-        if bob is not None:
-            db.add(auth_service.Contribution(
-                user_id=bob.id, description="initial"))
-            db.add(auth_service.XPEvent(user_id=bob.id, xp=150))
+        db.add(auth_service.Contribution(user_id=bob.id, description="initial"))
+        db.add(auth_service.XPEvent(user_id=bob.id, xp=150))
         db.commit()
 
     admin_token = _get_token(client, "admin", "adm")
@@ -246,18 +193,14 @@ def test_user_levels_and_promote():
 
     with auth_service.SessionLocal() as db:
         bob = db.query(auth_service.User).filter_by(username="bob").first()
-        assert bob is not None and bool(getattr(bob, "is_admin", False))
-        bob = db.query(auth_service.User).filter_by(username="bob").first()
         assert bob.is_admin
-
 
 def test_register_duplicate_username():
     app = auth_service.create_app()
     client = TestClient(app)
 
     client.post("/api/register", json={"username": "bob", "password": "pwd"})
-    resp = client.post(
-        "/api/register", json={"username": "bob", "password": "pwd"})
+    resp = client.post("/api/register", json={"username": "bob", "password": "pwd"})
     assert resp.status_code == 400
     assert resp.json()["detail"] == "Username exists"
 
@@ -266,259 +209,243 @@ def test_login_invalid_credentials():
     app = auth_service.create_app()
     client = TestClient(app)
 
-    client.post("/api/register",
-                json={"username": "alice", "password": "secret"})
-    resp = client.post(
-        "/api/login", json={"username": "alice", "password": "wrong"})
+    client.post("/api/register", json={"username": "alice", "password": "secret"})
+    resp = client.post("/api/login", json={"username": "alice", "password": "wrong"})
     assert resp.status_code == 400
     assert resp.json()["detail"] == "Invalid credentials"
 
+
+def test_xp_accumulation_and_level_calculation():
+    app = auth_service.create_app()
+    client = TestClient(app)
+
+    client.post("/api/register", json={"username": "eve", "password": "pw"})
     with auth_service.SessionLocal() as db:
         eve = db.query(auth_service.User).filter_by(username="eve").first()
-        if eve is not None:
-            db.add_all([
-                auth_service.XPEvent(user_id=eve.id, xp=120),
-                auth_service.XPEvent(user_id=eve.id, xp=80),
-                auth_service.XPEvent(user_id=eve.id, xp=60),
-            ])
-            db.commit()
+        db.add_all([
             auth_service.XPEvent(user_id=eve.id, xp=120),
             auth_service.XPEvent(user_id=eve.id, xp=80),
             auth_service.XPEvent(user_id=eve.id, xp=60),
         ])
         db.commit()
 
-            token= _get_token(client, "eve", "pw")
-            resp= client.get("/api/user/level",
-                          headers={"Authorization": f"Bearer {token}"})
-            assert resp.status_code == 200
-            assert resp.json() == {"level": 3}
+    token = _get_token(client, "eve", "pw")
+    resp = client.get("/api/user/level", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+    assert resp.json() == {"level": 3}
 
 
-            def test_contribution_endpoint_awards_xp():
-            app= auth_service.create_app()
-            client= TestClient(app)
+def test_contribution_endpoint_awards_xp():
+    app = auth_service.create_app()
+    client = TestClient(app)
 
-            client.post("/api/register",
-                        json={"username": "sam", "password": "pw"})
-            token= _get_token(client, "sam", "pw")
+    client.post("/api/register", json={"username": "sam", "password": "pw"})
+    token = _get_token(client, "sam", "pw")
 
-            headers= {"Authorization": f"Bearer {token}"}
-            client.post(
-                "/api/user/contributions",
-                json={"description": "docs"},
-                headers=headers,
-                )
-            client.post(
+    headers = {"Authorization": f"Bearer {token}"}
+    client.post(
+        "/api/user/contributions",
+        json={"description": "docs"},
+        headers=headers,
+    )
+    client.post(
         "/api/user/contributions",
         json={"description": "tests"},
         headers=headers,
-                )
+    )
 
-    resp= client.get("/api/user/level", headers=headers)
-            assert resp.json() == {"level": 2}
+    resp = client.get("/api/user/level", headers=headers)
+    assert resp.json() == {"level": 2}
 
 
-            def test_user_endpoint_returns_flags(monkeypatch):
-    app= auth_service.create_app()
-    client= TestClient(app)
+def test_user_endpoint_returns_flags(monkeypatch):
+    app = auth_service.create_app()
+    client = TestClient(app)
 
-            monkeypatch.setattr(
+    monkeypatch.setattr(
         auth_service,
         "get_user_roles",
         lambda token: {"10": ["mod"], "30": ["edu"]},
-                )
+    )
 
-            monkeypatch.setattr(
+    monkeypatch.setattr(
         auth_service,
         "resolve_user_flags",
         roles_utils.resolve_user_flags,
-                )
+    )
 
-            monkeypatch.setattr(
+    monkeypatch.setattr(
         auth_service,
         "get_user_profile",
         lambda token: {"id": "5", "username": "d", "avatar": None},
-                )
+    )
 
-            monkeypatch.setenv("ADMIN_SERVER_GUILD_ID", "10")
-            monkeypatch.setenv("OWNER_ROLE_ID", "owner")
-            monkeypatch.setenv("ADMINISTRATOR_ROLE_ID", "admin")
-            monkeypatch.setenv("MODERATOR_ROLE_ID", "mod")
-            monkeypatch.setenv("VERIFIED_USER_ROLE_ID", "verified")
-            monkeypatch.setenv("VERIFIED_MEMBER_ROLE_ID", "vmember")
-            monkeypatch.setenv("GOVERNMENT_ROLE_ID", "gov")
-            monkeypatch.setenv("MILITARY_ROLE_ID", "mil")
-            monkeypatch.setenv("EDUCATION_ROLE_ID", "edu")
+    monkeypatch.setenv("ADMIN_SERVER_GUILD_ID", "10")
+    monkeypatch.setenv("OWNER_ROLE_ID", "owner")
+    monkeypatch.setenv("ADMINISTRATOR_ROLE_ID", "admin")
+    monkeypatch.setenv("MODERATOR_ROLE_ID", "mod")
+    monkeypatch.setenv("VERIFIED_USER_ROLE_ID", "verified")
+    monkeypatch.setenv("VERIFIED_MEMBER_ROLE_ID", "vmember")
+    monkeypatch.setenv("GOVERNMENT_ROLE_ID", "gov")
+    monkeypatch.setenv("MILITARY_ROLE_ID", "mil")
+    monkeypatch.setenv("EDUCATION_ROLE_ID", "edu")
 
-            client.post("/api/register",
-                        json={"username": "carl", "password": "pwd"})
-    token= _get_token(client, "carl", "pwd")
+    client.post("/api/register", json={"username": "carl", "password": "pwd"})
+    token = _get_token(client, "carl", "pwd")
 
-    resp= client.get(
-        "/api/user", headers={"Authorization": f"Bearer {token}"})
-    data= resp.json()
-            assert data["isAdmin"] is True
-            assert data["isVerified"] is False
-            assert data["verificationType"] is None
+    resp = client.get("/api/user", headers={"Authorization": f"Bearer {token}"})
+    data = resp.json()
+    assert data["isAdmin"] is True
+    assert data["isVerified"] is False
+    assert data["verificationType"] is None
 
 
-            def test_other_guild_roles_do_not_grant_admin(monkeypatch):
-    app= auth_service.create_app()
-    client= TestClient(app)
+def test_other_guild_roles_do_not_grant_admin(monkeypatch):
+    app = auth_service.create_app()
+    client = TestClient(app)
 
-            monkeypatch.setattr(
+    monkeypatch.setattr(
         auth_service,
         "get_user_roles",
         lambda token: {"20": ["mod"]},
-                )
+    )
 
-            monkeypatch.setattr(
+    monkeypatch.setattr(
         auth_service,
         "resolve_user_flags",
         roles_utils.resolve_user_flags,
-                )
+    )
 
-            monkeypatch.setattr(
+    monkeypatch.setattr(
         auth_service,
         "get_user_profile",
         lambda token: {"id": "7", "username": "x", "avatar": None},
-                )
+    )
 
-            monkeypatch.setenv("ADMIN_SERVER_GUILD_ID", "10")
-            monkeypatch.setenv("OWNER_ROLE_ID", "owner")
-            monkeypatch.setenv("ADMINISTRATOR_ROLE_ID", "admin")
-            monkeypatch.setenv("MODERATOR_ROLE_ID", "mod")
-            monkeypatch.setenv("VERIFIED_USER_ROLE_ID", "verified")
-            monkeypatch.setenv("VERIFIED_MEMBER_ROLE_ID", "vmember")
-            monkeypatch.setenv("GOVERNMENT_ROLE_ID", "gov")
-            monkeypatch.setenv("MILITARY_ROLE_ID", "mil")
-            monkeypatch.setenv("EDUCATION_ROLE_ID", "edu")
+    monkeypatch.setenv("ADMIN_SERVER_GUILD_ID", "10")
+    monkeypatch.setenv("OWNER_ROLE_ID", "owner")
+    monkeypatch.setenv("ADMINISTRATOR_ROLE_ID", "admin")
+    monkeypatch.setenv("MODERATOR_ROLE_ID", "mod")
+    monkeypatch.setenv("VERIFIED_USER_ROLE_ID", "verified")
+    monkeypatch.setenv("VERIFIED_MEMBER_ROLE_ID", "vmember")
+    monkeypatch.setenv("GOVERNMENT_ROLE_ID", "gov")
+    monkeypatch.setenv("MILITARY_ROLE_ID", "mil")
+    monkeypatch.setenv("EDUCATION_ROLE_ID", "edu")
 
-            client.post("/api/register",
-                        json={"username": "alex", "password": "pw"})
-    token= _get_token(client, "alex", "pw")
+    client.post("/api/register", json={"username": "alex", "password": "pw"})
+    token = _get_token(client, "alex", "pw")
 
-    resp= client.get(
-        "/api/user", headers={"Authorization": f"Bearer {token}"})
-    data= resp.json()
-            assert data["isAdmin"] is False
-            assert data["isVerified"] is False
+    resp = client.get("/api/user", headers={"Authorization": f"Bearer {token}"})
+    data = resp.json()
+    assert data["isAdmin"] is False
+    assert data["isVerified"] is False
 
 
-            class StubResponse:
-            def __init__(self, status_code: int, json_data: object):
+class StubResponse:
+    def __init__(self, status_code: int, json_data: object):
         self.status_code = status_code
         self._json = json_data
-            # Provide dummy request/response objects to avoid type errors
-            dummy_request = httpx.Request("GET", "http://test")
-            dummy_response = httpx.Response(self.status_code, request=dummy_request)
-            raise httpx.HTTPStatusError(
-                "error", request=dummy_request, response=dummy_response)
-            def json(self):
+
+    def json(self):
         return self._json
 
-            def raise_for_status(self) -> None:
+    def raise_for_status(self) -> None:
         if self.status_code >= 400:
             raise httpx.HTTPStatusError("error", request=None, response=None)
 
 
-            def test_discord_oauth_callback_issues_jwt(monkeypatch):
+def test_discord_oauth_callback_issues_jwt(monkeypatch):
     app = auth_service.create_app()
     client = TestClient(app)
 
-            def fake_post(url: str, data: dict, headers: dict):
+    def fake_post(url: str, data: dict, headers: dict):
         assert url.endswith("/token")
         assert data["code"] == "abc"
         return StubResponse(200, {"access_token": "tok"})
 
-            monkeypatch.setattr(httpx, "post", fake_post)
-            monkeypatch.setattr(auth_service, "get_user_roles", lambda tok: {})
-            monkeypatch.setattr(
+    monkeypatch.setattr(httpx, "post", fake_post)
+    monkeypatch.setattr(auth_service, "get_user_roles", lambda tok: {})
+    monkeypatch.setattr(
         auth_service,
         "resolve_user_flags",
         lambda roles: {
-          "isAdmin": False,
-           "isVerified": False,
+            "isAdmin": False,
+            "isVerified": False,
             "verificationType": None,
         },
-        )
-        monkeypatch.setattr(
-            auth_service,
-            "get_user_profile",
-            lambda tok: {
-          "id": "99",
-           "username": "d",
+    )
+    monkeypatch.setattr(
+        auth_service,
+        "get_user_profile",
+        lambda tok: {
+            "id": "99",
+            "username": "d",
             "avatar": None,
         },
-        )
+    )
 
-            resp = client.get("/login/discord/callback?code=abc")
-            assert resp.status_code == 200
-            token = resp.json()["token"]
-            assert token
+    resp = client.get("/login/discord/callback?code=abc")
+    assert resp.status_code == 200
+    token = resp.json()["token"]
+    assert token
 
-            resp = client.get(
-            "/api/user", headers={"Authorization": f"Bearer {token}"})
-            assert resp.status_code == 200
+    resp = client.get("/api/user", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
 
 
-            def test_oauth_callback_updates_existing_user(monkeypatch):
+def test_oauth_callback_updates_existing_user(monkeypatch):
     app = auth_service.create_app()
-        client= TestClient(app)
+    client = TestClient(app)
 
-            def fake_post(url: str, data: dict, headers: dict):
-            return StubResponse(200, {"access_token": data["code"]})
+    def fake_post(url: str, data: dict, headers: dict):
+        return StubResponse(200, {"access_token": data["code"]})
 
-            monkeypatch.setattr(httpx, "post", fake_post)
-            monkeypatch.setattr(auth_service, "get_user_roles", lambda tok: {})
-            monkeypatch.setattr(
+    monkeypatch.setattr(httpx, "post", fake_post)
+    monkeypatch.setattr(auth_service, "get_user_roles", lambda tok: {})
+    monkeypatch.setattr(
         auth_service,
         "resolve_user_flags",
         lambda roles: {
-          "isAdmin": False,
-           "isVerified": False,
+            "isAdmin": False,
+            "isVerified": False,
             "verificationType": None,
         },
-        )
-            monkeypatch.setattr(
-            auth_service,
-            "get_user_profile",
-            lambda tok: {
-          "id": "5",
-           "username": "p",
-        assert user is not None and getattr(
-            user, "discord_token", None) == "second"
+    )
+    monkeypatch.setattr(
+        auth_service,
+        "get_user_profile",
+        lambda tok: {
+            "id": "5",
+            "username": "p",
+            "avatar": None,
         },
-        )
+    )
 
-            client.get("/login/discord/callback?code=first")
-            resp = client.get("/login/discord/callback?code=second")
-            assert resp.status_code == 200
-            with auth_service.SessionLocal() as db:
+    client.get("/login/discord/callback?code=first")
+    resp = client.get("/login/discord/callback?code=second")
+    assert resp.status_code == 200
+    with auth_service.SessionLocal() as db:
         user = db.query(auth_service.User).filter_by(username="5").first()
-            assert user.discord_token == "second"
+        assert user.discord_token == "second"
 
 
-            def test_expired_token_rejected(monkeypatch):
-            monkeypatch.setenv("TOKEN_EXPIRE_SECONDS", "1")
-            importlib.reload(auth_service)
-            auth_service.Base.metadata.drop_all(bind=auth_service.engine)
-            auth_service.init_db()
-            auth_service.get_user_roles = lambda token: {}
-            auth_service.resolve_user_flags = (
-            lambda roles: {"isAdmin": False,
-                     "isVerified": False, "verificationType": None}
-                      )
-                      auth_service.get_user_profile = (
-                           lambda token: {"id": "0", "username": "", "avatar": None}
-                           )
-                           app= auth_service.create_app()
-                          client = TestClient(app)
+def test_expired_token_rejected(monkeypatch):
+    monkeypatch.setenv("TOKEN_EXPIRE_SECONDS", "1")
+    importlib.reload(auth_service)
+    auth_service.Base.metadata.drop_all(bind=auth_service.engine)
+    auth_service.init_db()
+    auth_service.get_user_roles = lambda token: {}
+    auth_service.resolve_user_flags = (
+        lambda roles: {"isAdmin": False, "isVerified": False, "verificationType": None}
+    )
+    auth_service.get_user_profile = (
+        lambda token: {"id": "0", "username": "", "avatar": None}
+    )
+    app = auth_service.create_app()
+    client = TestClient(app)
 
-                          client.post("/api/register", json={"username": "tim", "password": "pw"})
-                          token = _get_token(client, "tim", "pw")
-                          time.sleep(2.1)
-                          resp = client.get(
-                           "/api/user", headers={"Authorization": f"Bearer {token}"})
-                          assert resp.status_code == 401
+    client.post("/api/register", json={"username": "tim", "password": "pw"})
+    token = _get_token(client, "tim", "pw")
+    time.sleep(2.1)
+    resp = client.get("/api/user", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 401


### PR DESCRIPTION
## Summary
- remove broken duplicated sections in `test_auth_service.py`
- restore correct tests for login, contributions and OAuth

## Testing
- `ruff check tests/test_auth_service.py`
- `pytest tests/test_auth_service.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68568a0b3d1483209e934738c4f8b5ff