### PR TITLE
Add service health endpoints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,11 +47,11 @@ jobs:
             - name: Wait for auth service
               run: |
                 for i in {1..30}; do
-                  if nc -z localhost 8002; then
-                    echo "Service is up!";
+                  if curl -sf http://localhost:8002/health; then
+                    echo "Service is up!"
                     break
                   fi
-                  echo "Waiting for service...";
+                  echo "Waiting for service..."
                   sleep 2
                 done
             - name: Run tests with coverage
@@ -67,7 +67,7 @@ jobs:
             - name: Wait for auth service
               run: |
                 for i in {1..30}; do
-                  nc -z localhost 8002 && exit 0
+                  curl -sf http://localhost:8002/health && exit 0
                   echo "Waiting for service..."
                   sleep 2
                 done

--- a/docker-compose.ci.yaml
+++ b/docker-compose.ci.yaml
@@ -20,6 +20,11 @@ services:
   auth:
     <<: [*app-base, *env-dev]
     command: ["devonboarder-auth"]
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8002/health"]
+      interval: 5s
+      timeout: 2s
+      retries: 10
   db:
     <<: [*db-base, *env-dev]
 

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -24,6 +24,11 @@ services:
   auth:
     <<: [*app-base, *env-dev]
     command: ["devonboarder-auth"]
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8002/health"]
+      interval: 5s
+      timeout: 2s
+      retries: 10
 
   bot:
     build: ./bot
@@ -36,6 +41,11 @@ services:
   xp:
     <<: [*app-base, *env-dev]
     command: ["devonboarder-api"]
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8001/health"]
+      interval: 5s
+      timeout: 2s
+      retries: 10
 
   frontend:
     <<: [*node-base, *env-dev]

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -24,6 +24,11 @@ services:
   auth:
     <<: [*app-base, *env-prod]
     command: ["devonboarder-auth"]
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8002/health"]
+      interval: 5s
+      timeout: 2s
+      retries: 10
 
   bot:
     <<: [*node-base, *env-prod]
@@ -34,6 +39,11 @@ services:
   xp:
     <<: [*app-base, *env-prod]
     command: ["devonboarder-api"]
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8001/health"]
+      interval: 5s
+      timeout: 2s
+      retries: 10
 
   frontend:
     <<: [*node-base, *env-prod]

