### PR TITLE
Add codespell pre-commit hook

### DIFF
--- a/.codespell-ignore
+++ b/.codespell-ignore
@@ -1,0 +1,3 @@
+DevOnboarder
+nodeenv
+pyenv

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,12 @@ repos:
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.1
+    hooks:
+      - id: codespell
+        files: '\.(md|txt|rst)$'
+        args: ['--ignore-words=.codespell-ignore']
   - repo: local
     hooks:
       - id: docs-quality

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to this project will be recorded in this file.
 - Documented Ubuntu commands for installing Docker, Docker Compose, Node.js 20, and Python 3.12. Linked the setup guide from the README quickstart.
 - CI workflow now builds service containers before starting Compose.
 - CI workflow installs Vale automatically before documentation checks.
+- Added `codespell` pre-commit hook for Markdown and text files.
+- Codespell ignore list covers `DevOnboarder`, `nodeenv`, and `pyenv`.
 - Pinned Vale version to 3.4.2 in CI, documentation, and scripts.
 - Added `/health` endpoints for auth and XP services with compose and CI healthchecks.
 - Confirmed all Docker healthchecks and CI wait steps use `/health` instead of the deprecated `/healthz` path.

--- a/docs/doc-quality-onboarding.md
+++ b/docs/doc-quality-onboarding.md
@@ -78,6 +78,10 @@ Install pre-commit hooks so documentation and code checks run automatically:
 pre-commit install
 ```
 
+The hooks run Black, Ruff, Prettier, Codespell, and our docs-quality script.
+Codespell relies on `.codespell-ignore` for project-specific terms you want to
+skip. The default list skips `DevOnboarder`, `nodeenv`, and `pyenv`.
+
 ---
 
 ### Batch‑Fixing Documentation


### PR DESCRIPTION
## Summary
- integrate codespell into pre-commit
- describe hook and ignore list in documentation
- note codespell ignore list in the changelog

## Testing
- `pre-commit run --files .pre-commit-config.yaml docs/CHANGELOG.md docs/doc-quality-onboarding.md .codespell-ignore` *(fails: certificate verify failed)*
- `bash scripts/run_tests.sh` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685babcb2700832097dc88d1f8ece045