### PR TITLE
Improve doc quality guide

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -239,6 +239,9 @@ All notable changes to this project will be recorded in this file.
   `devonboarder`.
 - Documented Codex CI Monitoring Policy and linked it from the onboarding guide.
 - Added ignore patterns and token filters to `.vale.ini` to skip code blocks and frontmatter.
+- Documented the new Vale ignore patterns and Codespell hook in
+  `docs/doc-quality-onboarding.md`, including how to disable Vale with
+  `<!-- vale off -->` / `<!-- vale on -->` and a reference to `.pre-commit-config.yaml`.
 
 ## [0.1.0] - 2025-06-14
 

--- a/docs/doc-quality-onboarding.md
+++ b/docs/doc-quality-onboarding.md
@@ -82,6 +82,15 @@ The hooks run Black, Ruff, Prettier, Codespell, and our docs-quality script.
 Codespell relies on `.codespell-ignore` for project-specific terms you want to
 skip. The default list skips `DevOnboarder`, `nodeenv`, and `pyenv`.
 
+### Vale Ignore Patterns & Codespell Hook
+
+The project now defines ignore patterns in `.vale.ini` to skip fenced code
+blocks, indented code, YAML frontmatter, and `auto-gen` sections. If a snippet
+still triggers warnings, wrap it between `<!-- vale off -->` and `<!-- vale on -->`.
+
+`.pre-commit-config.yaml` runs Vale and Codespell automatically once you execute
+`pre-commit install`, so every commit is checked for style issues and typos.
+
 ---
 
 ### Batch‑Fixing Documentation


### PR DESCRIPTION
## Summary
- document Vale ignore patterns and codespell hook
- mention how to disable Vale temporarily and point to `.pre-commit-config.yaml`

## Testing
- `bash scripts/check_docs.sh` *(fails: No module named 'language_tool_python')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'devonboarder')*

------
https://chatgpt.com/codex/tasks/task_e_685baf79ff348320a228ee14da451478