### PR TITLE
Ensure dev requirements installed before tests

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -275,6 +275,7 @@ All notable changes to this project will be recorded in this file.
 - Added nodeenv SSL troubleshooting steps to `docs/network-troubleshooting.md`.
 - Rewrote the repository README with a concise introduction and quickstart linking to `docs/README.md` and removed Vale instructions.
 - Added a package docstring to `src/routes/__init__.py` summarizing the routes module.
+- `scripts/run_tests.sh` now always installs development requirements before running tests to ensure packages like PyYAML are available.
 
 ## [0.1.0] - 2025-06-14
 

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,11 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Ensure development requirements are installed
-if ! command -v pytest >/dev/null 2>&1; then
-    echo "Installing dev requirements..."
-    pip install -r requirements-dev.txt
-fi
+# Always ensure development requirements are installed
+echo "Installing dev requirements..."
+pip install -r requirements-dev.txt
 
 # Ensure runtime dependencies are installed
 if [ -f pyproject.toml ]; then


### PR DESCRIPTION
## Summary
- always run `pip install -r requirements-dev.txt` in `scripts/run_tests.sh`
- document this behavior in the changelog

## Testing
- `npm ci` in `bot`
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685c0673eb1483208b14a8c21d03cc46