### PR TITLE
Add GitHub annotations for doc checks

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -40,6 +40,9 @@ All notable changes to this project will be recorded in this file.
 - Documented Vale installation steps and improved `scripts/check_docs.sh` to
   verify the command is available before running.
 
+- Updated `scripts/check_docs.sh` to output GitHub error annotations when
+  Vale or LanguageTool find issues.
+
 - Dropped unused `user_id` argument from `utils.discord.get_user_roles`.
 - Docstring check now detects FastAPI route decorators instead of relying on function name prefixes.
 - Added missing docstrings to auth service endpoints.

--- a/scripts/check_docs.sh
+++ b/scripts/check_docs.sh
@@ -1,12 +1,19 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 FILES=$(git ls-files '*.md')
 
 if ! command -v vale >/dev/null 2>&1; then
-  echo "Vale not installed. Install it with 'brew install vale' or see docs/README.md."
+  echo "::error file=scripts/check_docs.sh,line=$LINENO::Vale not installed"
   exit 1
 fi
 
-vale $FILES
-python scripts/languagetool_check.py $FILES
+if ! vale $FILES; then
+  echo "::error file=scripts/check_docs.sh,line=$LINENO::Vale issues found"
+  exit 1
+fi
+
+if ! python scripts/languagetool_check.py $FILES; then
+  echo "::error file=scripts/check_docs.sh,line=$LINENO::LanguageTool issues found"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- emit `::error` annotations in `check_docs.sh` when Vale or LanguageTool fail
- note new behavior in the changelog

## Testing
- `ruff check .`
- `pytest -q`
- `bash scripts/check_docs.sh` *(fails: LanguageTool issues found)*

------
https://chatgpt.com/codex/tasks/task_e_685a105d0bb08320a9e508bed204fe34