### PR TITLE
Add license fields

### DIFF
--- a/bot/package.json
+++ b/bot/package.json
@@ -1,6 +1,7 @@
 {
   "name": "devonboarder-bot",
   "version": "1.0.0",
+  "license": "MIT",
   "main": "dist/main.js",
   "scripts": {
     "build": "tsc",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be recorded in this file.
 - Added `docs/about-potato.md` describing the Potato origin story and Easter egg.
 - Linked `docs/about-potato.md` from the documentation README.
 - Documented how to request a full QA sweep with Codex using `@codex run full-qa` in `docs/ONBOARDING.md`.
+- Added `"license": "MIT"` to `bot/package.json` and `frontend/package.json`.
 - Expanded the Codex QA instructions with troubleshooting tips and a Potato-themed Easter egg in `docs/ONBOARDING.md`.
 - Documented a sample QA response, randomized Easter egg reply, and the Vale/LanguageTool fallback policy.
 - Refactored `auth_service.create_app()` to instantiate a new `FastAPI` app and

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,7 @@
 {
   "name": "devonboarder-frontend",
   "version": "0.1.0",
+  "license": "MIT",
   "private": true,
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- add `"license": "MIT"` to bot and frontend package metadata
- document change in the changelog

## Testing
- `ruff check .`
- `pytest -q`
- `npm test` in bot
- `bash scripts/check_docs.sh`

------
https://chatgpt.com/codex/tasks/task_e_685bf88a88708320bb7fa6a37c1345c6