### PR TITLE
Improve docs lint instructions and scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ Workflow documentation lives under the [docs/](docs/) directory. New contributor
 10. Run `./scripts/check_docs.sh` to lint documentation with Vale and
     LanguageTool. Set `LANGUAGETOOL_URL` if you use a local LanguageTool
     server.
+11. Install Vale with `brew install vale` (or see the [Vale installation docs](https://vale.sh/docs/installation/))
+    and install Python dependencies from `requirements-dev.txt` so the
+    documentation checks work locally.
 
 These files expand on the steps listed in the Quickstart section.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -38,6 +38,8 @@ All notable changes to this project will be recorded in this file.
 - `scripts/check_docstrings.py` now accepts an optional directory argument and
   CI passes `src/devonboarder` explicitly.
 - Added `docs/sample-pr.md` with an example pull request.
+- Documented Vale installation steps and improved `scripts/check_docs.sh` to
+  verify the command is available before running.
 
 - Dropped unused `user_id` argument from `utils.discord.get_user_roles`.
 - Docstring check now detects FastAPI route decorators instead of relying on function name prefixes.

--- a/docs/README.md
+++ b/docs/README.md
@@ -94,6 +94,15 @@ who has contributed and when.
 - `.python-version` &ndash; indicates the Python version for pyenv.
 - `.nvmrc` &ndash; defines the Node.js version for nvm.
 
+## Documentation Quality Checks
+
+All Markdown files must pass Vale and LanguageTool checks.
+
+- Run `bash scripts/check_docs.sh` before pushing any changes.
+- Install Vale with `brew install vale` or see the [Vale installation docs](https://vale.sh/docs/installation/).
+- Install Python dev dependencies with `pip install -r requirements-dev.txt`.
+- Set `LANGUAGETOOL_URL` if you use a self-hosted LanguageTool server. See the [LanguageTool HTTP server guide](https://dev.languagetool.org/http-server).
+
 ## Issues and Pull Requests
 
 1. Search existing issues to avoid duplicates and provide clear reproduction steps.

--- a/scripts/check_docs.sh
+++ b/scripts/check_docs.sh
@@ -3,5 +3,10 @@ set -e
 
 FILES=$(git ls-files '*.md')
 
+if ! command -v vale >/dev/null 2>&1; then
+  echo "Vale not installed. Install it with 'brew install vale' or see docs/README.md."
+  exit 1
+fi
+
 vale $FILES
 python scripts/languagetool_check.py $FILES

--- a/scripts/languagetool_check.py
+++ b/scripts/languagetool_check.py
@@ -1,46 +1,46 @@
 import os
 import sys
+
 import language_tool_python
-try:
-    from requests.exceptions import RequestException
-except Exception:
-    RequestException = Exception
 
-files = sys.argv[1:]
-if not files:
-    print('No files provided')
-    sys.exit(0)
 
-server = os.environ.get("LANGUAGETOOL_URL", "https://api.languagetool.org/v2")
-try:
-    tool = language_tool_python.LanguageTool("en-US", remote_server=server)
-except RequestException as e:
-    print(f"Could not reach the LanguageTool server: {e}")
-    sys.exit(1)
-except Exception as e:
-    print(f"Failed to initialize LanguageTool: {e}")
-    sys.exit(1)
-
-errors = 0
-for path in files:
-    with open(path, 'r', encoding='utf-8') as f:
+def check_file(path: str, tool: language_tool_python.LanguageTool) -> int:
+    """Check a single file and return the number of issues."""
+    with open(path, encoding="utf-8") as f:
         text = f.read()
     try:
         matches = tool.check(text)
-    except RequestException as e:
-        print(f"{path}: LanguageTool connection error: {e}")
-        sys.exit(1)
-    except Exception as e:
+    except Exception as e:  # network or parsing errors
         print(f"{path}: LanguageTool error {e}")
-        sys.exit(1)
+        return 1
     if matches:
         print(f"{path}: {len(matches)} issues found")
         for m in matches:
             line, col = m.get_line_and_column(text)
             print(f"- Line {line}, column {col}: {m.message}")
-        errors += len(matches)
+        return len(matches)
+    return 0
 
-if errors:
-    print(f'{errors} issues found.')
-    sys.exit(1)
-print('No LanguageTool issues found.')
+
+def main(files: list[str]) -> None:
+    url = os.environ.get("LANGUAGETOOL_URL", "https://api.languagetool.org/v2")
+    try:
+        tool = language_tool_python.LanguageTool("en-US", remote_server=url)
+    except Exception as e:  # initialization errors
+        print(f"Failed to initialize LanguageTool: {e}")
+        sys.exit(2)
+
+    errors = 0
+    for path in files:
+        errors += check_file(path, tool)
+    if errors:
+        print(f"{errors} issues found.")
+    else:
+        print("No LanguageTool issues found.")
+    sys.exit(errors)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) <= 1:
+        sys.exit(0)
+    main(sys.argv[1:])


### PR DESCRIPTION
## Summary
- explain how to install Vale in the onboarding docs
- add Documentation Quality Checks section to docs/README
- update changelog for docs-quality script change
- check for Vale before running docs script
- refactor LanguageTool checker script

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError)*
- `bash scripts/check_docs.sh` *(fails: Vale not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68598dd8b50883209f4162da91995df2