### PR TITLE
Add contribute route to XP API

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be recorded in this file.
 - Recorded npm audit results showing zero vulnerabilities and noted
   pip-audit could not run in the sandbox environment.
 - Updated Codex dashboard and plan to mark auth, XP, and bot modules complete.
+- Added `/api/user/contribute` endpoint to the XP API requiring a JWT.
 
 - `scripts/check_docstrings.py` now accepts an optional directory argument and
   CI passes `src/devonboarder` explicitly.

--- a/docs/endpoint-reference.md
+++ b/docs/endpoint-reference.md
@@ -4,11 +4,13 @@ This document lists HTTP routes exposed by DevOnboarder services and how Discord
 
 ## XP API
 
-These endpoints provide onboarding and XP details without authentication. Pass a
-`username` query parameter to look up records for that user.
+These endpoints provide onboarding and XP details. Most routes accept a
+`username` query parameter and do not require authentication. The
+`/api/user/contribute` route requires a valid JWT.
 
 - `GET /api/user/onboarding-status?username=<name>` – current onboarding phase.
 - `GET /api/user/level?username=<name>` – calculated user level.
+- `POST /api/user/contribute` – record a contribution and award XP.
 
 ## Auth Service
 

--- a/src/devonboarder/openapi.json
+++ b/src/devonboarder/openapi.json
@@ -1,5 +1,74 @@
 {
   "openapi": "3.0.0",
   "info": {"title": "DevOnboarder API", "version": "1.0.0"},
-  "paths": {}
+  "paths": {
+    "/api/user/onboarding-status": {
+      "get": {
+        "summary": "User onboarding status",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "username",
+            "required": true,
+            "schema": {"type": "string"}
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Onboarding status",
+            "content": {"application/json": {"schema": {"type": "object"}}}
+          }
+        }
+      }
+    },
+    "/api/user/level": {
+      "get": {
+        "summary": "User level",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "username",
+            "required": true,
+            "schema": {"type": "string"}
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Level",
+            "content": {"application/json": {"schema": {"type": "object"}}}
+          }
+        }
+      }
+    },
+    "/api/user/contribute": {
+      "post": {
+        "summary": "Record a contribution and award XP",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {"description": {"type": "string"}},
+                "required": ["description"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Contribution recorded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {"recorded": {"type": "string"}}
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
 }

--- a/src/devonboarder/xp_api.py
+++ b/src/devonboarder/xp_api.py
@@ -35,6 +35,24 @@ def user_level(
     return {"level": level}
 
 
+@router.post("/api/user/contribute")
+def contribute(
+    data: dict,
+    current_user: auth_service.User = Depends(auth_service.get_current_user),
+    db: Session = Depends(auth_service.get_db),
+) -> dict[str, str]:
+    """Record a contribution and award XP."""
+    description = data["description"]
+    db.add(
+        auth_service.Contribution(user_id=current_user.id, description=description)
+    )
+    db.add(
+        auth_service.XPEvent(user_id=current_user.id, xp=auth_service.CONTRIBUTION_XP)
+    )
+    db.commit()
+    return {"recorded": description}
+
+
 def create_app() -> FastAPI:
     """Create a FastAPI application with the XP router."""
     app = FastAPI()

--- a/tests/test_xp_api.py
+++ b/tests/test_xp_api.py
@@ -6,6 +6,13 @@ from fastapi.testclient import TestClient
 def setup_function(function):
     auth_service.Base.metadata.drop_all(bind=auth_service.engine)
     auth_service.init_db()
+    auth_service.get_user_roles = lambda token: {}
+    auth_service.resolve_user_flags = (
+        lambda roles: {"isAdmin": False, "isVerified": False, "verificationType": None}
+    )
+    auth_service.get_user_profile = (
+        lambda token: {"id": "0", "username": "", "avatar": None}
+    )
 
 
 def _seed_data():
@@ -22,6 +29,15 @@ def _seed_data():
         db.commit()
 
 
+def _create_token(username: str) -> str:
+    with auth_service.SessionLocal() as db:
+        user = auth_service.User(username=username, password_hash="x")
+        db.add(user)
+        db.commit()
+        db.refresh(user)
+        return auth_service.create_token(user)
+
+
 def test_onboarding_status_and_level():
     _seed_data()
     app = create_app()
@@ -33,4 +49,29 @@ def test_onboarding_status_and_level():
 
     resp = client.get("/api/user/level", params={"username": "alice"})
     assert resp.status_code == 200
+    assert resp.json() == {"level": 2}
+
+
+def test_contribute_endpoint_awards_xp():
+    token = _create_token("bob")
+    app = create_app()
+    client = TestClient(app)
+    headers = {"Authorization": f"Bearer {token}"}
+
+    resp = client.post(
+        "/api/user/contribute",
+        json={"description": "docs"},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"recorded": "docs"}
+
+    resp = client.post(
+        "/api/user/contribute",
+        json={"description": "tests"},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+
+    resp = client.get("/api/user/level", params={"username": "bob"})
     assert resp.json() == {"level": 2}


### PR DESCRIPTION
## Summary
- allow recording contributions via `/api/user/contribute`
- test contribution flow in xp_api tests
- document the new endpoint
- note change in changelog

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856a60612d88320bd54165872876dba