### PR TITLE
Clarify install steps before running tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,15 @@ docker compose -f docker-compose.prod.yaml --env-file .env.prod up -d
 3. Copy each `*.env.example` to `.env` inside its service directory.
 4. Build the containers with `make deps` and start them with `make up`.
 5. Apply database migrations using `bash scripts/run_migrations.sh`.
-6. Verify changes with `ruff check .`, `pytest -q`, and `npm test` from `bot/`.
+6. Install the project and dev requirements, then run the tests:
+
+   ```bash
+   pip install -e .  # or `pip install -r requirements.txt` if present
+   pip install -r requirements-dev.txt
+   ruff check .
+   pytest -q
+   npm test --prefix bot
+   ```
 
 Licensed under the MIT License. See `LICENSE.md` for details.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,10 +30,10 @@ If you're setting up a fresh Ubuntu machine, follow [ubuntu-setup.md](ubuntu-set
    and `curl http://localhost:8001/api/user/level`.
 12. Stop services with `docker compose -f docker-compose.dev.yaml --env-file .env.dev down`.
 13. Verify changes with `ruff check .`, `pytest -q`, and `npm test` from the `bot/` directory before committing.
-    Before running the tests, install the project and dev requirements:
+    Install the project and dev requirements **before running the tests**:
 
     ```bash
-    pip install -e .
+    pip install -e .  # or `pip install -r requirements.txt` if you have one
     pip install -r requirements-dev.txt
     ```
 14. Install git hooks with `pre-commit install` so these checks run automatically.

--- a/docs/doc-quality-onboarding.md
+++ b/docs/doc-quality-onboarding.md
@@ -14,9 +14,12 @@ Welcome to the project! To keep our docs clear and professional, we run two tool
 ### Step 1: Install All Dev Requirements
 
 ```bash
-pip install -e .
+pip install -e .  # or `pip install -r requirements.txt` if present
 pip install -r requirements-dev.txt
 ```
+
+Run these commands **before executing tests or documentation checks** so Python
+imports resolve correctly.
 
 ---
 
@@ -120,7 +123,7 @@ and commit the change with your documentation update.
 ### Troubleshooting
 
 * **Vale not found:** install it as shown above or download the binary manually and set `VALE_BINARY` to its path.
-* **Python errors:** ensure `pip install -e .` and `pip install -r requirements-dev.txt` succeeded.
+* **Python errors:** ensure `pip install -e .` (or `pip install -r requirements.txt`) and `pip install -r requirements-dev.txt` succeeded.
 * **LanguageTool API issues:** run a local server and set `LANGUAGETOOL_URL` to its address.
 * **pytest fails:** double-check that all dev dependencies and the project itself are installed.
 

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -15,6 +15,8 @@
 <!-- Detail how a reviewer can verify the change. Include any setup commands. -->
 
 ```bash
+pip install -e .  # or `pip install -r requirements.txt` if present
+pip install -r requirements-dev.txt
 ruff check .
 pytest -q
 bash scripts/check_docs.sh
@@ -22,9 +24,9 @@ bash scripts/check_docs.sh
 
 ## Documentation & QA Checklist
 
-Refer to [doc-quality-onboarding.md](doc-quality-onboarding.md) for setup steps.
+-Refer to [doc-quality-onboarding.md](doc-quality-onboarding.md) for setup steps.
 
-- [ ] All Python and JS dependencies installed (`pip install -e .` and `pip install -r requirements-dev.txt`, `npm ci` if needed)
+- [ ] All Python and JS dependencies installed (`pip install -e .` or `pip install -r requirements.txt`, then `pip install -r requirements-dev.txt`; `npm ci` if needed)
 - [ ] Vale is installed locally (`vale --version`)
 - [ ] All Markdown docs pass checks (`bash scripts/check_docs.sh`)
 - [ ] All new or updated docs are clear, concise, and free of grammar issues

--- a/docs/ubuntu-setup.md
+++ b/docs/ubuntu-setup.md
@@ -25,3 +25,14 @@ sudo add-apt-repository ppa:deadsnakes/ppa -y
 sudo apt-get update
 sudo apt-get install -y python3.13 python3.13-venv python3.13-dev
 ```
+
+## Install Project Dependencies
+
+After Python is installed, set up the project in editable mode so tests and
+scripts can run:
+
+```bash
+pip install -e .  # or `pip install -r requirements.txt` if you created one
+pip install -r requirements-dev.txt
+```
+


### PR DESCRIPTION
## Summary
- mention `pip install -e .` (or `pip install -r requirements.txt`) before running tests in the docs
- expand quickstart instructions with install and test commands
- update pull request template to show the install step
- clarify doc quality onboarding instructions
- add Python dependency install section to Ubuntu setup guide

## Testing
- `ruff check .`
- `pytest -q`
- `bash scripts/check_docs.sh` *(fails: Vale failed to run)*

------
https://chatgpt.com/codex/tasks/task_e_685c02c754f883208e5e1c0927532bee