### PR TITLE
Fix linter command in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
             - name: Doc coverage check
               run: python scripts/check_docstrings.py src/devonboarder
             - name: Run linter
-              run: ruff check --format=github .
+              run: ruff check --output-format=github .
             - name: Install Vale
               run: |
                 curl -fsSL https://github.com/errata-ai/vale/releases/latest/download/vale_Linux_amd64.tar.gz | tar xz

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be recorded in this file.
 - Generated `frontend/package-lock.json` to pin npm dependencies.
 - Added Vale and LanguageTool documentation linting in CI.
 - CI now saves Vale results as `vale-results.json` and uploads them as an artifact.
+- Linter step now uses `ruff check --output-format=github .`.
 - Improved LanguageTool script with line/column output and graceful connection error handling.
 - CI workflow now records pytest results and uploads them as an artifact.
 - LanguageTool checks now skip files that exceed the request size limit instead of failing.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-ruff
+ruff==0.1.7
 pytest
 pyyaml
 pre-commit


### PR DESCRIPTION
## Summary
- use `ruff check --output-format=github .` in CI
- pin ruff version in requirements-dev
- document the change in the changelog

## Testing
- `ruff check --output-format=github .`
- `pytest -q`
- `bash scripts/check_docs.sh` *(fails: LanguageTool and Vale lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_685afac297bc8320bc04a5c2f995c277