### PR TITLE
Improve LanguageTool check and docs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,10 +1,10 @@
 # PR Review Checklist
 
 - [ ] All code passes automated lint, type, test, and security checks
-- [ ] OpenAPI/contract and migration checks pass
-- [ ] All FastAPI endpoints have docstrings and are documented
+- [ ] OpenAPI, contract, and migration checks pass
+- [ ] All FastAPI endpoints include docstrings and documentation
 - [ ] CORS and security headers validated
 - [ ] No secrets or sensitive data are present in commits
-- [ ] Did Codex introduce any direct commit to main?
+- [ ] Did Codex introduce any direct commits to `main`?
 - [ ] Are all Codex changes covered by tests and docs?
 - [ ] Coverage does not decrease (see Codecov status)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
               run: python scripts/check_docstrings.py src/devonboarder
             - name: Run linter
               run: ruff check .
+            - name: Documentation style check
+              run: ./scripts/check_docs.sh
             - name: Prepare environment file
               run: cp .env.example .env.dev
             - name: Start docker compose

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,3 +16,10 @@ repos:
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
+  - repo: local
+    hooks:
+      - id: docs-quality
+        name: Docs quality checks
+        entry: bash scripts/check_docs.sh
+        language: system
+        files: \.md$

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,5 @@
+StylesPath = styles
+MinAlertLevel = warning
+
+[*.md]
+BasedOnStyles = DevOnboarder

--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ Workflow documentation lives under the [docs/](docs/) directory. New contributor
 7. See [docs/founders/README.md](docs/founders/README.md) for Founder's Circle guidelines.
 8. Follow our [emails/style-guide.md](emails/style-guide.md) when crafting invitations.
 9. Check [docs/sample-pr.md](docs/sample-pr.md) for a small example update.
+10. Run `./scripts/check_docs.sh` to lint documentation with Vale and
+    LanguageTool. Set `LANGUAGETOOL_URL` if you use a local LanguageTool
+    server.
 
 These files expand on the steps listed in the Quickstart section.
 
@@ -112,6 +115,7 @@ docker compose -f docker-compose.prod.yaml --env-file .env.prod up -d
    `cp xp/.env.example xp/.env`
    `cp frontend/.env.example frontend/.env`
 3. Install the project with `pip install -e .`.
+   Install development tools with `pip install -r requirements-dev.txt`.
 4. Start the services with `docker compose -f docker-compose.dev.yaml --env-file .env.dev up -d`.
    The services launch using the commands defined in the compose file.
 5. Run `alembic upgrade head` to create the initial tables.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be recorded in this file.
 ## [Unreleased]
 
 - Generated `frontend/package-lock.json` to pin npm dependencies.
+- Added Vale and LanguageTool documentation linting in CI.
+- Improved LanguageTool script with line/column output and graceful
+  connection error handling.
 - Documented committing the lockfile in the README and frontend README.
 - Added `docs/Agents.md` with a consolidated overview of service agents and healthchecks.
 - Documented database agent and synced environment variables with `.env.example`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ Welcome to **DevOnboarder**. This page explains how to get your environment runn
    Update `DATABASE_URL` in `.env.dev` if you are not using the default
    Postgres credentials.
 2. Install the project in editable mode with `pip install -e .`.
+   Install the dev requirements with `pip install -r requirements-dev.txt`.
 3. Start services with `docker compose -f docker-compose.dev.yaml --env-file .env.dev up -d`.
    This launches the auth, bot, XP API, frontend, and Postgres services.
    The `frontend/` folder now hosts a React app built with Vite.
@@ -25,6 +26,17 @@ Welcome to **DevOnboarder**. This page explains how to get your environment runn
 10. Stop services with `docker compose -f docker-compose.dev.yaml --env-file .env.dev down`.
 11. Verify changes with `ruff check .`, `pytest -q`, and `npm test` from the `bot/` directory before committing.
 12. Install git hooks with `pre-commit install` so these checks run automatically.
+13. Lint all Markdown docs with `./scripts/check_docs.sh` before pushing.
+    This script uses **Vale** for style and **LanguageTool** for grammar.
+    LanguageTool requires network access to `api.languagetool.org` unless you
+    provide a custom server URL in the `LANGUAGETOOL_URL` environment variable.
+    If your environment blocks outbound requests, run your own instance with:
+
+    ```bash
+    docker run -d --name languagetool -p 8010:8010 silviof/docker-languagetool
+    ```
+    
+    Then set `LANGUAGETOOL_URL=http://localhost:8010/v2`.
 
 The compose files define common service settings using YAML anchors. Each
 environment file overrides differences like `env_file` or exposed ports below the