--- a/docs/Agents.md
+++ b/docs/Agents.md
@@ -7,27 +7,28 @@ This document defines all agents (services, bots, integrations, and guards) in t
 ## Table of Contents
 1. [Agent Service Map](#agent-service-map)
 2. [Auth Server (Backend Agent)](#auth-server-backend-agent)
-3. [Frontend Session Agent](#frontend-session-agent)
-4. [Role Guard (RBAC Agent)](#role-guard-rbac-agent)
-5. [Discord Integration Agent](#discord-integration-agent)
-6. [Verification Agent](#verification-agent)
-7. [Session/JWT Agent](#sessionjwt-agent)
-8. [Database Service (Postgres)](#database-service-postgres)
-9. [DevOps/Infrastructure Agents](#devopsinfrastructure-agents)
-10. [Planned Agents / Stubs](#planned-agents--stubs)
-11. [Startup Healthcheck (Autocheck Agent)](#startup-healthcheck-autocheck-agent)
-12. [Healthcheck Implementation Guide](#healthcheck-implementation-guide)
-13. [CI Wait Example](#ci-wait-example)
-14. [Agent Task Checklist](#agent-task-checklist)
-15. [Next Steps / Remediation Timeline](#next-steps--remediation-timeline)
-16. [Agent Health/Liveness Matrix](#agent-healthliveness-matrix)
-17. [Environment Variable Reference](#environment-variable-reference)
-18. [Codex Observability](#codex-observability)
-19. [How to Extend/Contribute](#how-to-extendcontribute)
-20. [Deprecation & Retirement](#deprecation--retirement)
-21. [Glossary](#glossary)
-22. [Related Docs](#related-docs)
-23. [Revision History](#revision-history)
+3. [XP API](#xp-api)
+4. [Frontend Session Agent](#frontend-session-agent)
+5. [Role Guard (RBAC Agent)](#role-guard-rbac-agent)
+6. [Discord Integration Agent](#discord-integration-agent)
+7. [Verification Agent](#verification-agent)
+8. [Session/JWT Agent](#sessionjwt-agent)
+9. [Database Service (Postgres)](#database-service-postgres)
+10. [DevOps/Infrastructure Agents](#devopsinfrastructure-agents)
+11. [Planned Agents / Stubs](#planned-agents--stubs)
+12. [Startup Healthcheck (Autocheck Agent)](#startup-healthcheck-autocheck-agent)
+13. [Healthcheck Implementation Guide](#healthcheck-implementation-guide)
+14. [CI Wait Example](#ci-wait-example)
+15. [Agent Task Checklist](#agent-task-checklist)
+16. [Next Steps / Remediation Timeline](#next-steps--remediation-timeline)
+17. [Agent Health/Liveness Matrix](#agent-healthliveness-matrix)
+18. [Environment Variable Reference](#environment-variable-reference)
+19. [Codex Observability](#codex-observability)
+20. [How to Extend/Contribute](#how-to-extendcontribute)
+21. [Deprecation & Retirement](#deprecation--retirement)
+22. [Glossary](#glossary)
+23. [Related Docs](#related-docs)
+24. [Revision History](#revision-history)
 
 ---
 
@@ -47,7 +48,7 @@ This document defines all agents (services, bots, integrations, and guards) in t
 
 **Purpose:** Provides Discord OAuth, role checks, JWT issuance, and user session endpoints.
 
-**Key Endpoints:** `POST /api/discord/exchange`, `GET /api/auth/user`, `GET /api/verification/status`
+**Key Endpoints:** `POST /api/discord/exchange`, `GET /api/auth/user`, `GET /api/verification/status`, `GET /health`
 
 **Environment:** Discord client credentials, role IDs, JWT secret and config.
 
@@ -55,6 +56,14 @@ This document defines all agents (services, bots, integrations, and guards) in t
 1. Receive code from frontend.
 2. Exchange it for a Discord token and fetch roles.
 3. Issue a JWT and session payload to the frontend.
+
+## XP API
+
+**Purpose:** Provides onboarding and XP routes backed by the auth service database.
+
+**Key Endpoints:** `GET /api/user/onboarding-status`, `GET /api/user/level`, `POST /api/user/contribute`, `GET /health`
+
+**Environment:** Shares database connection via `DATABASE_URL`.
 
 ---
 
@@ -284,9 +293,10 @@ When retiring an agent, mark the section as deprecated with the date and reason.
 | Date        | Version | Author    | Summary                                |
 | ----------- | ------- | --------- | -------------------------------------- |
 | 22 Jun 2025 | v0.3.0  | Codex     | Added service map and healthcheck guide |
+| 23 Jun 2025 | v0.3.1  | Codex     | Documented `/health` endpoints |
 | 21 Jun 2025 | v0.2.1  | Codex     | Added database agent and updated env vars |
 | 21 Jun 2025 | v0.2.0  | C. Reesey | Master merged, health matrix, glossary |
 | 21 Jun 2025 | v0.1.0  | C. Reesey | Initial draft                          |
 
-*Last updated: 22 June 2025*
+*Last updated: 23 June 2025*
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be recorded in this file.
 ## [Unreleased]
 
 - CI workflow now builds service containers before starting Compose.
+- Added `/health` endpoints for auth and XP services with compose and CI healthchecks.
 - Generated `frontend/package-lock.json` to pin npm dependencies.
 - Added Vale and LanguageTool documentation linting in CI.
 - Improved LanguageTool script with line/column output and graceful

--- a/src/devonboarder/auth_service.py
+++ b/src/devonboarder/auth_service.py
@@ -173,6 +173,12 @@ app.add_middleware(
 app.add_middleware(_SecurityHeadersMiddleware)
 
 
+@app.get("/health")
+def health() -> dict[str, str]:
+    """Return service health status."""
+    return {"status": "ok"}
+
+
 @app.post("/api/register")
 def register(data: dict, db: Session = Depends(get_db)) -> dict[str, str]:
     """Create a new user and return an authentication token."""

--- a/src/devonboarder/xp_api.py
+++ b/src/devonboarder/xp_api.py
@@ -72,6 +72,11 @@ def create_app() -> FastAPI:
     )
     app.add_middleware(_SecurityHeadersMiddleware)
 
+    @app.get("/health")
+    def health() -> dict[str, str]:
+        """Return service health status."""
+        return {"status": "ok"}
+
     app.include_router(router)
     return app
 

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,17 @@
+from fastapi.testclient import TestClient
+from devonboarder.auth_service import create_app as create_auth_app
+from devonboarder.xp_api import create_app as create_xp_app
+
+
+def test_auth_health():
+    client = TestClient(create_auth_app())
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+
+
+def test_xp_health():
+    client = TestClient(create_xp_app())
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}


### PR DESCRIPTION
## Summary
- expose `/health` in the auth and XP services
- test the new endpoints
- add Docker healthchecks for API services
- update CI workflow to poll `/health`
- document endpoints in the agents guide and changelog

## Testing
- `ruff check .`
- `LANGUAGETOOL_URL=http://localhost:9999 bash scripts/check_docs.sh`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68599ddea7bc8320865a23507a57ddba