### PR TITLE
Document dev requirements before running tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: deps gen-secrets up
+.PHONY: deps gen-secrets up test
 
 deps:
 	docker compose -f docker-compose.dev.yaml build
@@ -7,4 +7,7 @@ gen-secrets:
 	./scripts/generate-secrets.sh
 
 up: gen-secrets deps
-	docker compose -f docker-compose.dev.yaml up
+        docker compose -f docker-compose.dev.yaml up
+
+test:
+	bash scripts/run_tests.sh

--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ First install Docker, Docker Compose, Node.js 20, and Python 3.12. See [docs/ubu
    The services launch using the commands defined in the compose file.
 6. Run `alembic upgrade head` to create the initial tables.
 7. Execute the tests using `pytest -q`.
+   If `pytest` is not available, first run `pip install -r requirements-dev.txt`.
+   You can also run `make test` to install missing dependencies automatically.
 
 ## License
 This project is licensed under the MIT License. See LICENSE.md.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,8 @@ All notable changes to this project will be recorded in this file.
 - CI workflow now records pytest results and uploads them as an artifact.
 - CI workflow now uses `actions/upload-artifact@v4`.
 - Documented where to download the `pytest-results.xml` artifact in the doc-quality onboarding guide.
+- Added a `make test` target that installs dev requirements before running tests.
+- Documented installing `requirements-dev.txt` prior to running `pytest`.
 - LanguageTool checks now skip files that exceed the request size limit instead of failing.
 - LanguageTool script now emits GitHub error annotations and exits with a non-zero code when issues are found.
 - `scripts/check_docs.sh` now skips the Vale check with a warning when the binary cannot be downloaded or executed.

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,7 @@ If you're setting up a fresh Ubuntu machine, follow [ubuntu-setup.md](ubuntu-set
    and `curl http://localhost:8001/api/user/level`.
 12. Stop services with `docker compose -f docker-compose.dev.yaml --env-file .env.dev down`.
 13. Verify changes with `ruff check .`, `pytest -q`, and `npm test` from the `bot/` directory before committing.
+    If the `pytest` command is missing, run `pip install -r requirements-dev.txt` first or execute `make test`.
 14. Install git hooks with `pre-commit install` so these checks run automatically.
 15. Lint all Markdown docs with `./scripts/check_docs.sh` before pushing.
     This script uses **Vale** for style and **LanguageTool** for grammar.

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Ensure development requirements are installed
+if ! command -v pytest >/dev/null 2>&1; then
+    echo "Installing dev requirements..."
+    pip install -r requirements-dev.txt
+fi
+
+ruff check .
+pytest -q
+if [ -d bot ] && [ -f bot/package.json ]; then
+    (cd bot && npm test)
+fi


### PR DESCRIPTION
## Summary
- note that tests require development dependencies
- add `make test` wrapper around a new `scripts/run_tests.sh`

## Testing
- `ruff check .`
- `pytest -q`
- `bash scripts/check_docs.sh` *(fails: LanguageTool issues found)*

------
https://chatgpt.com/codex/tasks/task_e_685b734e003883209ae1df465ac96dc8