### PR TITLE
Add offline setup guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ This repository follows the DevOnboarder protocol. Key points:
 - Pull request template: `docs/pull_request_template.md`.
 - Maintainer merge checklist: `docs/merge-checklist.md`.
 - Project changelog: `docs/CHANGELOG.md`.
+- Offline setup instructions: `docs/offline-setup.md`.
 
 3. **Development Environment**
 - Use the provided container setup and compose files for local development.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be recorded in this file.
 
 ## [Unreleased]
 
+- Added `docs/offline-setup.md` explaining how to install dependencies without internet access and linked it from the onboarding docs.
 - Added a "Project Statement" section to the README highlighting the project's purpose.
 - Added `scripts/run_migrations.sh` for running `alembic upgrade head` and
   updated onboarding docs to reference it.

--- a/docs/README.md
+++ b/docs/README.md
@@ -63,6 +63,7 @@ platforms. Please report any issues you encounter on your operating system.
 - [Changelog](CHANGELOG.md) &ndash; record notable updates for each release.
 - [Doc QA onboarding](doc-quality-onboarding.md) &ndash; quickstart for documentation checks.
 - [Network troubleshooting](network-troubleshooting.md) &ndash; tips for working around network restrictions.
+- [Offline setup](offline-setup.md) &ndash; download Python wheels and npm packages on another machine.
 - [Security audit](security-audit-2025-06-21.md) &ndash; latest dependency check results.
 - [Environment variables](env.md) &ndash; explanation of `.env` settings and the role-based permission system.
 - [Alpha tester onboarding](alpha/README.md) &ndash; guide for early testers.

--- a/docs/offline-setup.md
+++ b/docs/offline-setup.md
@@ -1,0 +1,41 @@
+# Offline Setup
+
+Some environments block direct access to package registries. Use another machine with internet access to download the files and copy them to your development system.
+
+## Python wheels
+
+1. On a machine with internet access, download the required wheels:
+
+   ```bash
+   mkdir -p ~/devonboarder-offline/python
+   pip download -r requirements-dev.txt -d ~/devonboarder-offline/python
+   ```
+
+2. Transfer the `devonboarder-offline` folder to your offline machine (USB drive or internal share).
+
+3. Install the packages locally:
+
+   ```bash
+   pip install --no-index --find-links=/path/to/devonboarder-offline/python -r requirements-dev.txt
+   ```
+
+## npm packages
+
+1. On the online machine, prime an npm cache:
+
+   ```bash
+   mkdir -p ~/devonboarder-offline/npm
+   cd frontend
+   npm ci --cache ~/devonboarder-offline/npm
+   ```
+
+2. Copy the `devonboarder-offline` folder to your offline machine.
+
+3. Install dependencies from the cache:
+
+   ```bash
+   cd frontend
+   npm ci --offline --cache /path/to/devonboarder-offline/npm
+   ```
+
+After installing dependencies, run the usual setup commands such as `make deps` or `pre-commit install`.


### PR DESCRIPTION
## Summary
- document how to install Python and npm dependencies without internet access
- link new guide from onboarding docs
- mention offline instructions in AGENTS file
- record change in changelog

## Testing
- `ruff check .`
- `pytest -q`
- `bash scripts/check_docs.sh` *(fails: Vale failed to run)*

------
https://chatgpt.com/codex/tasks/task_e_685ba45c13808320b6c21cf8c21b6353