### PR TITLE
Add CI monitoring policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,3 +22,10 @@ This repository follows the DevOnboarder protocol. Key points:
 4. **Contribution Guidelines**
 - Keep pull requests focused and small.
 - Update documentation and the changelog with each change.
+
+## Codex CI Monitoring Policy
+
+The `codex.ci.yml` workflow watches every CI job and step. When a failure
+occurs, Codex automatically opens a task describing the error so maintainers can
+investigate. The bot retries the build once and includes logs in the task if the
+second attempt fails.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -233,6 +233,7 @@ All notable changes to this project will be recorded in this file.
 - Added `docs/tasks/doc_lint_debt.md` as a template issue for documentation lint backlog.
 - Ensured tests set `APP_ENV` and `JWT_SECRET_KEY` before importing modules from
   `devonboarder`.
+- Documented Codex CI Monitoring Policy and linked it from the onboarding guide.
 
 ## [0.1.0] - 2025-06-14
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -123,3 +123,4 @@ See [doc-quality-onboarding.md](doc-quality-onboarding.md) for a step-by-step gu
 2. Start branches from the latest `main` and follow the git guidelines.
 3. Use the pull request template and ensure the checklist passes.
 4. Review [sample-pr.md](sample-pr.md) for an end-to-end example.
+5. See the Codex CI Monitoring Policy in [../AGENTS.md](../AGENTS.md) for how failed CI jobs automatically create tasks.


### PR DESCRIPTION
## Summary
- document Codex CI Monitoring Policy
- reference policy from onboarding docs

## Testing
- `ruff check .`
- `pytest -q`
- `npm test`
- `bash scripts/check_docs.sh` *(fails: Vale unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_685b9fe3686c83208dc1c46c2c3f6d11