### PR TITLE
Document pytest artifact

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be recorded in this file.
 - Linter step now uses `ruff check --output-format=github .`.
 - Improved LanguageTool script with line/column output and graceful connection error handling.
 - CI workflow now records pytest results and uploads them as an artifact.
+- Documented where to download the `pytest-results.xml` artifact in the doc-quality onboarding guide.
 - LanguageTool checks now skip files that exceed the request size limit instead of failing.
 - LanguageTool script now emits GitHub error annotations and exits with a non-zero code when issues are found.
 - Documented committing the lockfile in the README and frontend README.

--- a/docs/doc-quality-onboarding.md
+++ b/docs/doc-quality-onboarding.md
@@ -54,6 +54,8 @@ This generates `vale-results.json` for machine-readable output, which CI stores 
 
 This will fail if Vale is missing, run both Vale and LanguageTool, and print issues by file, line, and column.
 
+CI also uploads `pytest-results.xml` when the test suite runs in GitHub Actions. Visit a workflow run, open the **Artifacts** drop-down, and download the file to review which tests failed and why.
+
 ---
 
 ### Step 5: Pre‑commit Integration (Recommended)


### PR DESCRIPTION
## Summary
- mention the `pytest-results.xml` artifact in doc onboarding guide
- reference artifact location in changelog

## Testing
- `pytest -q`
- `bash scripts/check_docs.sh` *(fails: LanguageTool issues found)*

------
https://chatgpt.com/codex/tasks/task_e_685afd05f5488320a89639cab7cf3d1f