### PR TITLE
Update Vale to 3.12.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     test:
         runs-on: ubuntu-latest
         env:
-            VALE_VERSION: 3.4.2
+            VALE_VERSION: 3.12.0
 
         steps:
             - uses: actions/checkout@v3
@@ -42,7 +42,7 @@ jobs:
               run: ruff check --output-format=github .
             - name: Install Vale
               run: |
-                curl -fsSL https://github.com/errata-ai/vale/releases/download/v3.4.2/vale_3.4.2_Linux_64-bit.tar.gz | tar xz # pinned version
+                curl -fsSL https://github.com/errata-ai/vale/releases/download/v3.12.0/vale_3.12.0_Linux_64-bit.tar.gz | tar xz # pinned version
                 sudo mv vale /usr/local/bin/
             - name: Documentation style check
               run: ./scripts/check_docs.sh

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -33,7 +33,7 @@ All notable changes to this project will be recorded in this file.
 - Expanded nodeenv troubleshooting with certificate verification failure tips and
   linked the section from the onboarding docs.
 - Documented the `NODEJS_MIRROR` environment variable and linked the troubleshooting guide from the PR template.
-- Pinned Vale version to 3.4.2 in CI, documentation, and scripts.
+- Pinned Vale version to 3.12.0 in CI, documentation, and scripts.
 - Added `/health` endpoints for auth and XP services with compose and CI healthchecks.
 - Confirmed all Docker healthchecks and CI wait steps use `/health` instead of the deprecated `/healthz` path.
 - Generated `frontend/package-lock.json` to pin npm dependencies.

--- a/docs/README.md
+++ b/docs/README.md
@@ -117,9 +117,9 @@ All Markdown files must pass Vale and LanguageTool checks.
 See [doc-quality-onboarding.md](doc-quality-onboarding.md) for a step-by-step guide.
 
 - Run `bash scripts/check_docs.sh` before pushing any changes.
-- Install Vale (version 3.4.2) with `brew install vale` or download it from the
+- Install Vale (version 3.12.0) with `brew install vale` or download it from the
   [Vale releases page](https://github.com/errata-ai/vale/releases).
-- If your network blocks direct downloads, fetch version 3.4.2 from
+- If your network blocks direct downloads, fetch version 3.12.0 from
   `https://github.com/errata-ai/vale/releases` on another machine and copy the
   `vale` binary to a directory in your `PATH`.
 - Install Python dev dependencies with `pip install -r requirements-dev.txt`.

--- a/docs/doc-quality-onboarding.md
+++ b/docs/doc-quality-onboarding.md
@@ -28,8 +28,8 @@ imports resolve correctly.
 * On macOS: `brew install vale`
 * On Windows: `choco install vale`
 * Or see [Vale Installation Docs](https://vale.sh/docs/installation/) for other platforms
-* If the script cannot download Vale automatically, manually download `vale_3.4.2_Linux_64-bit.tar.gz` from the [releases page](https://github.com/errata-ai/vale/releases), extract the `vale` binary, and set `VALE_BINARY` to its path.
-* **The project uses Vale 3.4.2. CI installs this version automatically**, but you still need it locally to run the checks before committing.
+* If the script cannot download Vale automatically, manually download `vale_3.12.0_Linux_64-bit.tar.gz` from the [releases page](https://github.com/errata-ai/vale/releases), extract the `vale` binary, and set `VALE_BINARY` to its path.
+* **The project uses Vale 3.12.0. CI installs this version automatically**, but you still need it locally to run the checks before committing.
 
 ---
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,5 +5,5 @@ pre-commit==4.2.0  # LTS as of 2025-06
 openapi-spec-validator==0.7.2  # LTS as of 2025-06
 requests==2.32.4  # LTS as of 2025-06
 pytest-cov==6.2.1  # LTS as of 2025-06
-vale==3.12.0.0  # LTS as of 2025-06
+vale==3.12.0  # LTS as of 2025-06
 language-tool-python==2.9.4  # LTS as of 2025-06

--- a/scripts/check_docs.sh
+++ b/scripts/check_docs.sh
@@ -6,8 +6,8 @@ RESULTS_FILE="vale-results.json"
 
 # Try to locate or download Vale
 VALE_CMD="${VALE_BINARY:-vale}"
-# Allow overriding the version; default to 3.4.2
-VALE_VERSION="${VALE_VERSION:-3.4.2}"
+# Allow overriding the version; default to 3.12.0
+VALE_VERSION="${VALE_VERSION:-3.12.0}"
 
 if ! command -v "$VALE_CMD" >/dev/null 2>&1; then
   echo "Vale not found; attempting download of version $VALE_VERSION..."


### PR DESCRIPTION
## Summary
- pin Vale 3.12.0 in requirements and workflow
- update docs to reference Vale 3.12.0
- change default version in `scripts/check_docs.sh`

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`
- `curl -I https://github.com/errata-ai/vale/releases/download/v3.12.0/vale_3.12.0_Linux_64-bit.tar.gz`

------
https://chatgpt.com/codex/tasks/task_e_685c14ed42e483208181f0554b11c16b