### PR TITLE
Add codespell ignore tip and nodeenv troubleshooting

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -242,6 +242,8 @@ All notable changes to this project will be recorded in this file.
 - Documented the new Vale ignore patterns and Codespell hook in
   `docs/doc-quality-onboarding.md`, including how to disable Vale with
   `<!-- vale off -->` / `<!-- vale on -->` and a reference to `.pre-commit-config.yaml`.
+- Documented how to add words to `.codespell-ignore`.
+- Added nodeenv SSL troubleshooting steps to `docs/network-troubleshooting.md`.
 
 ## [0.1.0] - 2025-06-14
 

--- a/docs/doc-quality-onboarding.md
+++ b/docs/doc-quality-onboarding.md
@@ -108,6 +108,14 @@ one is easy to review and merge without conflicts.
 
 ---
 
+### Adding New Codespell Ignore Terms
+
+If Codespell flags a project-specific word (for example, a brand or tool name),
+append it to `.codespell-ignore` in the repository root. Add one term per line
+and commit the change with your documentation update.
+
+---
+
 ### Troubleshooting
 
 * **Vale not found:** install it as shown above or download the binary manually and set `VALE_BINARY` to its path.

--- a/docs/network-troubleshooting.md
+++ b/docs/network-troubleshooting.md
@@ -22,3 +22,10 @@ Some development environments restrict outbound network traffic. These tips help
   npm config set registry <mirror-url>
   pip config set global.index-url <mirror-url>
   ```
+
+## pre-commit nodeenv SSL errors
+- The Prettier hook downloads Node.js using pre-commit's built-in nodeenv. Some
+  networks block this download or fail SSL verification.
+- Install Node.js 22 manually (see [ubuntu-setup.md](ubuntu-setup.md)) and set
+  `PRE_COMMIT_NO_INSTALL=1` so pre-commit uses your system Node instead.
+- Re-run `pre-commit install` after exporting the variable.


### PR DESCRIPTION
## Summary
- document how to add project-specific codespell terms
- document pre-commit nodeenv SSL workaround
- record these docs in the changelog

## Testing
- `bash scripts/check_docs.sh` *(fails: ModuleNotFoundError: No module named 'language_tool_python')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'devonboarder')*

------
https://chatgpt.com/codex/tasks/task_e_685bb0b98c8483209a5d3ede0e4d119a