### PR TITLE
Update Vale version across repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     test:
         runs-on: ubuntu-latest
         env:
-            VALE_VERSION: 3.4.2
+            VALE_VERSION: 3.12.0.0
 
         steps:
             - uses: actions/checkout@v3
@@ -42,7 +42,7 @@ jobs:
               run: ruff check --output-format=github .
             - name: Install Vale
               run: |
-                curl -fsSL https://github.com/errata-ai/vale/releases/download/v3.4.2/vale_3.4.2_Linux_64-bit.tar.gz | tar xz # pinned version
+                curl -fsSL https://github.com/errata-ai/vale/releases/download/v3.12.0.0/vale_3.12.0.0_Linux_64-bit.tar.gz | tar xz # pinned version
                 sudo mv vale /usr/local/bin/
             - name: Documentation style check
               run: ./scripts/check_docs.sh

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -34,6 +34,7 @@ All notable changes to this project will be recorded in this file.
   linked the section from the onboarding docs.
 - Documented the `NODEJS_MIRROR` environment variable and linked the troubleshooting guide from the PR template.
 - Pinned Vale version to 3.4.2 in CI, documentation, and scripts.
+- Updated Vale version to 3.12.0.0 across documentation and scripts.
 - Added `/health` endpoints for auth and XP services with compose and CI healthchecks.
 - Confirmed all Docker healthchecks and CI wait steps use `/health` instead of the deprecated `/healthz` path.
 - Generated `frontend/package-lock.json` to pin npm dependencies.

--- a/docs/README.md
+++ b/docs/README.md
@@ -117,9 +117,9 @@ All Markdown files must pass Vale and LanguageTool checks.
 See [doc-quality-onboarding.md](doc-quality-onboarding.md) for a step-by-step guide.
 
 - Run `bash scripts/check_docs.sh` before pushing any changes.
-- Install Vale (version 3.4.2) with `brew install vale` or download it from the
+- Install Vale (version 3.12.0.0) with `brew install vale` or download it from the
   [Vale releases page](https://github.com/errata-ai/vale/releases).
-- If your network blocks direct downloads, fetch version 3.4.2 from
+- If your network blocks direct downloads, fetch version 3.12.0.0 from
   `https://github.com/errata-ai/vale/releases` on another machine and copy the
   `vale` binary to a directory in your `PATH`.
 - Install Python dev dependencies with `pip install -r requirements-dev.txt`.

--- a/docs/doc-quality-onboarding.md
+++ b/docs/doc-quality-onboarding.md
@@ -28,8 +28,8 @@ imports resolve correctly.
 * On macOS: `brew install vale`
 * On Windows: `choco install vale`
 * Or see [Vale Installation Docs](https://vale.sh/docs/installation/) for other platforms
-* If the script cannot download Vale automatically, manually download `vale_3.4.2_Linux_64-bit.tar.gz` from the [releases page](https://github.com/errata-ai/vale/releases), extract the `vale` binary, and set `VALE_BINARY` to its path.
-* **The project uses Vale 3.4.2. CI installs this version automatically**, but you still need it locally to run the checks before committing.
+* If the script cannot download Vale automatically, manually download `vale_3.12.0.0_Linux_64-bit.tar.gz` from the [releases page](https://github.com/errata-ai/vale/releases), extract the `vale` binary, and set `VALE_BINARY` to its path.
+* **The project uses Vale 3.12.0.0. CI installs this version automatically**, but you still need it locally to run the checks before committing.
 
 ---
 

--- a/scripts/check_docs.sh
+++ b/scripts/check_docs.sh
@@ -6,8 +6,8 @@ RESULTS_FILE="vale-results.json"
 
 # Try to locate or download Vale
 VALE_CMD="${VALE_BINARY:-vale}"
-# Allow overriding the version; default to 3.4.2
-VALE_VERSION="${VALE_VERSION:-3.4.2}"
+# Allow overriding the version; default to 3.12.0.0
+VALE_VERSION="${VALE_VERSION:-3.12.0.0}"
 
 if ! command -v "$VALE_CMD" >/dev/null 2>&1; then
   echo "Vale not found; attempting download of version $VALE_VERSION..."


### PR DESCRIPTION
## Summary
- align Vale version references to 3.12.0.0
- document Vale 3.12.0.0 in the README and doc-quality onboarding guide
- update CI workflow and docs script for the new version
- record change in CHANGELOG

## Testing
- `bash scripts/run_tests.sh` *(fails: `jest` not found)*
- `bash scripts/check_docs.sh` *(fails: Vale missing)*

------
https://chatgpt.com/codex/tasks/task_e_685c120228e08320918354e9d36d7e8b