### PR TITLE
Add GitHub annotations for LanguageTool issues

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be recorded in this file.
 - Added Vale and LanguageTool documentation linting in CI.
 - Improved LanguageTool script with line/column output and graceful connection error handling.
 - LanguageTool checks now skip files that exceed the request size limit instead of failing.
+- LanguageTool script now emits GitHub error annotations and exits with a non-zero code when issues are found.
 - Documented committing the lockfile in the README and frontend README.
 - Added `docs/Agents.md` with a consolidated overview of service agents and healthchecks.
 - Cleaned up README and AGENTS docs to reduce documentation lint warnings.

--- a/scripts/languagetool_check.py
+++ b/scripts/languagetool_check.py
@@ -21,7 +21,7 @@ def check_file(path: str, tool: language_tool_python.LanguageTool) -> int:
         print(f"{path}: {len(matches)} issues found")
         for m in matches:
             line, col = m.get_line_and_column(text)
-            print(f"- Line {line}, column {col}: {m.message}")
+            print(f"::error file={path},line={line}::{m.message}")
         return len(matches)
     return 0
 


### PR DESCRIPTION
# Summary
- emit GitHub Actions error annotations for LanguageTool findings
- fail when issues are detected
- document the new behavior in the changelog

# Testing Steps
```bash
ruff check .
pytest -q
bash scripts/check_docs.sh
```


------
https://chatgpt.com/codex/tasks/task_e_685a1316d0fc832082dfa22186f09319