### PR TITLE
Fix docs lint errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,22 +3,22 @@
 This repository follows the DevOnboarder protocol. Key points:
 
 1. **Trunk-based workflow**
-   - All stable code lives on `main`.
-   - Short-lived branches are created off `main` for every change.
-   - Changes are merged back into `main` through pull requests.
-   - Feature branches are deleted after merge.
+- All stable code lives on `main`.
+- Short-lived branches are created off `main` for every change.
+- Changes are merged back into `main` through pull requests.
+- Feature branches are deleted after merge.
 
 2. **Documentation**
-   - General onboarding instructions: `docs/README.md`.
-   - Git guidelines: `docs/git-guidelines.md`.
-   - Pull request template: `docs/pull_request_template.md`.
-   - Maintainer merge checklist: `docs/merge-checklist.md`.
-   - Project changelog: `docs/CHANGELOG.md`.
+- General onboarding instructions: `docs/README.md`.
+- Git guidelines: `docs/git-guidelines.md`.
+- Pull request template: `docs/pull_request_template.md`.
+- Maintainer merge checklist: `docs/merge-checklist.md`.
+- Project changelog: `docs/CHANGELOG.md`.
 
 3. **Development Environment**
-   - Use the provided container setup and compose files for local development.
-   - Ensure all tests pass before submitting a PR.
+- Use the provided container setup and compose files for local development.
+- Ensure all tests pass before submitting a PR.
 
 4. **Contribution Guidelines**
-   - Keep pull requests focused and small.
-   - Update documentation and the changelog with each change.
+- Keep pull requests focused and small.
+- Update documentation and the changelog with each change.

--- a/README.md
+++ b/README.md
@@ -14,20 +14,19 @@ container setup used by Codex.
 
 - `config/` – Configuration files, including `devonboarder.config.yml`.
 - `scripts/` – Helper scripts for bootstrapping and environment setup.
-- `.devcontainer/` – Contains `devcontainer.json` which builds the VS Code
-  development container, forwards port `3000`, and runs `scripts/setup-env.sh`.
-  - `docker-compose.dev.yaml` – Compose file for local development using `.env.dev`.
-  - `docker-compose.ci.yaml` – Compose file used by the CI pipeline.
-  - `docker-compose.prod.yaml` – Compose file for production using `.env.prod`.
-  - `docker-compose.yml` – Base compose file for generic deployments.
-  - `docker-compose.codex.yml` – Compose file used when running in Codex.
-  - `docker-compose.override.yaml` – Overrides for the base compose file.
-  - `bot/` – Discord bot written in TypeScript.
-  - `frontend/` – Placeholder directory for the upcoming web UI.
-  - `auth/` – Environment files for the authentication service.
-  - `xp/` – Environment files for the XP API.
-  - `config/devonboarder.config.yml` – Config for the `devonboarder` tool.
-  - `.env.example` – Sample variables shared across services.
+- `.devcontainer/` – Contains `devcontainer.json` which builds the VS Code development container, forwards port `3000`, and runs `scripts/setup-env.sh`.
+- `docker-compose.dev.yaml` – Compose file for local development using `.env.dev`.
+- `docker-compose.ci.yaml` – Compose file used by the CI pipeline.
+- `docker-compose.prod.yaml` – Compose file for production using `.env.prod`.
+- `docker-compose.yml` – Base compose file for generic deployments.
+- `docker-compose.codex.yml` – Compose file used when running in Codex.
+- `docker-compose.override.yaml` – Overrides for the base compose file.
+- `bot/` – Discord bot written in TypeScript.
+- `frontend/` – Placeholder directory for the upcoming web UI.
+- `auth/` – Environment files for the authentication service.
+- `xp/` – Environment files for the XP API.
+- `config/devonboarder.config.yml` – Config for the `devonboarder` tool.
+- `.env.example` – Sample variables shared across services.
 
 ## Documentation and Onboarding
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be recorded in this file.
 - LanguageTool checks now skip files that exceed the request size limit instead of failing.
 - Documented committing the lockfile in the README and frontend README.
 - Added `docs/Agents.md` with a consolidated overview of service agents and healthchecks.
+- Cleaned up README and AGENTS docs to reduce documentation lint warnings.
 - Auth service now errors at startup when `AUTH_SECRET_KEY` is unset or "secret" outside development mode.
 - Documented database agent and synced environment variables with `.env.example`.
 - `setup-env.sh` now falls back to `npm install` when `pnpm` is unavailable.


### PR DESCRIPTION
## Summary
- adjust README and AGENTS markdown to silence whitespace warnings
- note doc cleanup in the changelog

## Testing
- `bash scripts/check_docs.sh` *(fails: 282 issues found)*

------
https://chatgpt.com/codex/tasks/task_e_6859c22d57108320822fc2493aa4dcf2