### PR TITLE
Add React frontend session component

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -81,6 +81,7 @@ All notable changes to this project will be recorded in this file.
 - Added Postgres `db` service in the compose files and initial Alembic
   migrations for `users`, `contributions`, and `xp_events` tables.
 - Added placeholder `frontend/README.md` to reserve the upcoming UI directory.
+- Added React/Vite frontend with OAuth session component.
 - Corrected `ADMINISTRATOR_ROLE_ID` variable name in docs, code and tests.
 - Added authentication service with SQLAlchemy models and JWT-protected routes.
 - Documented running `devonboarder-auth` in the onboarding guide.

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,7 @@ Welcome to **DevOnboarder**. This page explains how to get your environment runn
 2. Install the project in editable mode with `pip install -e .`.
 3. Start services with `docker compose -f docker-compose.dev.yaml --env-file .env.dev up -d`.
    This launches the auth, bot, XP API, frontend, and Postgres services.
-   The `frontend/` folder currently contains only a placeholder README.
+   The `frontend/` folder now hosts a React app built with Vite.
 4. Run `alembic upgrade head` to apply the initial database migration.
 5. Alternatively, run `devonboarder-server` to start the app without Docker. Stop it with Ctrl+C.
 6. Visit `http://localhost:8000` to see the greeting server.

--- a/docs/env.md
+++ b/docs/env.md
@@ -79,3 +79,8 @@ screen. After granting permissions, Discord redirects back to
 `DISCORD_REDIRECT_URI`. The auth service exchanges the provided code for an
 access token, creates or looks up the user, then returns a JWT from
 `/login/discord/callback`.
+
+## Frontend
+
+- `VITE_API_URL` &ndash; base URL for the XP API.
+- `VITE_AUTH_URL` &ndash; base URL for the auth service.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,3 +1,6 @@
 # Frontend
 
-This directory holds placeholder files for the upcoming frontend.
+This directory contains a small React app built with Vite.
+
+Run `npm install` followed by `npm run dev` to start the development server.
+Environment variables are defined in `.env.example`.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>DevOnboarder</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "devonboarder-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "start": "vite"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.37",
+    "@types/react-dom": "^18.2.15",
+    "@vitejs/plugin-react": "^4.1.0",
+    "typescript": "^5.4.3",
+    "vite": "^5.2.0"
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,10 @@
+import SessionStatus from './components/SessionStatus';
+
+export default function App() {
+  return (
+    <div>
+      <h1>DevOnboarder</h1>
+      <SessionStatus />
+    </div>
+  );
+}

--- a/frontend/src/components/SessionStatus.tsx
+++ b/frontend/src/components/SessionStatus.tsx
@@ -1,0 +1,79 @@
+import { useEffect, useState } from 'react';
+
+interface UserInfo {
+  id: string | null;
+  username: string | null;
+  avatar: string | null;
+}
+
+export default function SessionStatus() {
+  const [token, setToken] = useState<string | null>(null);
+  const [user, setUser] = useState<UserInfo | null>(null);
+  const [level, setLevel] = useState<number | null>(null);
+  const [status, setStatus] = useState<string | null>(null);
+  const authUrl = import.meta.env.VITE_AUTH_URL;
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const code = params.get('code');
+    const stored = localStorage.getItem('jwt');
+
+    if (!stored && code) {
+      fetch(`${authUrl}/login/discord/callback?code=${code}`)
+        .then((r) => r.json())
+        .then((data) => {
+          localStorage.setItem('jwt', data.token);
+          setToken(data.token);
+          window.history.replaceState({}, '', '/');
+        })
+        .catch(console.error);
+    } else if (stored) {
+      setToken(stored);
+    }
+  }, [authUrl]);
+
+  useEffect(() => {
+    if (!token) return;
+    const headers = { Authorization: `Bearer ${token}` };
+
+    fetch(`${authUrl}/api/user`, { headers })
+      .then((r) => r.json())
+      .then(setUser)
+      .catch(console.error);
+
+    fetch(`${authUrl}/api/user/level`, { headers })
+      .then((r) => r.json())
+      .then((d) => setLevel(d.level))
+      .catch(console.error);
+
+    fetch(`${authUrl}/api/user/onboarding-status`, { headers })
+      .then((r) => r.json())
+      .then((d) => setStatus(d.status))
+      .catch(console.error);
+  }, [token, authUrl]);
+
+  if (!token) {
+    return <a href={`${authUrl}/login/discord`}>Log in with Discord</a>;
+  }
+
+  return (
+    <div>
+      {user && (
+        <p>
+          Logged in as {user.username}
+          {user.avatar && user.id && (
+            <img
+              src={`https://cdn.discordapp.com/avatars/${user.id}/${user.avatar}.png`}
+              alt="avatar"
+              width={40}
+              height={40}
+            />
+          )}
+        </p>
+      )}
+      <p>Level: {level ?? '...'}</p>
+      <p>Onboarding: {status ?? '...'}</p>
+      {status === 'intro' && <button>Start Onboarding</button>}
+    </div>
+  );
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
# Summary
- init minimal Vite React app under `frontend/`
- implement `SessionStatus` component for OAuth callbacks and level display
- document new Vite environment variables
- note React frontend in docs and changelog

# Linked Issues
- frontend-001

# Screenshots
<!-- Optional: add before/after screenshots -->

# Testing Steps
```bash
ruff check .
pytest -q
(cd bot && npm test)
```


------
https://chatgpt.com/codex/tasks/task_e_6856aaa2ec08832084693f897ac195a0