### PR TITLE
Add CLI module docstring

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be recorded in this file.
 ## [Unreleased]
 
 - Added `docs/offline-setup.md` explaining how to install dependencies without internet access and linked it from the onboarding docs.
+- Added a module-level docstring to `src/devonboarder/cli.py` describing CLI usage.
 - Added a "Project Statement" section to the README highlighting the project's purpose.
 - Added `scripts/run_migrations.sh` for running `alembic upgrade head` and
   updated onboarding docs to reference it.

--- a/src/devonboarder/cli.py
+++ b/src/devonboarder/cli.py
@@ -1,3 +1,12 @@
+"""Command-line interface for DevOnboarder.
+
+Usage::
+
+    devonboarder [name]
+
+Prints a friendly greeting to ``name`` or ``World`` by default.
+"""
+
 import argparse
 
 from .app import greet


### PR DESCRIPTION
# Summary
- document DevOnboarder command-line interface usage
- note CLI docstring in changelog

# Linked Issues

# Screenshots

# Testing Steps
```bash
ruff check .
pytest -q
bash scripts/check_docs.sh
```


------
https://chatgpt.com/codex/tasks/task_e_685be86bfa848320b4a59ada84dc131d