### PR TITLE
Document dev Dockerfiles

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -28,6 +28,9 @@ All notable changes to this project will be recorded in this file.
   moved endpoints to an `APIRouter`.
 - Clarified where Codex posts QA results, added a "What happens next?" section, and noted that "⚠️ Docs: Lint skipped" doesn't block merges.
 - Refined the onboarding snippet to show a sample Codex QA response and referenced network troubleshooting and the Codex FAQ.
+- Documented how `docker-compose.dev.yaml` builds the bot and frontend from
+  `Dockerfile.dev`, noting the `pnpm install`/`npm ci` steps from
+  `frontend/README.md`.
 
 - Added Dockerfiles for the bot and frontend and updated `docker-compose.dev.yaml` to build them.
 - Documented Ubuntu commands for installing Docker, Docker Compose, Node.js 20, and Python 3.12. Linked the setup guide from the README quickstart.

--- a/docs/env.md
+++ b/docs/env.md
@@ -92,3 +92,12 @@ status and level.
 - `VITE_API_URL` &ndash; base URL for the XP API.
 - `VITE_DISCORD_CLIENT_ID` &ndash; OAuth client ID for Discord.
 - `VITE_SESSION_REFRESH_INTERVAL` &ndash; interval (seconds) between session refreshes.
+
+## Docker development images
+
+`docker-compose.dev.yaml` builds the bot and frontend containers using
+`bot/Dockerfile.dev` and `frontend/Dockerfile.dev`. These Dockerfiles install
+dependencies with `npm ci` and run the development servers. When running the
+frontend outside Docker, follow [../frontend/README.md](../frontend/README.md)
+and install packages with `pnpm install` (or `npm ci` for a clean install) before
+starting `npm run dev`.


### PR DESCRIPTION
## Summary
- mention pnpm/npm install in Docker development flow
- clarify Dockerfile.dev usage for bot and frontend
- record update in changelog

## Testing
- `bash scripts/run_tests.sh`
- `pre-commit run --files docs/env.md docs/CHANGELOG.md` *(fails: certificate verify failed)*

------
https://chatgpt.com/codex/tasks/task_e_685c70ecbfdc8320b054fbf00d250472