### PR TITLE
Clarify Codex QA instructions

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,10 @@ All notable changes to this project will be recorded in this file.
 - Added `docs/about-potato.md` describing the Potato origin story and Easter egg.
 - Linked `docs/about-potato.md` from the documentation README.
 - Documented how to request a full QA sweep with Codex using `@codex run full-qa` in `docs/ONBOARDING.md`.
+- Expanded the Codex QA instructions with troubleshooting tips and a Potato-themed Easter egg in `docs/ONBOARDING.md`.
+- Documented a sample QA response, randomized Easter egg reply, and the Vale/LanguageTool fallback policy.
+- Clarified where Codex posts QA results, added a "What happens next?" section, and noted that "⚠️ Docs: Lint skipped" doesn't block merges.
+- Refined the onboarding snippet to show a sample Codex QA response and referenced network troubleshooting and the Codex FAQ.
 
 - Added Dockerfiles for the bot and frontend and updated `docker-compose.dev.yaml` to build them.
 - Documented Ubuntu commands for installing Docker, Docker Compose, Node.js 20, and Python 3.12. Linked the setup guide from the README quickstart.

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -2,12 +2,49 @@
 
 This page collects helpful tips for new contributors. Follow [docs/README.md](README.md) for a complete development setup.
 
-## Requesting a Full QA Sweep
+## Requesting a Codex QA Assessment
 
-Codex can run a comprehensive quality assessment of the repository. To trigger this check, comment on a pull request or issue with:
+* **To trigger a full QA sweep:** Simply comment
 
-```text
-@codex run full-qa
+  ```
+  @codex run full-qa
+  ```
+
+  on any Pull Request or GitHub Issue.
+* **What this does:** Codex will analyze CI logs, code quality, test coverage, lint results, and documentation checks. It will reply with a **detailed checklist** of all issues it finds—each with actionable tasks you can assign, discuss, or address.
+* **Note:** You must resolve all critical issues before merging, per project policy.
+
+### Sample Codex QA Response
+
+After you comment `@codex run full-qa`, Codex replies directly to your comment with a checklist like:
+
+```
+- ❌ Lint: 3 Python files have PEP8 errors (see ruff logs)
+- ❌ Test: 1 backend test failed (see pytest-results.xml)
+- ⚠️ Docs: 12 Vale/LanguageTool warnings (docs/README.md)
+- ⚠️ Security: 1 dependency flagged by pip-audit
+- ✅ All workflows run with correct tool versions
 ```
 
-Codex will parse CI results, run additional analysis, and create tasks for any failures it finds. Merges are blocked until critical issues from the sweep are resolved.
+Each line links to the CI logs or artifacts so you can jump straight to the problem.
+
+### What happens next?
+
+Codex posts this checklist as a reply to your `@codex run full-qa` comment. If you see `⚠️ Docs: Lint skipped`, the documentation step failed (usually due to network issues). You may merge if all other checks pass, but run `bash scripts/check_docs.sh` locally when possible.
+
+For more help, see [Network troubleshooting](network-troubleshooting.md) and the Codex FAQ.
+
+**Troubleshooting:**
+If Codex does not respond, make sure:
+
+* Codex bot is installed and has permission to comment and create issues.
+* Workflow files (such as `.github/workflows/codex.ci.yml`) include `full-qa` as a supported command.
+
+### Optional Easter Egg (for fun!)
+
+You could add:
+
+> Want to know the secret identity of Potato?
+> Try commenting `@codex who-is-potato` in any issue for a surprise!
+
+Codex will reply with a short, Potato-themed message on the same thread. The bot rotates through a few quirky facts, so feel free to try again later for a different response!


### PR DESCRIPTION
## Summary
- add a sample Codex QA response to onboarding
- clarify where Codex posts QA results and link to troubleshooting
- record the change in the changelog

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `bash scripts/check_docs.sh` *(Vale download failed)*

------
https://chatgpt.com/codex/tasks/task_e_685bdc2da9548320a9b75b38d3b7eba6