### PR TITLE
Add Playwright E2E tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,12 @@ jobs:
             - name: Run frontend tests
               run: npm test --if-present
               working-directory: frontend
+            - name: Install Playwright browsers
+              run: npx playwright install --with-deps
+              working-directory: frontend
+            - name: Run E2E tests
+              run: npm run test:e2e
+              working-directory: frontend
             - name: Upload coverage to Codecov
               uses: codecov/codecov-action@v3
             - name: Install bot dependencies

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be recorded in this file.
 - Added `scripts/run_migrations.sh` for running `alembic upgrade head` and
   updated onboarding docs to reference it.
 - Documented installing the project with `pip install -e .` before running tests and updated setup scripts.
+- Added Playwright E2E tests and documented how to run them.
 - Added `docs/about-potato.md` describing the Potato origin story and Easter egg.
 - Linked `docs/about-potato.md` from the documentation README.
 - Documented how to request a full QA sweep with Codex using `@codex run full-qa` in `docs/ONBOARDING.md`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -91,6 +91,7 @@ platforms. Please report any issues you encounter on your operating system.
 - [Founders log](../FOUNDERS.md) &ndash; record core contributors and how they help.
 - [Frontend README](../frontend/README.md) &ndash; instructions for running the React app.
 - [Marketing site home](../frontend/index.html) &ndash; early look at the public landing page.
+- [E2E test guide](e2e-tests.md) &ndash; run the Playwright suite.
 
 ## Onboarding Phases
 

--- a/docs/e2e-tests.md
+++ b/docs/e2e-tests.md
@@ -1,0 +1,28 @@
+# End-to-End Tests
+
+The React frontend includes a small suite of Playwright tests.
+These tests exercise the OAuth login flow and assume the dev services are running.
+
+## Running Locally
+
+1. Install dependencies and browsers:
+
+   ```bash
+   cd frontend
+   npm ci
+   npx playwright install
+   ```
+
+2. Start the services:
+
+   ```bash
+   docker compose -f docker-compose.dev.yaml --env-file .env.dev up -d
+   ```
+
+3. Execute the tests:
+
+   ```bash
+   npm run test:e2e
+   ```
+
+The configuration at `frontend/playwright.config.ts` automatically launches the Vite dev server before running the tests.

--- a/frontend/e2e/oauth.spec.ts
+++ b/frontend/e2e/oauth.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from '@playwright/test';
+
+const AUTH = 'http://localhost:8002';
+
+test('login flow shows user info', async ({ page }) => {
+  await page.route(`${AUTH}/login/discord/callback*`, route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ token: 'test-token' })
+    })
+  );
+  await page.route(`${AUTH}/api/user`, route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ id: '1', username: 'tester', avatar: null })
+    })
+  );
+  await page.route(`${AUTH}/api/user/level`, route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ level: 7 })
+    })
+  );
+  await page.route(`${AUTH}/api/user/onboarding-status`, route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ status: 'intro' })
+    })
+  );
+
+  await page.goto('/login/discord/callback?code=abc');
+
+  await expect(page.locator('text=Logged in as')).toContainText('tester');
+  await expect(page.locator('text=Level:')).toContainText('7');
+  await expect(page.locator('text=Onboarding:')).toContainText('intro');
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
+        "@playwright/test": "^1.53.1",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
         "@types/react": "^18.3.23",
@@ -939,6 +940,22 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.53.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.53.1.tgz",
+      "integrity": "sha512-Z4c23LHV0muZ8hfv4jw6HngPJkbbtZxTkxPNIg7cJcTc9C28N/p2q7g3JZS2SiKBBHJ3uM1dgDye66bB7LEk5w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.53.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -2304,6 +2321,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.53.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.53.1.tgz",
+      "integrity": "sha512-LJ13YLr/ocweuwxyGf1XNFWIU4M2zUSo149Qbp+A4cpwDjsxRPj7k6H25LBrEHiEwxvRbD8HdwvQmRMSvquhYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.53.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.53.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.53.1.tgz",
+      "integrity": "sha512-Z46Oq7tLAyT0lGoFx4DOuB1IA9D1TPj0QkYxpPVUnGDqHHvDpCftu1J2hM2PiWsNMoZh8+LQaarAWcDfPBc6zg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "preview": "vite preview",
     "start": "vite",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "react": "^18.3.1",
@@ -23,6 +24,7 @@
     "vitest": "^3.2.4",
     "@testing-library/react": "^16.3.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "jsdom": "^26.1.0"
+    "jsdom": "^26.1.0",
+    "@playwright/test": "^1.53.1"
   }
 }

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  webServer: {
+    command: 'npm run dev',
+    port: 3000,
+    reuseExistingServer: !process.env.CI,
+  },
+  use: {
+    baseURL: 'http://localhost:3000',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -7,5 +7,7 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     setupFiles: './src/setupTests.ts',
+    include: ['src/**/*.test.tsx'],
+    exclude: ['e2e/**'],
   },
 });


### PR DESCRIPTION
## Summary
- add Playwright test setup to the frontend
- stub login flow spec
- run Playwright in CI
- document E2E testing steps

## Testing
- `ruff check --output-format=github .`
- `pytest -q`
- `npm test --prefix frontend`
- `npm ci --prefix bot`
- `npm test --prefix bot`
- `bash scripts/check_docs.sh`
- `npx playwright install chromium --with-deps -y --prefix frontend` *(fails: interactive install)*
- `npm run test:e2e --prefix frontend` *(fails: Playwright web server exited early)*

------
https://chatgpt.com/codex/tasks/task_e_685c7ccd000083208b8ca34437796746