### PR TITLE
Update frontend env docs

### DIFF
--- a/docs/Agents.md
+++ b/docs/Agents.md
@@ -244,7 +244,8 @@ Use a small loop in your workflow to wait for the auth service before running te
 | DISCORD_GUILD_IDS            | Guilds where the bot operates              |
 | BOT_JWT                      | JWT used by the bot for API calls          |
 | API_BASE_URL                 | XP API URL for the bot                     |
-| VITE_AUTH_API_BASE_URL       | Auth service URL for the frontend          |
+| VITE_AUTH_URL                | Auth service URL for the frontend          |
+| VITE_API_URL                 | XP API URL for the frontend                |
 | VITE_DISCORD_CLIENT_ID       | Discord client ID for the frontend         |
 | VITE_SESSION_REFRESH_INTERVAL| How often the frontend refreshes sessions  |
 | INIT_DB_ON_STARTUP           | Auto-run migrations when the auth service starts |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -198,6 +198,7 @@ All notable changes to this project will be recorded in this file.
 - Removed duplicate auth wait step from CI workflow.
 - Added Vitest setup and a basic React test.
 - Added Discord server configuration guide noting that the Widget must be enabled.
+- Replaced `VITE_AUTH_API_BASE_URL` with `VITE_AUTH_URL` and documented `VITE_API_URL`.
 
 ## [0.1.0] - 2025-06-14
 

--- a/docs/env.md
+++ b/docs/env.md
@@ -83,6 +83,7 @@ access token, creates or looks up the user, then returns a JWT from
 
 ## Frontend
 
-- `VITE_AUTH_API_BASE_URL` &ndash; base URL for the auth API.
+- `VITE_AUTH_URL` &ndash; base URL for the auth API.
+- `VITE_API_URL` &ndash; base URL for the XP API.
 - `VITE_DISCORD_CLIENT_ID` &ndash; OAuth client ID for Discord.
 - `VITE_SESSION_REFRESH_INTERVAL` &ndash; interval (seconds) between session refreshes.


### PR DESCRIPTION
## Summary
- rename `VITE_AUTH_API_BASE_URL` to `VITE_AUTH_URL`
- document `VITE_API_URL`
- update Agents doc table to new variable names

## Testing
- `ruff check .`
- `pytest -q`
- `bash scripts/check_docs.sh` *(fails: Vale not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685a4c082e288320b0f2ed9e2c681ab6