### PR TITLE
Fix environment lines placement

### DIFF
--- a/tests/test_auth_service.py
+++ b/tests/test_auth_service.py
@@ -1,7 +1,5 @@
 import importlib
 import os
-os.environ.setdefault("APP_ENV", "development")
-os.environ.setdefault("JWT_SECRET_KEY", "devsecret")
 from fastapi.testclient import TestClient
 from devonboarder import auth_service
 from utils import roles as roles_utils
@@ -10,6 +8,9 @@ import pytest
 import time
 import sqlalchemy
 import httpx
+
+os.environ.setdefault("APP_ENV", "development")
+os.environ.setdefault("JWT_SECRET_KEY", "devsecret")
 
 
 def setup_function(function):

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,9 +1,10 @@
 from fastapi.testclient import TestClient
 import os
-os.environ.setdefault("APP_ENV", "development")
-os.environ.setdefault("JWT_SECRET_KEY", "devsecret")
 from devonboarder.auth_service import create_app as create_auth_app
 from devonboarder.xp_api import create_app as create_xp_app
+
+os.environ.setdefault("APP_ENV", "development")
+os.environ.setdefault("JWT_SECRET_KEY", "devsecret")
 
 
 def test_auth_health():

--- a/tests/test_xp_api.py
+++ b/tests/test_xp_api.py
@@ -1,9 +1,10 @@
 from devonboarder.xp_api import create_app
 import os
-os.environ.setdefault("APP_ENV", "development")
-os.environ.setdefault("JWT_SECRET_KEY", "devsecret")
 from devonboarder import auth_service
 from fastapi.testclient import TestClient
+
+os.environ.setdefault("APP_ENV", "development")
+os.environ.setdefault("JWT_SECRET_KEY", "devsecret")
 
 
 def setup_function(function):


### PR DESCRIPTION
## Summary
- standardize environment setup order in tests

## Testing
- `pytest -q` *(fails: JWT_SECRET_KEY must be set to a non-default value)*

------
https://chatgpt.com/codex/tasks/task_e_685b5662f4648320b726517f5ec6232e