### PR TITLE
docs: replace marketing preview links

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be recorded in this file.
 - Updated Codex dashboard and plan to mark auth, XP, and bot modules complete.
 - Added `/api/user/contribute` endpoint to the XP API requiring a JWT.
 - Updated README to describe the Vite-based React frontend.
+- Replaced marketing preview links with `frontend/index.html`.
 
 - `scripts/check_docstrings.py` now accepts an optional directory argument and
   CI passes `src/devonboarder` explicitly.

--- a/docs/README.md
+++ b/docs/README.md
@@ -53,7 +53,7 @@ platforms. Please report any issues you encounter on your operating system.
 - [Endpoint reference](endpoint-reference.md) &ndash; list of API routes and Discord command mappings.
 - [Alpha testers log](../ALPHA_TESTERS.md) &ndash; track invitations and feedback status.
 - [Founders log](../FOUNDERS.md) &ndash; record core contributors and how they help.
-- [Marketing site preview](../frontend/marketing-preview.html) &ndash; early look at the public landing page.
+- [Marketing site home](../frontend/index.html) &ndash; early look at the public landing page.
 
 ## Onboarding Phases
 

--- a/docs/alpha/README.md
+++ b/docs/alpha/README.md
@@ -34,7 +34,7 @@ Refer to [emails/style-guide.md](../../emails/style-guide.md) for our email tone
 
 ## Marketing Site Preview
 Get a first look at the upcoming website in
-[frontend/marketing-preview.html](../../frontend/marketing-preview.html).
+[frontend/index.html](../../frontend/index.html).
 Share this link with prospective testers who want a quick overview.
 
 ## Setup Validation


### PR DESCRIPTION
## Summary
- link to `frontend/index.html` from onboarding docs
- note link update in changelog

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6858b2267ee08320958cc404a5be3bd5