### PR TITLE
Improve offline doc lint instructions

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be recorded in this file.
 - LanguageTool script now emits GitHub error annotations and exits with a non-zero code when issues are found.
 - `scripts/check_docs.sh` now skips the Vale check with a warning when the binary cannot be downloaded or executed.
 - Documented how to install Vale manually when network access is restricted.
+- Added offline instructions for manual Vale installation and running LanguageTool locally.
 - Added `docs/network-troubleshooting.md` with tips for working behind restricted networks.
 - Documented committing the lockfile in the README and frontend README.
 - Documented starting the frontend with `npm install` (or `pnpm install`) and `npm run dev`.

--- a/docs/doc-quality-onboarding.md
+++ b/docs/doc-quality-onboarding.md
@@ -24,17 +24,25 @@ pip install -r requirements-dev.txt
 * On macOS: `brew install vale`
 * On Windows: `choco install vale`
 * Or see [Vale Installation Docs](https://vale.sh/docs/installation/) for other platforms
+* If the script cannot download Vale automatically, manually download `vale_3.4.2_Linux_64-bit.tar.gz` from the [releases page](https://github.com/errata-ai/vale/releases), extract the `vale` binary, and set `VALE_BINARY` to its path.
 * **The project uses Vale 3.4.2. CI installs this version automatically**, but you still need it locally to run the checks before committing.
 
 ---
 
 ### Step 3: (Optional) Set Up Local LanguageTool Server
 
-By default the project uses the public LanguageTool API, but CI or firewalls may block it. For local use:
+By default the project uses the public LanguageTool API, but CI or firewalls may block it. For local use or when offline:
 
 ```bash
 docker run -d -p 8010:8010 --name languagetool \
   quay.io/languagetool/languagetool:latest
+export LANGUAGETOOL_URL="http://localhost:8010"
+```
+
+You can also download a LanguageTool release from <https://languagetool.org/download/> and run it with Java:
+
+```bash
+java -jar languagetool-server.jar --port 8010 &
 export LANGUAGETOOL_URL="http://localhost:8010"
 ```
 
@@ -89,9 +97,9 @@ one is easy to review and merge without conflicts.
 
 ### Troubleshooting
 
-* **Vale not found:** install it as shown above.
+* **Vale not found:** install it as shown above or download the binary manually and set `VALE_BINARY` to its path.
 * **Python errors:** ensure `pip install -r requirements-dev.txt` succeeded.
-* **LanguageTool API issues:** run a local server and set `LANGUAGETOOL_URL`.
+* **LanguageTool API issues:** run a local server and set `LANGUAGETOOL_URL` to its address.
 * **pytest fails:** double-check that all dev dependencies are installed.
 
 ---

--- a/scripts/check_docs.sh
+++ b/scripts/check_docs.sh
@@ -5,24 +5,24 @@ FILES=$(git ls-files '*.md')
 RESULTS_FILE="vale-results.json"
 
 # Try to locate or download Vale
-VALE_CMD="vale"
+VALE_CMD="${VALE_BINARY:-vale}"
 # Allow overriding the version; default to 3.4.2
 VALE_VERSION="${VALE_VERSION:-3.4.2}"
 
-if ! command -v vale >/dev/null 2>&1; then
+if ! command -v "$VALE_CMD" >/dev/null 2>&1; then
   echo "Vale not found; attempting download of version $VALE_VERSION..."
   VALE_URL="https://github.com/errata-ai/vale/releases/download/v${VALE_VERSION}/vale_${VALE_VERSION}_Linux_64-bit.tar.gz"
   if curl -fsSL "$VALE_URL" | tar xz >/dev/null 2>&1; then
     chmod +x vale
     VALE_CMD="./vale"
   else
-    echo "::warning file=scripts/check_docs.sh,line=$LINENO::Vale unavailable; skipping documentation style check"
+    echo "::warning file=scripts/check_docs.sh,line=$LINENO::Unable to download Vale. Install version $VALE_VERSION manually and set VALE_BINARY to its path. Skipping documentation style check"
     exit 0
   fi
 fi
 
 if ! "$VALE_CMD" --version >/dev/null 2>&1; then
-  echo "::warning file=scripts/check_docs.sh,line=$LINENO::Vale failed to run; skipping documentation style check"
+  echo "::warning file=scripts/check_docs.sh,line=$LINENO::Vale failed to run. Install version $VALE_VERSION and set VALE_BINARY if necessary. Skipping documentation style check"
   exit 0
 fi
 
@@ -36,7 +36,12 @@ if [ $status -ne 0 ]; then
   exit $status
 fi
 
-if ! python scripts/languagetool_check.py $FILES; then
+lt_status=0
+python scripts/languagetool_check.py $FILES || lt_status=$?
+if [ $lt_status -eq 2 ]; then
+  echo "::warning file=scripts/check_docs.sh,line=$LINENO::LanguageTool unavailable. Run a local server and set LANGUAGETOOL_URL."
+  exit 0
+elif [ $lt_status -ne 0 ]; then
   echo "::error file=scripts/check_docs.sh,line=$LINENO::LanguageTool issues found"
-  exit 1
+  exit $lt_status
 fi


### PR DESCRIPTION
## Summary
- clarify manual Vale install and local LanguageTool usage
- warn in `check_docs.sh` when download fails and suggest fallbacks
- note offline steps in the changelog

## Testing
- `bash scripts/check_docs.sh` *(fails: Vale failed to run)*
- `bash scripts/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_685ba2408acc8320908ebccfe02c5e49