### PR TITLE
Add Ubuntu setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ docker compose -f docker-compose.prod.yaml --env-file .env.prod up -d
 ```
 
 ## Quickstart
+First install Docker, Docker Compose, Node.js 20, and Python 3.12. See [docs/ubuntu-setup.md](docs/ubuntu-setup.md) for the Ubuntu commands.
 1. Run `bash scripts/bootstrap.sh` to copy `.env.example` to `.env.dev` and install dependencies.
 2. Copy each service example file to `.env`:
    `cp auth/.env.example auth/.env`

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be recorded in this file.
 ## [Unreleased]
 
 - Added Dockerfiles for the bot and frontend and updated `docker-compose.dev.yaml` to build them.
+- Documented Ubuntu commands for installing Docker, Docker Compose, Node.js 20, and Python 3.12. Linked the setup guide from the README quickstart.
 - CI workflow now builds service containers before starting Compose.
 - CI workflow installs Vale automatically before documentation checks.
 - Added `/health` endpoints for auth and XP services with compose and CI healthchecks.

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,7 @@
 
 Welcome to **DevOnboarder**. This page explains how to get your environment running and where to find documentation about our workflow.
 
+If you're setting up a fresh Ubuntu machine, follow [ubuntu-setup.md](ubuntu-setup.md) for the commands that install Docker, Docker Compose, Node.js 20, and Python 3.12.
 ## Local Development
 
 1. Run `bash scripts/bootstrap.sh` to create `.env.dev` and install dependencies

--- a/docs/ubuntu-setup.md
+++ b/docs/ubuntu-setup.md
@@ -1,0 +1,27 @@
+# Ubuntu Setup
+
+These commands install Docker, Docker Compose, Node.js 20, and Python 3.12 on Ubuntu 22.04 or newer.
+
+## Install Docker and Docker Compose
+```bash
+sudo apt-get update
+sudo apt-get install -y ca-certificates curl gnupg
+sudo install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+sudo apt-get update
+sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+```
+
+## Install Node.js 20
+```bash
+curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+sudo apt-get install -y nodejs
+```
+
+## Install Python 3.12
+```bash
+sudo add-apt-repository ppa:deadsnakes/ppa -y
+sudo apt-get update
+sudo apt-get install -y python3.12 python3.12-venv python3.12-dev
+```


### PR DESCRIPTION
## Summary
- document installation of Docker, Docker Compose, Node.js 20 and Python 3.12 on Ubuntu
- link the new setup guide from docs README and the README quickstart
- note the new docs in the changelog

## Testing
- `ruff check .`
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b12e705748320b646c59aa1f04382