### PR TITLE
Update frontend instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ container setup used by Codex.
 - `docker-compose.codex.yml` – Compose file used when running in Codex.
 - `docker-compose.override.yaml` – Overrides for the base compose file.
 - `bot/` – Discord bot written in TypeScript.
-- `frontend/` – Placeholder directory for the upcoming web UI.
+- `frontend/` – Vite-based React application.
 - `auth/` – Environment files for the authentication service.
 - `xp/` – Environment files for the XP API.
 - `config/devonboarder.config.yml` – Config for the `devonboarder` tool.
@@ -62,8 +62,7 @@ Alternatively, you can run the Docker Compose setup directly.
 This starts the auth, bot, XP API, frontend, and database services using
 environment variables from `.env.dev`.
 Copy each `*.env.example` to `.env` inside its service directory before starting.
-The `frontend/` directory hosts a Vite-based React app. Run `npm install` (which creates `package-lock.json`) and commit the lockfile to version control and
-`npm run dev` in that folder to start the development server:
+The `frontend/` directory hosts a Vite-based React app. Run `npm install` (or `pnpm install`) in that folder to install dependencies, commit the generated lockfile, and then start the development server with `npm run dev`:
 
 ```bash
 docker compose -f docker-compose.dev.yaml --env-file .env.dev up

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be recorded in this file.
 - LanguageTool checks now skip files that exceed the request size limit instead of failing.
 - LanguageTool script now emits GitHub error annotations and exits with a non-zero code when issues are found.
 - Documented committing the lockfile in the README and frontend README.
+- Documented starting the frontend with `npm install` (or `pnpm install`) and `npm run dev`.
 - Added `docs/Agents.md` with a consolidated overview of service agents and healthchecks.
 - Cleaned up README and AGENTS docs to reduce documentation lint warnings.
 - Auth service now errors at startup when `JWT_SECRET_KEY` is unset or "secret" outside development mode.


### PR DESCRIPTION
## Summary
- call out `frontend/` as the Vite-based React app
- explain how to install dependencies with `npm install` or `pnpm install`
- note starting the dev server with `npm run dev`
- log this documentation update in the changelog

## Testing
- `ruff check .`
- `pytest -q`
- `bash scripts/check_docs.sh` *(fails: LanguageTool issues found)*

------
https://chatgpt.com/codex/tasks/task_e_685a50cd26388320b3b106b05db35b5c