### PR TITLE
Fix duplicate wait step in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,15 +64,6 @@ jobs:
             - name: Run bot tests
               run: npm test
               working-directory: bot
-            - name: Wait for auth service
-              run: |
-                for i in {1..30}; do
-                  curl -sf http://localhost:8002/health && exit 0
-                  echo "Waiting for service..."
-                  sleep 2
-                done
-                echo "Auth service failed to start"
-                exit 1
             - name: Check CORS & security headers
               run: |
                 pip install requests

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -184,6 +184,7 @@ All notable changes to this project will be recorded in this file.
 - Expanded `docs/Agents.md` with a service map, healthcheck code samples and a
   remediation checklist.
 - Added `INIT_DB_ON_STARTUP` placeholder to `.env.example` and documented its purpose.
+- Removed duplicate auth wait step from CI workflow.
 
 ## [0.1.0] - 2025-06-14
 


### PR DESCRIPTION
## Summary
- clean up duplicated wait loop for the auth service in CI
- note change in changelog

## Testing
- `ruff check .`
- `pytest -q`
- `bash scripts/check_docs.sh` *(fails: 490 issues found)*

------
https://chatgpt.com/codex/tasks/task_e_6859b4162ee4832094c209acfc9af75b