### PR TITLE
Add Login OAuth component

### DIFF
--- a/codex.plan.md
+++ b/codex.plan.md
@@ -69,7 +69,7 @@ This document defines the roadmap and execution logic for Codex tasks during the
   - `bot/src/commands/verify.ts`
   - `bot/src/commands/profile.ts`
   - `bot/src/commands/contribute.ts`
-  - `frontend/src/components/SessionStatus.tsx`
+  - `frontend/src/components/Login.tsx`
 
 ---
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,9 @@ All notable changes to this project will be recorded in this file.
 - Documented how to request a full QA sweep with Codex using `@codex run full-qa` in `docs/ONBOARDING.md`.
 - Added `"license": "MIT"` to `bot/package.json` and `frontend/package.json`.
 - Expanded the Codex QA instructions with troubleshooting tips and a Potato-themed Easter egg in `docs/ONBOARDING.md`.
+- Added a `Login` React component that redirects to Discord OAuth and handles
+  the `/login/discord/callback` flow. Updated `frontend/README.md` and
+  `docs/env.md` with usage instructions.
 - Removed the `version:` field from all Docker compose files since Compose v2 no longer requires it.
 - Updated the frontend dependencies to `vite@7`, `vitest@3`, and the latest React and testing packages.
 - Documented a sample QA response, randomized Easter egg reply, and the Vale/LanguageTool fallback policy.

--- a/docs/env.md
+++ b/docs/env.md
@@ -82,6 +82,10 @@ screen. After granting permissions, Discord redirects back to
 access token, creates or looks up the user, then returns a JWT from
 `/login/discord/callback`.
 
+The React `Login` component in `frontend/` handles this callback route. It
+stores the returned token in the browser and displays the user's onboarding
+status and level.
+
 ## Frontend
 
 - `VITE_AUTH_URL` &ndash; base URL for the auth API.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -5,3 +5,11 @@ This directory houses the DevOnboarder React application built with Vite.
 Install dependencies with `pnpm install` (or `npm install` if `pnpm` is not available`). Commit the generated lockfile (`pnpm-lock.yaml` or `package-lock.json`).
 Start the development server with `npm run dev`.
 Environment variables are defined in `.env.example`.
+
+## Login Flow
+
+Open `http://localhost:3000` and click **Log in with Discord**.
+After approving the OAuth prompt, Discord redirects back to
+`/login/discord/callback` on the frontend. The `Login` component exchanges the
+provided `code` for a JWT via the auth service, stores it in `localStorage`, and
+then displays your onboarding status and level.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,10 +1,10 @@
-import SessionStatus from './components/SessionStatus';
+import Login from './components/Login';
 
 export default function App() {
   return (
     <div>
       <h1>DevOnboarder</h1>
-      <SessionStatus />
+      <Login />
     </div>
   );
 }

--- a/frontend/src/components/Login.tsx
+++ b/frontend/src/components/Login.tsx
@@ -6,7 +6,7 @@ interface UserInfo {
   avatar: string | null;
 }
 
-export default function SessionStatus() {
+export default function Login() {
   const [token, setToken] = useState<string | null>(null);
   const [user, setUser] = useState<UserInfo | null>(null);
   const [level, setLevel] = useState<number | null>(null);
@@ -17,8 +17,9 @@ export default function SessionStatus() {
     const params = new URLSearchParams(window.location.search);
     const code = params.get('code');
     const stored = localStorage.getItem('jwt');
+    const path = window.location.pathname;
 
-    if (!stored && code) {
+    if (!stored && path === '/login/discord/callback' && code) {
       fetch(`${authUrl}/login/discord/callback?code=${code}`)
         .then((r) => r.json())
         .then((data) => {


### PR DESCRIPTION
## Summary
- replace SessionStatus with Login component
- document the login flow in frontend README
- mention OAuth callback handler in docs
- update changelog and plan

## Testing
- `ruff check .`
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c6e28bb00832097d5bf7a0003d9d7