### PR TITLE
feat: annotate missing docstrings

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -48,6 +48,7 @@ All notable changes to this project will be recorded in this file.
 - Dropped unused `user_id` argument from `utils.discord.get_user_roles`.
 - Docstring check now detects FastAPI route decorators instead of relying on function name prefixes.
 - Added missing docstrings to auth service endpoints.
+- Docstring check now emits GitHub error annotations for missing docstrings.
 - Pinned Prettier pre-commit hook to `v3.1.0`.
 - Verified Prettier hook installation with `pre-commit autoupdate`.
 - Added `pytest-cov` to development requirements.

--- a/scripts/check_docstrings.py
+++ b/scripts/check_docstrings.py
@@ -42,17 +42,23 @@ def main() -> None:
     for dirpath, _, filenames in os.walk(api_path):
         for filename in filenames:
             if filename.endswith(".py"):
-                with open(os.path.join(dirpath, filename), "r") as f:
+                path = os.path.join(dirpath, filename)
+                with open(path, "r") as f:
                     tree = ast.parse(f.read())
                 for node in ast.walk(tree):
                     if isinstance(node, ast.FunctionDef):
-                        if any(_is_route_decorator(d) for d in node.decorator_list):
+                        if any(
+                            _is_route_decorator(d) for d in node.decorator_list
+                        ):
                             if not has_docstring(node):
-                                errors.append(
-                                    f"{filename}:{node.lineno} missing docstring"
+                                rel_path = os.path.relpath(path)
+                                msg = (
+                                    f"::error file={rel_path},line={node.lineno}"
+                                    "::missing docstring"
                                 )
+                                print(msg)
+                                errors.append(rel_path)
     if errors:
-        print("Missing docstrings:\n" + "\n".join(errors))
         exit(1)
     print("All endpoint docstrings present.")
 


### PR DESCRIPTION
## Summary
- print GitHub error annotations for each missing docstring
- document the annotation behavior in the changelog

## Testing Steps
```bash
ruff check .
pytest -q
bash scripts/check_docs.sh || true
```


------
https://chatgpt.com/codex/tasks/task_e_685a1fe911f48320b3ad80692bd08fac