### PR TITLE
Add project statement to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,13 @@
 This repository showcases a **trunk-based** workflow and a minimal
 container setup used by Codex.
 
+### 🔧 **Project Statement**
+
+> *"This project wasn’t built to impress — it was built to work. Quietly. Reliably. And in service of those who need it."*
+
+*Designed to automate onboarding, reduce friction, and support developers building from the ground up.*
+
+
 ## Trunk-Based Workflow
 
 - All stable code lives in the `main` branch.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be recorded in this file.
 
 ## [Unreleased]
 
+- Added a "Project Statement" section to the README highlighting the project's purpose.
 - Added `scripts/run_migrations.sh` for running `alembic upgrade head` and
   updated onboarding docs to reference it.
 


### PR DESCRIPTION
## Summary
- add "Project Statement" to README
- log the addition in the changelog

## Testing
- `ruff check .`
- `APP_ENV=development pytest -q`
- `bash scripts/check_docs.sh` *(fails: possible doc issues)*

------
https://chatgpt.com/codex/tasks/task_e_685b7bb68bd88320ab234d25c128ebb0