### PR TITLE
Remove version from compose

### DIFF
--- a/docker-compose.codex.yml
+++ b/docker-compose.codex.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   codex:
     image: alpine:latest

--- a/docker-compose.override.yaml
+++ b/docker-compose.override.yaml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   app:
     command: ["devonboarder-server"]

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 x-app-base: &app-base
   build: .
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   app:
     build: .

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be recorded in this file.
 - Documented how to request a full QA sweep with Codex using `@codex run full-qa` in `docs/ONBOARDING.md`.
 - Added `"license": "MIT"` to `bot/package.json` and `frontend/package.json`.
 - Expanded the Codex QA instructions with troubleshooting tips and a Potato-themed Easter egg in `docs/ONBOARDING.md`.
+- Removed the `version:` field from all Docker compose files since Compose v2 no longer requires it.
 - Updated the frontend dependencies to `vite@7`, `vitest@3`, and the latest React and testing packages.
 - Documented a sample QA response, randomized Easter egg reply, and the Vale/LanguageTool fallback policy.
 - Refactored `auth_service.create_app()` to instantiate a new `FastAPI` app and


### PR DESCRIPTION
## Summary
- drop deprecated `version:` key from compose configs
- document compose updates in the changelog

## Testing
- `./scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685c646b8bc083208d67d6cb24551665