### PR TITLE
Update agent docs with service map

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -184,6 +184,8 @@ All notable changes to this project will be recorded in this file.
   flagged missing React packages in the frontend and outdated `node-fetch` in
   the bot. `pip-audit` reported no issues while `npm audit` found moderate
   vulnerabilities in `esbuild` for the frontend with none in the bot.
+- Expanded `docs/Agents.md` with a service map, healthcheck code samples and a
+  remediation checklist.
 
 ## [0.1.0] - 2025-06-14
 


### PR DESCRIPTION
## Summary
- expand Agents overview with a service map table
- add healthcheck implementation guide and CI example
- track remediation steps and Codex monitoring
- document updates in the changelog

## Testing
- `ruff check .`
- `pytest -q`
- `npm test` in `bot/`
- `bash scripts/check_docs.sh` *(failed: 414 Request-URI Too Large)*

------
https://chatgpt.com/codex/tasks/task_e_6858f08c070483209ad45aaf90e9e4ed