### PR TITLE
Add About Potato Easter Egg

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be recorded in this file.
 - Added a "Project Statement" section to the README highlighting the project's purpose.
 - Added `scripts/run_migrations.sh` for running `alembic upgrade head` and
   updated onboarding docs to reference it.
+- Added `docs/about-potato.md` describing the Potato origin story and Easter egg.
+- Linked `docs/about-potato.md` from the documentation README.
 
 - Added Dockerfiles for the bot and frontend and updated `docker-compose.dev.yaml` to build them.
 - Documented Ubuntu commands for installing Docker, Docker Compose, Node.js 20, and Python 3.12. Linked the setup guide from the README quickstart.

--- a/docs/README.md
+++ b/docs/README.md
@@ -59,6 +59,7 @@ platforms. Please report any issues you encounter on your operating system.
 - [Git guidelines](git-guidelines.md) &ndash; branch naming, commit messages and the pre‑PR checklist.
 - [Pull request template](pull_request_template.md) &ndash; describe your changes and verify the checklist.
 - [Sample pull request](sample-pr.md) &ndash; walkthrough of a minimal docs update.
+- [About Potato](about-potato.md) &ndash; the playful backstory of our root vegetable mascot.
 - [Merge checklist](merge-checklist.md) &ndash; steps maintainers use before merging.
 - [Changelog](CHANGELOG.md) &ndash; record notable updates for each release.
 - [Doc QA onboarding](doc-quality-onboarding.md) &ndash; quickstart for documentation checks.

--- a/docs/about-potato.md
+++ b/docs/about-potato.md
@@ -1,0 +1,26 @@
+## 🥔 About Potato
+
+**Potato** isn’t just a root vegetable—it’s the heart and legend of this project. “Potato” honors the founder’s unique spirit and the original spark behind DevOnboarder. From humble beginnings, the Potato has been woven into every phase of the workflow: immortalized in `.gitignore`, `.dockerignore`, `.codespell-ignore`, and more.
+
+### Why Potato?
+
+* **A Running Joke**
+  What started as an inside joke soon became a symbol of creativity, humility, and perseverance in our engineering culture.
+* **A Guardian**
+  The presence of “Potato” and `Potato.md` in our ignore files reminds us never to take ourselves too seriously—and that every line of code carries a bit of our team’s story.
+* **A Check**
+  Our CI pipeline and pre-commit hooks protect Potato’s legacy, ensuring it is never accidentally removed and continues to travel with every branch, PR, and release.
+
+---
+
+### 🥚 Easter Egg: Who *is* Potato?
+
+Nobody knows for sure.
+Is Potato a mischievous mascot?
+A legendary coder who once hot-fixed production at midnight?
+Or just a humble vegetable with a dream?
+
+All we know is:
+**If you spot the Potato, you’re on the right path.**
+
+*(P.S. There might be a secret channel named after Potato. Ask a maintainer if you dare!)*


### PR DESCRIPTION
## Summary
- document the mythical Potato mascot in a new About Potato page
- link the new page from docs README
- log the addition in CHANGELOG

## Testing
- `ruff check .`
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685bd372bf088320afc77a10bf96a378