### PR TITLE
chore: require Python 3.13

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -225,6 +225,7 @@ All notable changes to this project will be recorded in this file.
 - Updated development tooling to stable versions and pinned the Vale download
   tag in CI for reproducibility.
 - Updated Node to 22 and Python to 3.13 across Dockerfiles, compose files, CI, and documentation.
+- Required Python 3.13 in `pyproject.toml` and ruff configuration.
 
 ## [0.1.0] - 2025-06-14
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.ruff]
 line-length = 88
-target-version = "py312"
+target-version = "py313"
 
 [tool.ruff.lint]
 select = ["E", "F"]
@@ -10,7 +10,7 @@ name = "devonboarder"
 version = "0.1.0"
 description = "Sample trunk-based workflow project"
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.13"
 dependencies = [
     "httpx<0.29",
     "fastapi",


### PR DESCRIPTION
## Summary
- bump `requires-python` to 3.13
- target ruff to py313

## Testing
- `ruff check .`
- `pytest -q`
- `bash scripts/check_docs.sh` *(fails: Vale failed to run)*

------
https://chatgpt.com/codex/tasks/task_e_685b8794b7b88320a0f7ebe257012643