### PR TITLE
Update CI to generate secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,8 @@ jobs:
               with:
                   name: vale-results
                   path: vale-results.json
-            - name: Prepare environment file
-              run: cp .env.example .env.dev
+            - name: Generate secrets
+              run: ./scripts/generate-secrets.sh
             - name: Build containers
               run: docker compose -f docker-compose.ci.yaml --env-file .env.dev build
             - name: Start docker compose

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -34,6 +34,7 @@ All notable changes to this project will be recorded in this file.
 - Codespell ignore list covers `DevOnboarder`, `nodeenv`, and `pyenv`.
 - Enforced "Potato" and `Potato.md` entries in ignore files with a pre-commit check.
 - CI now enforces the Potato policy with `scripts/check_potato_ignore.sh`.
+- CI workflow now runs `./scripts/generate-secrets.sh` instead of copying `.env.example` to `.env.dev`.
 - Expanded nodeenv troubleshooting with certificate verification failure tips and
   linked the section from the onboarding docs.
 - Documented the `NODEJS_MIRROR` environment variable and linked the troubleshooting guide from the PR template.

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,9 @@ If you're setting up a fresh Ubuntu machine, follow [ubuntu-setup.md](ubuntu-set
    Update `DATABASE_URL` in `.env.dev` if you are not using the default
    Postgres credentials.
 2. Generate throwaway secrets with `./scripts/generate-secrets.sh`.
-   This script overwrites `.env.dev` with fresh random values.
+   This script overwrites `.env.dev` with fresh random values. The CI
+   workflow runs the same script before building containers so your
+   environment matches the pipeline.
 3. Build the service containers with `make deps`.
 4. Install the project in editable mode with `pip install -e .`.
    Install the dev requirements with `pip install -r requirements-dev.txt`.


### PR DESCRIPTION
## Summary
- run `generate-secrets.sh` in CI before Docker build
- document the new CI step

## Testing
- `bash scripts/run_tests.sh`
- `npm ci && npm test` in `bot/`

------
https://chatgpt.com/codex/tasks/task_e_685c66f71738832097dcfa90cf4d8a70