### PR TITLE
Add migration helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ First install Docker, Docker Compose, Node.js 20, and Python 3.12. See [docs/ubu
 5. Start the services with `make up` or run
    `docker compose -f docker-compose.dev.yaml --env-file .env.dev up -d`.
    The services launch using the commands defined in the compose file.
-6. Run `alembic upgrade head` to create the initial tables.
+6. Run `bash scripts/run_migrations.sh` to create the initial tables.
 7. Execute the tests using `pytest -q`.
    If `pytest` is not available, first run `pip install -r requirements-dev.txt`.
    You can also run `make test` to install missing dependencies automatically.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be recorded in this file.
 
 ## [Unreleased]
 
+- Added `scripts/run_migrations.sh` for running `alembic upgrade head` and
+  updated onboarding docs to reference it.
+
 - Added Dockerfiles for the bot and frontend and updated `docker-compose.dev.yaml` to build them.
 - Documented Ubuntu commands for installing Docker, Docker Compose, Node.js 20, and Python 3.12. Linked the setup guide from the README quickstart.
 - CI workflow now builds service containers before starting Compose.

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,7 +18,7 @@ If you're setting up a fresh Ubuntu machine, follow [ubuntu-setup.md](ubuntu-set
    `docker compose -f docker-compose.dev.yaml --env-file .env.dev up -d`.
    This launches the auth, bot, XP API, frontend, and Postgres services.
    The `frontend/` folder now hosts a React app built with Vite.
-6. Run `alembic upgrade head` to apply the initial database migration.
+6. Run `bash scripts/run_migrations.sh` to apply the initial database migration.
 7. Alternatively, run `devonboarder-server` to start the app without Docker. Stop it with Ctrl+C.
 8. Visit `http://localhost:8000` to see the greeting server.
 9. Run `devonboarder-api` to start the user API at `http://localhost:8001`.

--- a/scripts/run_migrations.sh
+++ b/scripts/run_migrations.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v alembic >/dev/null 2>&1; then
+    echo "Alembic not installed. Install dependencies with 'pip install -r requirements-dev.txt'"
+    exit 1
+fi
+
+alembic upgrade head


### PR DESCRIPTION
## Summary
- add `scripts/run_migrations.sh` wrapper
- reference the new script in onboarding docs
- record change in the changelog

## Testing
- `ruff check .`
- `pytest -q`
- `bash scripts/check_docs.sh` *(fails: LanguageTool issues found)*

------
https://chatgpt.com/codex/tasks/task_e_685b761382c08320be117af8b24d218c