### PR TITLE
Update Vale ignore options

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -3,3 +3,5 @@ MinAlertLevel = warning
 
 [*.md]
 BasedOnStyles = DevOnboarder
+TokenIgnores = CODE, YAMLCODE, HTML, URL, NUMBER
+IgnorePatterns = (?s)^```[\s\S]+?```$, (?m)^ {4}.+, (?s)^---[\s\S]+?---\n, (?s)^```auto-gen[\s\S]+?```$

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -236,6 +236,7 @@ All notable changes to this project will be recorded in this file.
 - Ensured tests set `APP_ENV` and `JWT_SECRET_KEY` before importing modules from
   `devonboarder`.
 - Documented Codex CI Monitoring Policy and linked it from the onboarding guide.
+- Added ignore patterns and token filters to `.vale.ini` to skip code blocks and frontmatter.
 
 ## [0.1.0] - 2025-06-14
 


### PR DESCRIPTION
## Summary
- ignore code sections in Vale and register auto-gen fences
- document the Vale changes

## Testing
- `ruff check .`
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685ba866f7e48320aefc408d7efde0e0