### PR TITLE
Update docs to mention frontend tests

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be recorded in this file.
 
 ## [Unreleased]
 
+- Documented running `npm test` from the `frontend/` directory after installing dependencies and linked
+  `frontend/README.md` for details.
 - Clarified `frontend/README.md` to install dependencies with `pnpm` or `npm`, commit the lockfile, and run `npm run dev`.
 - Added `docs/offline-setup.md` explaining how to install dependencies without internet access and linked it from the onboarding docs.
 - Added a module-level docstring to `src/devonboarder/cli.py` describing CLI usage.

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,6 +31,8 @@ If you're setting up a fresh Ubuntu machine, follow [ubuntu-setup.md](ubuntu-set
    and `curl http://localhost:8001/api/user/level`.
 12. Stop services with `docker compose -f docker-compose.dev.yaml --env-file .env.dev down`.
 13. Verify changes with `ruff check .`, `pytest -q`, and `npm test` from the `bot/` directory before committing.
+    After installing dependencies, run `npm test` in the `frontend/` directory as well
+    (see [../frontend/README.md](../frontend/README.md) for details).
     Install the project and dev requirements **before running the tests**:
 
     ```bash


### PR DESCRIPTION
## Summary
- remind devs to run frontend tests after installing dependencies
- link to the frontend README for details
- record documentation update in the changelog

## Testing
- `ruff check .`
- `pytest -q`
- `npm test` in `bot/`
- `npm test` in `frontend/`
- `./scripts/check_docs.sh` *(warns Vale not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685c5f163a48832098bd447f1355be04