### PR TITLE
Update Playwright install docs

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to this project will be recorded in this file.
   updated onboarding docs to reference it.
 - Documented installing the project with `pip install -e .` before running tests and updated setup scripts.
 - Added Playwright E2E tests and documented how to run them.
+- Clarified Playwright install instructions in `docs/e2e-tests.md` to run
+  `npx playwright install --with-deps` inside the `frontend/` directory.
 - Added `docs/about-potato.md` describing the Potato origin story and Easter egg.
 - Linked `docs/about-potato.md` from the documentation README.
 - Documented how to request a full QA sweep with Codex using `@codex run full-qa` in `docs/ONBOARDING.md`.

--- a/docs/e2e-tests.md
+++ b/docs/e2e-tests.md
@@ -5,12 +5,12 @@ These tests exercise the OAuth login flow and assume the dev services are runnin
 
 ## Running Locally
 
-1. Install dependencies and browsers:
+1. Install dependencies and browsers from the `frontend/` directory:
 
    ```bash
    cd frontend
    npm ci
-   npx playwright install
+   npx playwright install --with-deps
    ```
 
 2. Start the services:


### PR DESCRIPTION
## Summary
- mention running Playwright install from the `frontend/` directory
- update the command to `npx playwright install --with-deps`
- record doc update in CHANGELOG

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685cae4d668c8320949a34a58e265a3a