### PR TITLE
Add test IDs for login and e2e checks

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be recorded in this file.
 
 ## [Unreleased]
 
+- Added `data-testid` attributes to user info in `Login.tsx` and updated
+  the Playwright tests and documentation.
 - Set the Vite dev server to listen on port `3000` and ensured all documentation
   and compose files reference the same port.
 

--- a/docs/e2e-tests.md
+++ b/docs/e2e-tests.md
@@ -26,3 +26,7 @@ These tests exercise the OAuth login flow and assume the dev services are runnin
    ```
 
 The configuration at `frontend/playwright.config.ts` automatically launches the Vite dev server before running the tests.
+
+User details rendered by `Login.tsx` expose `data-testid` attributes
+(`user-welcome`, `user-level`, and `onboarding-status`) so tests can
+select elements reliably.

--- a/frontend/e2e/oauth.spec.ts
+++ b/frontend/e2e/oauth.spec.ts
@@ -34,7 +34,7 @@ test('login flow shows user info', async ({ page }) => {
 
   await page.goto('/login/discord/callback?code=abc');
 
-  await expect(page.locator('text=Logged in as')).toContainText('tester');
-  await expect(page.locator('text=Level:')).toContainText('7');
-  await expect(page.locator('text=Onboarding:')).toContainText('intro');
+  await expect(page.getByTestId('user-welcome')).toContainText('tester');
+  await expect(page.getByTestId('user-level')).toContainText('7');
+  await expect(page.getByTestId('onboarding-status')).toContainText('intro');
 });

--- a/frontend/src/components/Login.tsx
+++ b/frontend/src/components/Login.tsx
@@ -60,7 +60,7 @@ export default function Login() {
   return (
     <div>
       {user && (
-        <p>
+        <p data-testid="user-welcome">
           Logged in as {user.username}
           {user.avatar && user.id && (
             <img
@@ -72,8 +72,8 @@ export default function Login() {
           )}
         </p>
       )}
-      <p>Level: {level ?? '...'}</p>
-      <p>Onboarding: {status ?? '...'}</p>
+      <p data-testid="user-level">Level: {level ?? '...'}</p>
+      <p data-testid="onboarding-status">Onboarding: {status ?? '...'}</p>
       {status === 'intro' && <button>Start Onboarding</button>}
     </div>
   );


### PR DESCRIPTION
## Summary
- expose data-testid attributes in the login component
- update Playwright spec to use test IDs
- document the new IDs for e2e tests

## Testing Steps
```bash
./scripts/run_tests.sh
# frontend tests
cd frontend && npm run test:e2e
```


------
https://chatgpt.com/codex/tasks/task_e_685cb5d1d0fc8320b05fe4ceeeafbbba