### PR TITLE
Remove duplicate bot env file

### DIFF
--- a/.env.bot.example
+++ b/.env.bot.example
@@ -1,8 +1,0 @@
-# Sample environment for the Discord bot
-# These values are secrets. Store real credentials in your deployment's
-# secret manager and keep them out of version control.
-DISCORD_BOT_TOKEN=your-discord-bot-token
-DISCORD_CLIENT_ID=your-discord-client-id
-DISCORD_CLIENT_SECRET=
-DISCORD_GUILD_IDS=comma,separated,ids
-API_BASE_URL=http://localhost:8001

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -191,7 +191,7 @@ All notable changes to this project will be recorded in this file.
 - Added Discord utilities for fetching user roles and resolving admin flags.
 - Documented role and guild ID placeholders in `.env.example` and created `docs/env.md` with details on the role-based permission system.
 - Added verified role ID placeholders to `.env.example` and documented them in `docs/env.md`.
-- Added a "Secrets" section in `docs/env.md` covering Discord OAuth and bot tokens, with matching placeholders in `.env.example` and `.env.bot.example`.
+- Added a "Secrets" section in `docs/env.md` covering Discord OAuth and bot tokens, with matching placeholders in `.env.example` and `bot/.env.example`.
 - Added `tests/test_roles.py` verifying admin and verified role flags.
 - Documented outdated packages and vulnerability scan results. `pip list` showed
   updates for mypy, pyright, pytest, ruff and typing extensions; `npm outdated`


### PR DESCRIPTION
## Summary
- drop `.env.bot.example`
- point changelog to `bot/.env.example`

## Testing
- `ruff check .`
- `pytest -q`
- `bash scripts/check_docs.sh` *(fails: Vale not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685b0afb33a4832080cf40a95f16a655