### PR TITLE
Fix npm audit reference

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be recorded in this file.
   macOS, and Linux.
 - Recorded npm audit results showing zero vulnerabilities and noted
   pip-audit could not run in the sandbox environment.
+- Removed outdated reference to `bot/npm-audit.json` in the security audit doc.
 - Updated Codex dashboard and plan to mark auth, XP, and bot modules complete.
 - Added `/api/user/contribute` endpoint to the XP API requiring a JWT.
 - Updated README to describe the Vite-based React frontend.

--- a/docs/security-audit-2025-06-21.md
+++ b/docs/security-audit-2025-06-21.md
@@ -8,4 +8,3 @@ No issues were identified in the partial results.
 
 ## Node (`npm audit`)
 `npm audit` reported zero vulnerabilities across all dependencies.
-See `bot/npm-audit.json` for the full output.


### PR DESCRIPTION
## Summary
- fix broken path to `bot/npm-audit.json` by removing reference
- mention update in the changelog

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858c6e3c7e08320932c148881d25598