### PR TITLE
Add documentation QA onboarding guide

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,19 @@
 # PR Review Checklist
 
+## Documentation & QA Checklist
+
+Refer to [doc-quality-onboarding.md](../docs/doc-quality-onboarding.md) for setup instructions.
+
+- [ ] All Python and JS dependencies installed (`pip install -r requirements-dev.txt`, `npm ci` if needed)
+- [ ] Vale is installed locally (`vale --version`)
+- [ ] All Markdown docs pass checks (`bash scripts/check_docs.sh`)
+- [ ] All new or updated docs are clear, concise, and free of grammar issues
+- [ ] pytest and other test suites pass
+- [ ] Pre-commit hooks installed (`pre-commit install`)
+- [ ] If doc checks failed, issues are resolved before requesting review
+
+## Code Checklist
+
 - [ ] All code passes automated lint, type, test, and security checks
 - [ ] OpenAPI, contract, and migration checks pass
 - [ ] All FastAPI endpoints include docstrings and documentation
@@ -8,3 +22,6 @@
 - [ ] Did Codex introduce any direct commits to `main`?
 - [ ] Are all Codex changes covered by tests and docs?
 - [ ] Coverage does not decrease (see Codecov status)
+
+_Reviewer Sign-Off_
+- [ ] I confirm all checklist items are complete.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to this project will be recorded in this file.
 - Documented committing the lockfile in the README and frontend README.
 - Added `docs/Agents.md` with a consolidated overview of service agents and healthchecks.
 - Documented database agent and synced environment variables with `.env.example`.
+- Added documentation & QA checklist to `docs/pull_request_template.md` and `.github/pull_request_template.md`.
+- Added `doc-quality-onboarding.md` with a quickstart for running documentation checks.
 
 - Replaced marketing preview links with the frontend README and React demo.
 - Updated `frontend/README.md` with DevOnboarder branding and removed outdated badge references.

--- a/docs/README.md
+++ b/docs/README.md
@@ -55,6 +55,7 @@ platforms. Please report any issues you encounter on your operating system.
 - [Sample pull request](sample-pr.md) &ndash; walkthrough of a minimal docs update.
 - [Merge checklist](merge-checklist.md) &ndash; steps maintainers use before merging.
 - [Changelog](CHANGELOG.md) &ndash; record notable updates for each release.
+- [Doc QA onboarding](doc-quality-onboarding.md) &ndash; quickstart for documentation checks.
 - [Security audit](security-audit-2025-06-21.md) &ndash; latest dependency check results.
 - [Environment variables](env.md) &ndash; explanation of `.env` settings and the role-based permission system.
 - [Alpha tester onboarding](alpha/README.md) &ndash; guide for early testers.
@@ -97,6 +98,7 @@ who has contributed and when.
 ## Documentation Quality Checks
 
 All Markdown files must pass Vale and LanguageTool checks.
+See [doc-quality-onboarding.md](doc-quality-onboarding.md) for a step-by-step guide.
 
 - Run `bash scripts/check_docs.sh` before pushing any changes.
 - Install Vale with `brew install vale` or see the [Vale installation docs](https://vale.sh/docs/installation/).

--- a/docs/doc-quality-onboarding.md
+++ b/docs/doc-quality-onboarding.md
@@ -1,0 +1,78 @@
+# 🛠️ Onboarding: Documentation Quality Checks & Contribution Guide
+
+## 🚀 Quickstart for Contributors
+
+Welcome to the project! To keep our docs clear and professional, we run two tools:
+
+* **Vale** – style and terminology checks
+* **LanguageTool** – grammar and spelling
+
+**You must pass both checks before pushing or opening a PR.**
+
+---
+
+### Step 1: Install All Dev Requirements
+
+```bash
+pip install -r requirements-dev.txt
+```
+
+---
+
+### Step 2: Install Vale
+
+* On macOS: `brew install vale`
+* On Windows: `choco install vale`
+* Or see [Vale Installation Docs](https://vale.sh/docs/installation/) for other platforms
+
+---
+
+### Step 3: (Optional) Set Up Local LanguageTool Server
+
+By default the project uses the public LanguageTool API, but CI or firewalls may block it. For local use:
+
+```bash
+docker run -d -p 8010:8010 --name languagetool \
+  quay.io/languagetool/languagetool:latest
+export LANGUAGETOOL_URL="http://localhost:8010"
+```
+
+Set this environment variable in your shell or profile for all checks.
+
+---
+
+### Step 4: Run Documentation Quality Checks
+
+Before every push or PR, run:
+
+```bash
+bash scripts/check_docs.sh
+```
+
+This will fail if Vale is missing, run both Vale and LanguageTool, and print issues by file, line, and column.
+
+---
+
+### Step 5: Pre‑commit Integration (Recommended)
+
+Install pre-commit hooks so documentation and code checks run automatically:
+
+```bash
+pre-commit install
+```
+
+---
+
+### Troubleshooting
+
+* **Vale not found:** install it as shown above.
+* **Python errors:** ensure `pip install -r requirements-dev.txt` succeeded.
+* **LanguageTool API issues:** run a local server and set `LANGUAGETOOL_URL`.
+* **pytest fails:** double-check that all dev dependencies are installed.
+
+---
+
+### More Info
+
+* See [docs/CHANGELOG.md](CHANGELOG.md) for recent updates.
+* For advanced configuration, check `.vale.ini` and `styles/DevOnboarder/`.

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -20,6 +20,18 @@ pytest -q
 bash scripts/check_docs.sh
 ```
 
+## Documentation & QA Checklist
+
+Refer to [doc-quality-onboarding.md](doc-quality-onboarding.md) for setup steps.
+
+- [ ] All Python and JS dependencies installed (`pip install -r requirements-dev.txt`, `npm ci` if needed)
+- [ ] Vale is installed locally (`vale --version`)
+- [ ] All Markdown docs pass checks (`bash scripts/check_docs.sh`)
+- [ ] All new or updated docs are clear, concise, and free of grammar issues
+- [ ] pytest and other test suites pass
+- [ ] Pre-commit hooks installed (`pre-commit install`)
+- [ ] If doc checks failed, issues are resolved before requesting review
+
 # Checklist
 
 - [ ] All code passes lint, type, and security checks


### PR DESCRIPTION
## Summary
- add `doc-quality-onboarding.md` with setup instructions
- link the new doc from `docs/README.md`
- reference the doc in PR templates
- update `docs/CHANGELOG.md`

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `bash scripts/check_docs.sh` *(fails: Vale not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6859943c88808320a2fbc865dd67b021