### PR TITLE
Update README about frontend app

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ Alternatively, you can run the Docker Compose setup directly.
 This starts the auth, bot, XP API, frontend, and database services using
 environment variables from `.env.dev`.
 Copy each `*.env.example` to `.env` inside its service directory before starting.
-The `frontend/` directory currently contains only a placeholder README:
+The `frontend/` directory hosts a Vite-based React app. Run `npm install` and
+`npm run dev` in that folder to start the development server:
 
 ```bash
 docker compose -f docker-compose.dev.yaml --env-file .env.dev up

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be recorded in this file.
   pip-audit could not run in the sandbox environment.
 - Updated Codex dashboard and plan to mark auth, XP, and bot modules complete.
 - Added `/api/user/contribute` endpoint to the XP API requiring a JWT.
+- Updated README to describe the Vite-based React frontend.
 
 - `scripts/check_docstrings.py` now accepts an optional directory argument and
   CI passes `src/devonboarder` explicitly.


### PR DESCRIPTION
## Summary
- note that the frontend directory contains an actual Vite app
- record the README update in the changelog

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685835f4716c83209125751954fc7ac1