### PR TITLE
Improve Vale download check

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -50,6 +50,8 @@ All notable changes to this project will be recorded in this file.
 - Added offline instructions for manual Vale installation and running LanguageTool locally.
 - Improved the Vale download logic in `scripts/check_docs.sh` to extract the tarball in a temporary directory and move only the binary.
 - Added a cleanup trap to remove the temporary Vale directory automatically.
+- `scripts/check_docs.sh` now verifies that the Vale binary was extracted
+  successfully before moving it, exiting with a warning if missing.
 - CI now prints auth container logs if the service fails to start before header checks.
 - Added a Known Limitations section to `doc-quality-onboarding.md` explaining that large files may skip LanguageTool checks.
 - Documented that grammar and style issues only produce CI warnings.

--- a/scripts/check_docs.sh
+++ b/scripts/check_docs.sh
@@ -15,6 +15,10 @@ if ! command -v "$VALE_CMD" >/dev/null 2>&1; then
   TMP_DIR=$(mktemp -d)
   trap 'rm -rf "$TMP_DIR"' EXIT
   if curl -fsSL "$VALE_URL" | tar -xzC "$TMP_DIR" --strip-components=1; then
+    if [ ! -f "$TMP_DIR/vale" ]; then
+      echo "::warning file=scripts/check_docs.sh,line=$LINENO::Unable to download Vale. Install version $VALE_VERSION manually and set VALE_BINARY to its path. Skipping documentation style check"
+      exit 0
+    fi
     mv "$TMP_DIR/vale" ./vale
     chmod +x ./vale
     VALE_CMD="./vale"


### PR DESCRIPTION
## Summary
- verify `scripts/check_docs.sh` extracted Vale before moving the binary
- document the safer Vale download logic

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685bf18b813083209a32544218240ffb