### PR TITLE
Fix OpenAPI validator invocation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
             - name: Validate OpenAPI contract
               run: |
                 pip install openapi-spec-validator
-                openapi-spec-validator --enable-format-check src/devonboarder/openapi.json
+                openapi-spec-validator src/devonboarder/openapi.json
             - name: Alembic migration lint
               run: ./scripts/alembic_migration_check.sh
             - name: Doc coverage check

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -38,6 +38,8 @@ All notable changes to this project will be recorded in this file.
 - Bot Dockerfile installs dev dependencies for the TypeScript build and prunes them for runtime.
 - CI compose now includes the auth service and waits for it before tests and header checks.
 - Enabled OpenAPI format validation in the CI workflow.
+- Updated CI to run `openapi-spec-validator` without the
+  `--enable-format-check` flag.
 - `init_db()` no longer drops existing tables. Tests now clean up the database
   themselves.
 - Introduced `utils/roles.py` and expanded `/api/user` to return role flags;


### PR DESCRIPTION
## Summary
- adjust OpenAPI validation command in CI
- document the CI change in the changelog

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68570272af948320848b8072e6b7d364