### PR TITLE
Add junit test output to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,18 @@ jobs:
                   sleep 2
                 done
             - name: Run tests with coverage
-              run: pytest --cov=src --cov-fail-under=85
+              run: pytest --cov=src --cov-fail-under=85 --junitxml=pytest-results.xml
+            - name: Upload pytest results
+              if: always()
+              uses: actions/upload-artifact@v3
+              with:
+                  name: pytest-results
+                  path: pytest-results.xml
+            - name: Annotate pytest failures
+              if: failure()
+              run: |
+                  line=$(grep -n -m 1 '<failure' pytest-results.xml | cut -d: -f1)
+                  echo "::error file=pytest-results.xml,line=${line}::Test failures detected"
             - name: Install frontend dependencies
               run: npm ci
               working-directory: frontend

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be recorded in this file.
 - Generated `frontend/package-lock.json` to pin npm dependencies.
 - Added Vale and LanguageTool documentation linting in CI.
 - Improved LanguageTool script with line/column output and graceful connection error handling.
+- CI workflow now records pytest results and uploads them as an artifact.
 - LanguageTool checks now skip files that exceed the request size limit instead of failing.
 - LanguageTool script now emits GitHub error annotations and exits with a non-zero code when issues are found.
 - Documented committing the lockfile in the README and frontend README.


### PR DESCRIPTION
## Summary
- emit pytest results in CI
- upload pytest report as artifact
- annotate failing tests in the workflow
- document workflow change in changelog

## Testing
- `ruff check .`
- `pytest -q`
- `bash scripts/check_docs.sh` *(fails: LanguageTool issues found)*

------
https://chatgpt.com/codex/tasks/task_e_685a183410e08320ae38f1cf31289c1a