### PR TITLE
docs: sync PR template

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,9 @@ All notable changes to this project will be recorded in this file.
 - Added `pytest-cov` to development requirements.
 - Added CORS and security middleware to the auth and XP services and updated the
   header smoke test.
+- Synced docs pull request template with `.github` to include OpenAPI and
+  migration checks, docstring enforcement, header validation, and coverage
+  requirements.
 - Header smoke test now queries `CHECK_HEADERS_URL` (defaults to
   `http://localhost:8002/api/user`).
 - CI compose now includes the auth service and the workflow waits for it to start.

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -21,9 +21,14 @@ pytest -q
 
 # Checklist
 
-- [ ] Updated `docs/CHANGELOG.md`
-- [ ] Updated relevant documentation in `docs/`
-- [ ] Lint and tests pass
+- [ ] All code passes automated lint, type, test, and security checks
+- [ ] OpenAPI/contract and migration checks pass
+- [ ] All FastAPI endpoints have docstrings and are documented
+- [ ] CORS and security headers validated
+- [ ] No secrets or sensitive data are present in commits
+- [ ] Did Codex introduce any direct commit to main?
+- [ ] Are all Codex changes covered by tests and docs?
+- [ ] Coverage does not decrease (see Codecov status)
 
 # Reviewer Sign-Off
 


### PR DESCRIPTION
## Summary
- keep the docs PR checklist consistent with `.github`
- document openapi, migrations, docstrings, header validation and coverage in the template
- note the updated template in the changelog

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'devonboarder')*

------
https://chatgpt.com/codex/tasks/task_e_68568c9b2cb88320a4d8eedbd91d2f0f