### PR TITLE
Add Discord server configuration doc

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -196,6 +196,7 @@ All notable changes to this project will be recorded in this file.
 - Added `INIT_DB_ON_STARTUP` placeholder to `.env.example` and documented its purpose.
 - Removed duplicate auth wait step from CI workflow.
 - Added Vitest setup and a basic React test.
+- Added Discord server configuration guide noting that the Widget must be enabled.
 
 ## [0.1.0] - 2025-06-14
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -64,6 +64,7 @@ platforms. Please report any issues you encounter on your operating system.
 - [Alpha phase roadmap](roadmap/alpha-phase.md) &ndash; pre- and post-launch milestones.
 - [Feedback dashboard PRD](prd/feedback-dashboard.md) &ndash; objectives and features for the feedback tool.
 - [Discord message templates](discord/discord-message-templates.md) &ndash; sample posts for the community.
+- [Discord server configuration](discord/configuration.md) &ndash; enable the widget for status display.
 - [Endpoint reference](endpoint-reference.md) &ndash; list of API routes and Discord command mappings.
 - [Alpha testers log](../ALPHA_TESTERS.md) &ndash; track invitations and feedback status.
 - [Founders log](../FOUNDERS.md) &ndash; record core contributors and how they help.

--- a/docs/discord/configuration.md
+++ b/docs/discord/configuration.md
@@ -1,0 +1,12 @@
+# Discord Server Configuration
+
+This guide explains how to configure the Discord server used by the project.
+
+## Steps
+
+1. Create a new Discord server or choose an existing one.
+2. Invite the DevOnboarder bot and grant it the permissions described in the README.
+3. Configure channels and roles as needed for your community.
+4. **Enable the Widget** in the server settings so the website can display the server's online status.
+
+With the Widget enabled, the marketing site and other tools can show who is online without requiring users to open Discord.


### PR DESCRIPTION
## Summary
- document how to configure the Discord server
- link new guide from the docs index
- record the addition in the changelog

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'devonboarder')*
- `npm test` from `bot/` *(fails: jest not found)*
- `bash scripts/check_docs.sh` *(fails: Vale not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685a2e72007c832091f2df36b1d2c447