### PR TITLE
Add Vale install step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,10 @@ jobs:
               run: python scripts/check_docstrings.py src/devonboarder
             - name: Run linter
               run: ruff check .
+            - name: Install Vale
+              run: |
+                curl -fsSL https://github.com/errata-ai/vale/releases/latest/download/vale_Linux_amd64.tar.gz | tar xz
+                sudo mv vale /usr/local/bin/
             - name: Documentation style check
               run: ./scripts/check_docs.sh
             - name: Prepare environment file

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be recorded in this file.
 ## [Unreleased]
 
 - CI workflow now builds service containers before starting Compose.
+- CI workflow installs Vale automatically before documentation checks.
 - Added `/health` endpoints for auth and XP services with compose and CI healthchecks.
 - Generated `frontend/package-lock.json` to pin npm dependencies.
 - Added Vale and LanguageTool documentation linting in CI.

--- a/docs/doc-quality-onboarding.md
+++ b/docs/doc-quality-onboarding.md
@@ -24,6 +24,7 @@ pip install -r requirements-dev.txt
 * On macOS: `brew install vale`
 * On Windows: `choco install vale`
 * Or see [Vale Installation Docs](https://vale.sh/docs/installation/) for other platforms
+* **CI automatically installs Vale**, but you still need it locally to run the checks before committing.
 
 ---
 


### PR DESCRIPTION
## Summary
- install Vale in CI workflow
- document automatic install in docs
- mention Vale setup in changelog

## Testing
- `ruff check .`
- `pytest -q`
- `bash scripts/check_docs.sh` *(fails: 364 issues found)*

------
https://chatgpt.com/codex/tasks/task_e_6859b6740ec48320ae40caa17d2fca5e