### PR TITLE
Fix README quickstart env path

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ docker compose -f docker-compose.prod.yaml --env-file .env.prod up -d
    `cp auth/.env.example auth/.env`
    `cp bot/.env.example bot/.env`
    `cp xp/.env.example xp/.env`
-   `cp frontend/.env.example frontend/.env`
+   `cp frontend/src/.env.example frontend/.env`
 3. Install the project with `pip install -e .`.
    Install development tools with `pip install -r requirements-dev.txt`.
 4. Start the services with `docker compose -f docker-compose.dev.yaml --env-file .env.dev up -d`.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -207,6 +207,7 @@ All notable changes to this project will be recorded in this file.
 - Replaced `VITE_AUTH_API_BASE_URL` with `VITE_AUTH_URL` and documented `VITE_API_URL`.
 - Added placeholders for `VITE_AUTH_URL`, `VITE_API_URL`, and `VITE_SESSION_REFRESH_INTERVAL` in `.env.example`.
 - Added `VITE_SESSION_REFRESH_INTERVAL` to `frontend/src/.env.example` with a default value and synced `docs/env.md`.
+- Corrected README quickstart path to `frontend/src/.env.example`.
 
 ## [0.1.0] - 2025-06-14
 


### PR DESCRIPTION
## Summary
- update the README quickstart step to reference `frontend/src/.env.example`
- note this documentation fix in the changelog

## Testing
- `ruff check .`
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b0f2334488320b9efc9ec75a38d97