### PR TITLE
Add CI monitor config

### DIFF
--- a/codex.ci.yml
+++ b/codex.ci.yml
@@ -1,0 +1,19 @@
+codex-tasks:
+  - monitor-ci:
+      workflows: all
+      on_failure:
+        - analyze-error:
+            summarize: true
+            classify: [lint, test, dependency, infra, config]
+        - propose-fix:
+            generate-patch: true
+            include-commit-message: true
+        - apply-fix:
+            if: safe
+            then: commit
+            else: open-pr
+        - retry-build: true
+        - if: build-fails-again
+          then:
+            notify: maintainer
+            include: [error-summary, fix-attempts, logs]

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -175,3 +175,4 @@ All notable changes to this project will be recorded in this file.
 - Documented branch naming, commit messages, and rebase policy in the Git guidelines. [#24](https://github.com/theangrygamershowproductions/DevOnboarder/pull/24)
 - Expanded `docs/pull_request_template.md` with sections for summary, linked issues, screenshots, testing steps, and a checklist referencing documentation and changelog updates. [#25](https://github.com/theangrygamershowproductions/DevOnboarder/pull/25)
 - Documented the requirement to pass lint and tests, update documentation and the changelog, and added a reviewer sign-off section to the pull request template. [#26](https://github.com/theangrygamershowproductions/DevOnboarder/pull/26)
+- Added `codex.ci.yml` to automate CI monitoring and fix failing builds.


### PR DESCRIPTION
## Summary
- add new `codex.ci.yml` automation file to monitor CI workflows
- document new CI automation in the changelog

## Testing Steps
```bash
ruff check .
pytest -q
```


------
https://chatgpt.com/codex/tasks/task_e_68571ac2c2ac83208175809d6a89451f