--- a/docs/git-guidelines.md
+++ b/docs/git-guidelines.md
@@ -57,9 +57,13 @@ Before opening a pull request, make sure to:
 - Run the linter and tests to confirm they pass:
 
 ```bash
-ruff check .
-pytest -q
+-  ruff check .
+-  pytest -q
 ```
+- Run documentation checks with `./scripts/check_docs.sh`.
+  These use **Vale** and **LanguageTool** and require network access to
+  `api.languagetool.org` or a locally hosted server specified via
+  `LANGUAGETOOL_URL`.
 - Keep Prettier pinned to `v3.1.0`. Run
   `pre-commit autoupdate --repo https://github.com/pre-commit/mirrors-prettier`
   to confirm the hook installs correctly.

--- a/docs/merge-checklist.md
+++ b/docs/merge-checklist.md
@@ -5,4 +5,5 @@ Reviewers must verify the following before merging a pull request:
 - [ ] All tests and lint checks pass.
 - [ ] `docs/CHANGELOG.md` includes an entry for the change.
 - [ ] Documentation in `docs/` is updated as needed.
+- [ ] Documentation passes `bash scripts/check_docs.sh`.
 - [ ] The pull request contains a completed reviewer sign-off section.

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -17,6 +17,7 @@
 ```bash
 ruff check .
 pytest -q
+bash scripts/check_docs.sh
 ```
 
 # Checklist
@@ -29,6 +30,7 @@ pytest -q
 - [ ] CORS and security headers validated
 - [ ] No secrets or sensitive data are present in commits
 - [ ] Codex did **not** introduce any direct commits to `main`
+- [ ] Documentation passes `bash scripts/check_docs.sh`
 - [ ] Are all Codex changes covered by tests and docs?
 - [ ] Coverage does not decrease (see Codecov status)
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,5 @@ pre-commit
 openapi-spec-validator
 requests
 pytest-cov
+vale
+language-tool-python

--- a/scripts/check_docs.sh
+++ b/scripts/check_docs.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -e
+
+FILES=$(git ls-files '*.md')
+
+vale $FILES
+python scripts/languagetool_check.py $FILES

--- a/scripts/languagetool_check.py
+++ b/scripts/languagetool_check.py
@@ -1,0 +1,46 @@
+import os
+import sys
+import language_tool_python
+try:
+    from requests.exceptions import RequestException
+except Exception:
+    RequestException = Exception
+
+files = sys.argv[1:]
+if not files:
+    print('No files provided')
+    sys.exit(0)
+
+server = os.environ.get("LANGUAGETOOL_URL", "https://api.languagetool.org/v2")
+try:
+    tool = language_tool_python.LanguageTool("en-US", remote_server=server)
+except RequestException as e:
+    print(f"Could not reach the LanguageTool server: {e}")
+    sys.exit(1)
+except Exception as e:
+    print(f"Failed to initialize LanguageTool: {e}")
+    sys.exit(1)
+
+errors = 0
+for path in files:
+    with open(path, 'r', encoding='utf-8') as f:
+        text = f.read()
+    try:
+        matches = tool.check(text)
+    except RequestException as e:
+        print(f"{path}: LanguageTool connection error: {e}")
+        sys.exit(1)
+    except Exception as e:
+        print(f"{path}: LanguageTool error {e}")
+        sys.exit(1)
+    if matches:
+        print(f"{path}: {len(matches)} issues found")
+        for m in matches:
+            line, col = m.get_line_and_column(text)
+            print(f"- Line {line}, column {col}: {m.message}")
+        errors += len(matches)
+
+if errors:
+    print(f'{errors} issues found.')
+    sys.exit(1)
+print('No LanguageTool issues found.')

--- a/styles/DevOnboarder/DevOnboarder.yml
+++ b/styles/DevOnboarder/DevOnboarder.yml
@@ -1,0 +1,6 @@
+extends: substitution
+message: "Use 'DevOnboarder' for the project name."
+level: warning
+ignorecase: true
+swap:
+  devonboarder: DevOnboarder


### PR DESCRIPTION
## Summary
- show line and column numbers for LanguageTool matches
- allow a custom server via LANGUAGETOOL_URL and handle connection errors
- document Vale and LanguageTool requirements and troubleshooting
- update merge and PR templates with docs lint step
- note LanguageTool script improvements in the changelog

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError for project dependencies)*
- `bash scripts/check_docs.sh` *(reports LanguageTool warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6858e196c5d48320a56b7c56479906cc