### PR TITLE
Enable OpenAPI format checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
             - name: Validate OpenAPI contract
               run: |
                 pip install openapi-spec-validator
-                openapi-spec-validator src/devonboarder/openapi.json
+                openapi-spec-validator --enable-format-check src/devonboarder/openapi.json
             - name: Alembic migration lint
               run: ./scripts/alembic_migration_check.sh
             - name: Doc coverage check

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to this project will be recorded in this file.
 - Auth service wait step now retries the port check up to 30 times and fails if the service isn't reachable.
 - Bot Dockerfile installs dev dependencies for the TypeScript build and prunes them for runtime.
 - CI compose now includes the auth service and waits for it before tests and header checks.
+- Enabled OpenAPI format validation in the CI workflow.
 - `init_db()` no longer drops existing tables. Tests now clean up the database
   themselves.
 - Introduced `utils/roles.py` and expanded `/api/user` to return role flags;


### PR DESCRIPTION
## Summary
- update OpenAPI validation command in CI
- document the new CI check in the changelog

## Testing
- `ruff check .`
- `pytest -q` *(fails: Client.__init__() got an unexpected keyword argument 'app')*
- `act --list` *(fails: daemon Docker Engine socket not found)*

------
https://chatgpt.com/codex/tasks/task_e_68568ed798ec8320930ef93fc3967c4a