### PR TITLE
Set Vite dev server port

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be recorded in this file.
 
 ## [Unreleased]
 
+- Set the Vite dev server to listen on port `3000` and ensured all documentation
+  and compose files reference the same port.
+
 - Documented running `npm test` from the `frontend/` directory after installing dependencies and linked
   `frontend/README.md` for details.
 - Clarified `frontend/README.md` to install dependencies with `pnpm` or `npm`, commit the lockfile, and run `npm run dev`.

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -2,6 +2,9 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
+  server: {
+    port: 3000,
+  },
   plugins: [react()],
   test: {
     environment: 'jsdom',


### PR DESCRIPTION
## Summary
- expose Vite on port 3000
- document the new port in the changelog

## Testing
- `bash scripts/run_tests.sh`
- `pre-commit run --files frontend/vite.config.ts docs/CHANGELOG.md` *(fails: certificate verify failed)*

------
https://chatgpt.com/codex/tasks/task_e_685cab2cc53c83209bff55c64f0fe760