### PR TITLE
Pin Vale version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
 jobs:
     test:
         runs-on: ubuntu-latest
+        env:
+            VALE_VERSION: 3.4.2
 
         steps:
             - uses: actions/checkout@v3
@@ -38,7 +40,7 @@ jobs:
               run: ruff check --output-format=github .
             - name: Install Vale
               run: |
-                curl -fsSL https://github.com/errata-ai/vale/releases/latest/download/vale_Linux_amd64.tar.gz | tar xz
+                curl -fsSL https://github.com/errata-ai/vale/releases/download/v${VALE_VERSION}/vale_${VALE_VERSION}_Linux_64-bit.tar.gz | tar xz
                 sudo mv vale /usr/local/bin/
             - name: Documentation style check
               run: ./scripts/check_docs.sh

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be recorded in this file.
 - Documented Ubuntu commands for installing Docker, Docker Compose, Node.js 20, and Python 3.12. Linked the setup guide from the README quickstart.
 - CI workflow now builds service containers before starting Compose.
 - CI workflow installs Vale automatically before documentation checks.
+- Pinned Vale version to 3.4.2 in CI, documentation, and scripts.
 - Added `/health` endpoints for auth and XP services with compose and CI healthchecks.
 - Confirmed all Docker healthchecks and CI wait steps use `/health` instead of the deprecated `/healthz` path.
 - Generated `frontend/package-lock.json` to pin npm dependencies.

--- a/docs/README.md
+++ b/docs/README.md
@@ -108,8 +108,9 @@ All Markdown files must pass Vale and LanguageTool checks.
 See [doc-quality-onboarding.md](doc-quality-onboarding.md) for a step-by-step guide.
 
 - Run `bash scripts/check_docs.sh` before pushing any changes.
-- Install Vale with `brew install vale` or see the [Vale installation docs](https://vale.sh/docs/installation/).
-- If your network blocks direct downloads, fetch the latest Vale release from
+- Install Vale (version 3.4.2) with `brew install vale` or download it from the
+  [Vale releases page](https://github.com/errata-ai/vale/releases).
+- If your network blocks direct downloads, fetch version 3.4.2 from
   `https://github.com/errata-ai/vale/releases` on another machine and copy the
   `vale` binary to a directory in your `PATH`.
 - Install Python dev dependencies with `pip install -r requirements-dev.txt`.

--- a/docs/doc-quality-onboarding.md
+++ b/docs/doc-quality-onboarding.md
@@ -24,7 +24,7 @@ pip install -r requirements-dev.txt
 * On macOS: `brew install vale`
 * On Windows: `choco install vale`
 * Or see [Vale Installation Docs](https://vale.sh/docs/installation/) for other platforms
-* **CI automatically installs Vale**, but you still need it locally to run the checks before committing.
+* **The project uses Vale 3.4.2. CI installs this version automatically**, but you still need it locally to run the checks before committing.
 
 ---
 

--- a/scripts/check_docs.sh
+++ b/scripts/check_docs.sh
@@ -6,9 +6,12 @@ RESULTS_FILE="vale-results.json"
 
 # Try to locate or download Vale
 VALE_CMD="vale"
+# Allow overriding the version; default to 3.4.2
+VALE_VERSION="${VALE_VERSION:-3.4.2}"
+
 if ! command -v vale >/dev/null 2>&1; then
-  echo "Vale not found; attempting download..."
-  VALE_URL="https://github.com/errata-ai/vale/releases/latest/download/vale_Linux_amd64.tar.gz"
+  echo "Vale not found; attempting download of version $VALE_VERSION..."
+  VALE_URL="https://github.com/errata-ai/vale/releases/download/v${VALE_VERSION}/vale_${VALE_VERSION}_Linux_64-bit.tar.gz"
   if curl -fsSL "$VALE_URL" | tar xz >/dev/null 2>&1; then
     chmod +x vale
     VALE_CMD="./vale"


### PR DESCRIPTION
## Summary
- allow specifying Vale version with `VALE_VERSION` (default 3.4.2)
- use the same Vale version in CI
- document the pinned version in onboarding docs
- record Vale pin in the changelog

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b7977bdf883209012552c3c322531