### PR TITLE
Add Codex QA sweep instructions

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be recorded in this file.
   updated onboarding docs to reference it.
 - Added `docs/about-potato.md` describing the Potato origin story and Easter egg.
 - Linked `docs/about-potato.md` from the documentation README.
+- Documented how to request a full QA sweep with Codex using `@codex run full-qa` in `docs/ONBOARDING.md`.
 
 - Added Dockerfiles for the bot and frontend and updated `docker-compose.dev.yaml` to build them.
 - Documented Ubuntu commands for installing Docker, Docker Compose, Node.js 20, and Python 3.12. Linked the setup guide from the README quickstart.
@@ -271,3 +272,4 @@ All notable changes to this project will be recorded in this file.
 - Expanded `docs/pull_request_template.md` with sections for summary, linked issues, screenshots, testing steps, and a checklist referencing documentation and changelog updates. [#25](https://github.com/theangrygamershowproductions/DevOnboarder/pull/25)
 - Documented the requirement to pass lint and tests, update documentation and the changelog, and added a reviewer sign-off section to the pull request template. [#26](https://github.com/theangrygamershowproductions/DevOnboarder/pull/26)
 - Added `codex.ci.yml` to automate CI monitoring and fix failing builds.
+

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -1,0 +1,13 @@
+# Project Onboarding Guide
+
+This page collects helpful tips for new contributors. Follow [docs/README.md](README.md) for a complete development setup.
+
+## Requesting a Full QA Sweep
+
+Codex can run a comprehensive quality assessment of the repository. To trigger this check, comment on a pull request or issue with:
+
+```text
+@codex run full-qa
+```
+
+Codex will parse CI results, run additional analysis, and create tasks for any failures it finds. Merges are blocked until critical issues from the sweep are resolved.


### PR DESCRIPTION
## Summary
- document how to trigger a full QA sweep with Codex
- log the new docs in the changelog

## Testing
- `bash scripts/run_tests.sh` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `npx markdownlint docs/ONBOARDING.md` *(fails: could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_e_685bd70d7f808320bc337a7cc3768466