### PR TITLE
auth: enforce non-default JWT secret

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,8 @@ VERIFIED_EDUCATION_ROLE_ID=
 # and never committed to version control.
 DISCORD_CLIENT_ID=
 DISCORD_CLIENT_SECRET=
+# Must be set to a non-empty value. The auth service refuses to start
+# if this variable is "secret" or empty outside development mode.
 AUTH_SECRET_KEY=
 DISCORD_BOT_TOKEN=
 DISCORD_GUILD_IDS=

--- a/docs/Agents.md
+++ b/docs/Agents.md
@@ -238,7 +238,7 @@ Use a small loop in your workflow to wait for the auth service before running te
 | VERIFIED_EDUCATION_ROLE_ID   | Role assigned after education verification |
 | DISCORD_CLIENT_ID            | Discord application client ID              |
 | DISCORD_CLIENT_SECRET        | Discord application client secret          |
-| AUTH_SECRET_KEY              | Secret key for JWT signing                 |
+| AUTH_SECRET_KEY              | Secret key for JWT signing (required; service errors if empty or "secret" outside `development`) |
 | DISCORD_BOT_TOKEN            | Token for the Discord bot                  |
 | DISCORD_GUILD_IDS            | Guilds where the bot operates              |
 | BOT_JWT                      | JWT used by the bot for API calls          |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be recorded in this file.
 - LanguageTool checks now skip files that exceed the request size limit instead of failing.
 - Documented committing the lockfile in the README and frontend README.
 - Added `docs/Agents.md` with a consolidated overview of service agents and healthchecks.
+- Auth service now errors at startup when `AUTH_SECRET_KEY` is unset or "secret" outside development mode.
 - Documented database agent and synced environment variables with `.env.example`.
 - `setup-env.sh` now falls back to `npm install` when `pnpm` is unavailable.
 - Added documentation & QA checklist to `docs/pull_request_template.md` and `.github/pull_request_template.md`.

--- a/src/devonboarder/auth_service.py
+++ b/src/devonboarder/auth_service.py
@@ -24,7 +24,12 @@ from jose import jwt, JWTError
 import os
 import time
 
-SECRET_KEY = os.getenv("AUTH_SECRET_KEY", "secret")
+SECRET_KEY = os.getenv("AUTH_SECRET_KEY")
+APP_ENV = os.getenv("APP_ENV")
+if (not SECRET_KEY or SECRET_KEY == "secret") and APP_ENV != "development":
+    raise RuntimeError(
+        "AUTH_SECRET_KEY must be set to a non-default value in production"
+    )
 ALGORITHM = "HS256"
 TOKEN_EXPIRE_SECONDS = int(os.getenv("TOKEN_EXPIRE_SECONDS", "3600"))
 

--- a/tests/test_auth_service.py
+++ b/tests/test_auth_service.py
@@ -1,4 +1,7 @@
 import importlib
+import os
+os.environ.setdefault("APP_ENV", "development")
+os.environ.setdefault("AUTH_SECRET_KEY", "devsecret")
 from fastapi.testclient import TestClient
 from devonboarder import auth_service
 from utils import roles as roles_utils

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,4 +1,7 @@
 from fastapi.testclient import TestClient
+import os
+os.environ.setdefault("APP_ENV", "development")
+os.environ.setdefault("AUTH_SECRET_KEY", "devsecret")
 from devonboarder.auth_service import create_app as create_auth_app
 from devonboarder.xp_api import create_app as create_xp_app
 

--- a/tests/test_xp_api.py
+++ b/tests/test_xp_api.py
@@ -1,4 +1,7 @@
 from devonboarder.xp_api import create_app
+import os
+os.environ.setdefault("APP_ENV", "development")
+os.environ.setdefault("AUTH_SECRET_KEY", "devsecret")
 from devonboarder import auth_service
 from fastapi.testclient import TestClient
 


### PR DESCRIPTION
## Summary
- fail fast when JWT secret is missing outside development
- document the new requirement
- show the env var guidance in `.env.example`
- update tests to set a development secret

## Testing
- `ruff check .`
- `pytest -q`
- `bash scripts/check_docs.sh`


------
https://chatgpt.com/codex/tasks/task_e_6859bcd67da48320b3a60c7bcec67bdf