### PR TITLE
Add routes package docstring

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -269,6 +269,7 @@ All notable changes to this project will be recorded in this file.
 - Documented how to add words to `.codespell-ignore`.
 - Added nodeenv SSL troubleshooting steps to `docs/network-troubleshooting.md`.
 - Rewrote the repository README with a concise introduction and quickstart linking to `docs/README.md` and removed Vale instructions.
+- Added a package docstring to `src/routes/__init__.py` summarizing the routes module.
 
 ## [0.1.0] - 2025-06-14
 

--- a/src/routes/__init__.py
+++ b/src/routes/__init__.py
@@ -1,0 +1,1 @@
+"""FastAPI API routes for the DevOnboarder application."""


### PR DESCRIPTION
## Summary
- document src.routes package
- log change in changelog

## Testing
- `ruff check .`
- `pytest -q`
- `bash scripts/check_docs.sh` *(fails: Vale not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685bea7103b083208fce69dc50d850b3