### PR TITLE
Improve doc lint workflow guidance

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -228,6 +228,9 @@ All notable changes to this project will be recorded in this file.
 - Updated Node to 22 and Python to 3.13 across Dockerfiles, compose files, CI, and documentation.
 - Required Python 3.13 in `pyproject.toml` and ruff configuration.
 - Fixed the Vale download path in CI to resolve a 404 error.
+- Documented batch doc fixes with `codespell` and Prettier in the doc-quality onboarding guide.
+- Added a reminder in `docs/merge-checklist.md` to keep `scripts/check_docs.sh` passing.
+- Added `docs/tasks/doc_lint_debt.md` as a template issue for documentation lint backlog.
 
 ## [0.1.0] - 2025-06-14
 

--- a/docs/doc-quality-onboarding.md
+++ b/docs/doc-quality-onboarding.md
@@ -72,6 +72,21 @@ pre-commit install
 
 ---
 
+### Batch‑Fixing Documentation
+
+When many files share typos or inconsistent formatting, fix them in bulk:
+
+```bash
+codespell -w docs/
+npx prettier -w "docs/**/*.md"
+bash scripts/check_docs.sh
+```
+
+Check the results carefully and create **small, focused pull requests** so each
+one is easy to review and merge without conflicts.
+
+---
+
 ### Troubleshooting
 
 * **Vale not found:** install it as shown above.

--- a/docs/merge-checklist.md
+++ b/docs/merge-checklist.md
@@ -7,3 +7,6 @@ Reviewers must verify the following before merging a pull request:
 - [ ] Documentation in `docs/` is updated as needed.
 - [ ] Documentation passes `bash scripts/check_docs.sh`.
 - [ ] The pull request contains a completed reviewer sign-off section.
+
+After merging large documentation updates, run `bash scripts/check_docs.sh`
+locally to ensure the main branch remains lint-free.

--- a/docs/tasks/doc_lint_debt.md
+++ b/docs/tasks/doc_lint_debt.md
@@ -1,0 +1,13 @@
+# Documentation Lint Debt
+
+This issue tracks Markdown files that still fail `scripts/check_docs.sh`.
+Use it when batch-fixing docs.
+
+## How to Help
+
+1. Follow the steps in [doc-quality-onboarding.md](../doc-quality-onboarding.md).
+2. Run `codespell -w docs/` and `npx prettier -w "docs/**/*.md"`.
+3. Re-run `bash scripts/check_docs.sh` and commit the fixes.
+4. Open a small pull request targeting a few files at a time.
+
+Add notes below about any tricky files or skipped warnings.


### PR DESCRIPTION
## Summary
- document how to batch-fix docs with codespell and Prettier
- remind maintainers to keep `scripts/check_docs.sh` passing
- add a template issue for tracking doc lint debt
- record changes in the changelog

## Testing
- `bash scripts/check_docs.sh`
- `JWT_SECRET_KEY=devsecret bash scripts/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_685b9d5dc2e88320bed94a637bec2d79