### PR TITLE
Skip Vale check when unavailable

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,8 @@ All notable changes to this project will be recorded in this file.
 - Documented where to download the `pytest-results.xml` artifact in the doc-quality onboarding guide.
 - LanguageTool checks now skip files that exceed the request size limit instead of failing.
 - LanguageTool script now emits GitHub error annotations and exits with a non-zero code when issues are found.
+- `scripts/check_docs.sh` now skips the Vale check with a warning when the binary cannot be downloaded or executed.
+- Documented how to install Vale manually when network access is restricted.
 - Documented committing the lockfile in the README and frontend README.
 - Documented starting the frontend with `npm install` (or `pnpm install`) and `npm run dev`.
 - Added `scripts/generate-secrets.sh` and a Makefile for generating throwaway secrets before starting Compose.

--- a/docs/README.md
+++ b/docs/README.md
@@ -108,6 +108,9 @@ See [doc-quality-onboarding.md](doc-quality-onboarding.md) for a step-by-step gu
 
 - Run `bash scripts/check_docs.sh` before pushing any changes.
 - Install Vale with `brew install vale` or see the [Vale installation docs](https://vale.sh/docs/installation/).
+- If your network blocks direct downloads, fetch the latest Vale release from
+  `https://github.com/errata-ai/vale/releases` on another machine and copy the
+  `vale` binary to a directory in your `PATH`.
 - Install Python dev dependencies with `pip install -r requirements-dev.txt`.
 - Set `LANGUAGETOOL_URL` if you use a self-hosted LanguageTool server. See the [LanguageTool HTTP server guide](https://dev.languagetool.org/http-server).
 

--- a/scripts/check_docs.sh
+++ b/scripts/check_docs.sh
@@ -4,13 +4,27 @@ set -euo pipefail
 FILES=$(git ls-files '*.md')
 RESULTS_FILE="vale-results.json"
 
+# Try to locate or download Vale
+VALE_CMD="vale"
 if ! command -v vale >/dev/null 2>&1; then
-  echo "::error file=scripts/check_docs.sh,line=$LINENO::Vale not installed"
-  exit 1
+  echo "Vale not found; attempting download..."
+  VALE_URL="https://github.com/errata-ai/vale/releases/latest/download/vale_Linux_amd64.tar.gz"
+  if curl -fsSL "$VALE_URL" | tar xz >/dev/null 2>&1; then
+    chmod +x vale
+    VALE_CMD="./vale"
+  else
+    echo "::warning file=scripts/check_docs.sh,line=$LINENO::Vale unavailable; skipping documentation style check"
+    exit 0
+  fi
+fi
+
+if ! "$VALE_CMD" --version >/dev/null 2>&1; then
+  echo "::warning file=scripts/check_docs.sh,line=$LINENO::Vale failed to run; skipping documentation style check"
+  exit 0
 fi
 
 set +e
-vale --output=JSON $FILES > "$RESULTS_FILE"
+"$VALE_CMD" --output=JSON $FILES > "$RESULTS_FILE"
 status=$?
 set -e
 if [ $status -ne 0 ]; then


### PR DESCRIPTION
## Summary
- try downloading Vale in `scripts/check_docs.sh`
- skip the Vale step with a warning if it can't be fetched or executed
- note how to manually install Vale in `docs/README.md`
- record the change in `docs/CHANGELOG.md`

## Testing
- `pytest -q`
- `bash scripts/check_docs.sh` *(fails: LanguageTool issues found)*

------
https://chatgpt.com/codex/tasks/task_e_685b6842bb5883209e48c8bedb52b4d2