### PR TITLE
Install runtime deps in tests

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be recorded in this file.
 - Added a "Project Statement" section to the README highlighting the project's purpose.
 - Added `scripts/run_migrations.sh` for running `alembic upgrade head` and
   updated onboarding docs to reference it.
+- Documented installing the project with `pip install -e .` before running tests and updated setup scripts.
 - Added `docs/about-potato.md` describing the Potato origin story and Easter egg.
 - Linked `docs/about-potato.md` from the documentation README.
 - Documented how to request a full QA sweep with Codex using `@codex run full-qa` in `docs/ONBOARDING.md`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,7 +30,12 @@ If you're setting up a fresh Ubuntu machine, follow [ubuntu-setup.md](ubuntu-set
    and `curl http://localhost:8001/api/user/level`.
 12. Stop services with `docker compose -f docker-compose.dev.yaml --env-file .env.dev down`.
 13. Verify changes with `ruff check .`, `pytest -q`, and `npm test` from the `bot/` directory before committing.
-    If the `pytest` command is missing, run `pip install -r requirements-dev.txt` first or execute `make test`.
+    Before running the tests, install the project and dev requirements:
+
+    ```bash
+    pip install -e .
+    pip install -r requirements-dev.txt
+    ```
 14. Install git hooks with `pre-commit install` so these checks run automatically.
 15. Lint all Markdown docs with `./scripts/check_docs.sh` before pushing.
     This script uses **Vale** for style and **LanguageTool** for grammar.

--- a/docs/doc-quality-onboarding.md
+++ b/docs/doc-quality-onboarding.md
@@ -14,6 +14,7 @@ Welcome to the project! To keep our docs clear and professional, we run two tool
 ### Step 1: Install All Dev Requirements
 
 ```bash
+pip install -e .
 pip install -r requirements-dev.txt
 ```
 
@@ -119,9 +120,9 @@ and commit the change with your documentation update.
 ### Troubleshooting
 
 * **Vale not found:** install it as shown above or download the binary manually and set `VALE_BINARY` to its path.
-* **Python errors:** ensure `pip install -r requirements-dev.txt` succeeded.
+* **Python errors:** ensure `pip install -e .` and `pip install -r requirements-dev.txt` succeeded.
 * **LanguageTool API issues:** run a local server and set `LANGUAGETOOL_URL` to its address.
-* **pytest fails:** double-check that all dev dependencies are installed.
+* **pytest fails:** double-check that all dev dependencies and the project itself are installed.
 
 ### Known Limitations
 

--- a/docs/git-guidelines.md
+++ b/docs/git-guidelines.md
@@ -51,14 +51,21 @@ Delete the feature branch after the merge completes.
 
 ## Pre-PR Checklist
 
-Before opening a pull request, make sure to:
+-Before opening a pull request, make sure to:
 
 - Rebase your branch on the latest `main`.
+- Install the project and dev requirements:
+
+```bash
+pip install -e .
+pip install -r requirements-dev.txt
+```
+
 - Run the linter and tests to confirm they pass:
 
 ```bash
--  ruff check .
--  pytest -q
+ruff check .
+pytest -q
 ```
 - Run documentation checks with `./scripts/check_docs.sh`.
   These use **Vale** and **LanguageTool** and require network access to

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -24,7 +24,7 @@ bash scripts/check_docs.sh
 
 Refer to [doc-quality-onboarding.md](doc-quality-onboarding.md) for setup steps.
 
-- [ ] All Python and JS dependencies installed (`pip install -r requirements-dev.txt`, `npm ci` if needed)
+- [ ] All Python and JS dependencies installed (`pip install -e .` and `pip install -r requirements-dev.txt`, `npm ci` if needed)
 - [ ] Vale is installed locally (`vale --version`)
 - [ ] All Markdown docs pass checks (`bash scripts/check_docs.sh`)
 - [ ] All new or updated docs are clear, concise, and free of grammar issues

--- a/docs/sample-pr.md
+++ b/docs/sample-pr.md
@@ -9,6 +9,8 @@ This guide demonstrates a minimal documentation update using the project workflo
 2. Make a small change, such as adding this file.
 3. Run the pre-PR checks:
    ```bash
+   pip install -e .
+   pip install -r requirements-dev.txt
    ruff check .
    pytest -q
    ```

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -7,6 +7,11 @@ if ! command -v pytest >/dev/null 2>&1; then
     pip install -r requirements-dev.txt
 fi
 
+# Ensure runtime dependencies are installed
+if [ -f pyproject.toml ]; then
+    pip install -e .
+fi
+
 ruff check .
 pytest -q
 if [ -d bot ] && [ -f bot/package.json ]; then

--- a/scripts/setup-env.sh
+++ b/scripts/setup-env.sh
@@ -20,6 +20,10 @@ else
     if [ -f requirements-dev.txt ]; then
         pip install -r requirements-dev.txt
     fi
+    # Install the project so runtime dependencies are available
+    if [ -f pyproject.toml ]; then
+        pip install -e .
+    fi
     if [ -d frontend ]; then
         cd frontend
         if command -v pnpm >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- install package when bootstrapping local env and test runs
- document that `pip install -e .` and dev requirements must run before tests

## Testing
- `bash scripts/run_tests.sh`
- `bash scripts/check_docs.sh`

------
https://chatgpt.com/codex/tasks/task_e_685bff05a9ac8320885ef1ae28025246