### PR TITLE
Fix dev compose bot and frontend

### DIFF
--- a/bot/Dockerfile.dev
+++ b/bot/Dockerfile.dev
@@ -1,0 +1,15 @@
+FROM node:20-alpine
+
+# set working directory
+WORKDIR /usr/src/app
+
+# copy package manifests and install deps
+COPY bot/package*.json ./
+RUN npm ci
+
+# copy source, compile TS
+COPY bot/ .
+RUN npm run build
+
+# default command
+CMD ["node", "dist/main.js"]

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 x-app-base: &app-base
   build: .
 
@@ -31,12 +29,11 @@ services:
       retries: 10
 
   bot:
-    build: ./bot
+    build:
+      context: .
+      dockerfile: bot/Dockerfile.dev
     env_file:
-      - ./bot/.env
-    volumes:
-      - ./bot:/usr/src/app
-    command: ["npm", "start"]
+      - .env.dev
 
   xp:
     <<: [*app-base, *env-dev]
@@ -48,11 +45,13 @@ services:
       retries: 10
 
   frontend:
-    <<: [*node-base, *env-dev]
-    working_dir: /frontend
-    volumes:
-      - ./frontend:/frontend
-    command: ["npm", "run", "dev"]
+    build:
+      context: .
+      dockerfile: frontend/Dockerfile.dev
+    env_file:
+      - .env.dev
+    ports:
+      - "3000:3000"
 
   db:
     <<: [*db-base, *env-dev]

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be recorded in this file.
 
 ## [Unreleased]
 
+- Added Dockerfiles for the bot and frontend and updated `docker-compose.dev.yaml` to build them.
 - CI workflow now builds service containers before starting Compose.
 - CI workflow installs Vale automatically before documentation checks.
 - Added `/health` endpoints for auth and XP services with compose and CI healthchecks.

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -1,0 +1,16 @@
+FROM node:18-alpine
+
+WORKDIR /usr/src/app
+
+# Copy manifests & install dependencies (including dev)
+COPY frontend/package*.json ./
+RUN npm ci
+
+# Copy frontend code
+COPY frontend/ .
+
+# Expose Vite default port
+EXPOSE 3000
+
+# Run dev server
+CMD ["npm", "run", "dev"]


### PR DESCRIPTION
## Summary
- add dedicated dev Dockerfiles for bot and frontend
- build the new images from docker-compose.dev.yaml
- remove the obsolete version key
- note the new build process in the changelog

## Testing
- `ruff check .`
- `pytest -q`
- `bash scripts/check_docs.sh` *(fails: LanguageTool issues found)*

------
https://chatgpt.com/codex/tasks/task_e_685a3e40d5a48320b77d6078dfa46eb5