### PR TITLE
Ensure env vars set before importing dev modules

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -228,6 +228,8 @@ All notable changes to this project will be recorded in this file.
 - Updated Node to 22 and Python to 3.13 across Dockerfiles, compose files, CI, and documentation.
 - Required Python 3.13 in `pyproject.toml` and ruff configuration.
 - Fixed the Vale download path in CI to resolve a 404 error.
+- Ensured tests set `APP_ENV` and `JWT_SECRET_KEY` before importing modules from
+  `devonboarder`.
 
 ## [0.1.0] - 2025-06-14
 

--- a/tests/test_auth_service.py
+++ b/tests/test_auth_service.py
@@ -1,5 +1,9 @@
 import importlib
 import os
+# Environment variables must be set before importing modules from devonboarder.
+os.environ.setdefault("APP_ENV", "development")
+os.environ.setdefault("JWT_SECRET_KEY", "devsecret")
+
 from fastapi.testclient import TestClient
 from devonboarder import auth_service
 from utils import roles as roles_utils
@@ -8,9 +12,6 @@ import pytest
 import time
 import sqlalchemy
 import httpx
-
-os.environ.setdefault("APP_ENV", "development")
-os.environ.setdefault("JWT_SECRET_KEY", "devsecret")
 
 
 def setup_function(function):

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,10 +1,11 @@
-from fastapi.testclient import TestClient
 import os
-from devonboarder.auth_service import create_app as create_auth_app
-from devonboarder.xp_api import create_app as create_xp_app
-
+# Environment variables must be set before importing modules from devonboarder.
 os.environ.setdefault("APP_ENV", "development")
 os.environ.setdefault("JWT_SECRET_KEY", "devsecret")
+
+from fastapi.testclient import TestClient
+from devonboarder.auth_service import create_app as create_auth_app
+from devonboarder.xp_api import create_app as create_xp_app
 
 
 def test_auth_health():

--- a/tests/test_xp_api.py
+++ b/tests/test_xp_api.py
@@ -1,10 +1,11 @@
-from devonboarder.xp_api import create_app
 import os
-from devonboarder import auth_service
-from fastapi.testclient import TestClient
-
+# Environment variables must be set before importing modules from devonboarder.
 os.environ.setdefault("APP_ENV", "development")
 os.environ.setdefault("JWT_SECRET_KEY", "devsecret")
+
+from devonboarder.xp_api import create_app
+from devonboarder import auth_service
+from fastapi.testclient import TestClient
 
 
 def setup_function(function):


### PR DESCRIPTION
## Summary
- fix import order in tests so `APP_ENV` and `JWT_SECRET_KEY` are set before loading devonboarder modules
- document the test requirement in the changelog

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b98fdb6248320b29b658985346ff7