### PR TITLE
Add completedTasks archive

### DIFF
--- a/codex.tasks.json
+++ b/codex.tasks.json
@@ -1,37 +1,40 @@
-[
-  {
-    "id": "auth-001",
-    "title": "Implement Discord OAuth2 Flow",
-    "module": "auth_service",
-    "description": "Add Discord login support using DISCORD_CLIENT_ID and DISCORD_CLIENT_SECRET from the .env. Create `/api/auth/discord/login` and `/api/auth/discord/callback` endpoints to complete the flow. Store the Discord user data in the existing User model and issue a JWT on success.",
-    "status": "complete"
-  },
-  {
-    "id": "bot-001",
-    "title": "Fix XP API Fetch Calls in Bot",
-    "module": "discord_bot",
-    "description": "Update `src/api.ts` to include `username` or token when calling `/api/user/level`, `/api/user/onboarding-status`, and other endpoints. Currently, requests return 422 errors due to missing required parameters.",
-    "status": "complete"
-  },
-  {
-    "id": "xp-001",
-    "title": "Add Contribution POST Endpoint",
-    "module": "xp_api",
-    "description": "Create a new POST route at `/api/user/contribute` that accepts a contribution event, awards XP, and stores the record in the Contribution and XPEvent models. This will support XP gain via bot commands like `/contribute`.",
-    "status": "complete"
-  },
-  {
-    "id": "bot-002",
-    "title": "Modularize Discord Bot Commands",
-    "module": "discord_bot",
-    "description": "Refactor `/verify`, `/profile`, and `/contribute` commands out of `index.ts` and into separate files in a new `/commands` folder. Implement dynamic loading and registration of commands based on Discord.js v14 or your current bot handler.",
-    "status": "complete"
-  },
-  {
-    "id": "frontend-001",
-    "title": "Stub Frontend OAuth Session Component",
-    "module": "frontend",
-    "description": "Add a simple React/Vite component that consumes the Discord OAuth token (if present), displays XP/level via `/api/user/level`, and shows onboarding state. Use environment variables defined in `.env.example` and align with backend API routes.",
-    "status": "complete"
-  }
-]
+{
+  "tasks": [],
+  "completedTasks": [
+    {
+      "id": "auth-001",
+      "title": "Implement Discord OAuth2 Flow",
+      "module": "auth_service",
+      "description": "Add Discord login support using DISCORD_CLIENT_ID and DISCORD_CLIENT_SECRET from the .env. Create `/api/auth/discord/login` and `/api/auth/discord/callback` endpoints to complete the flow. Store the Discord user data in the existing User model and issue a JWT on success.",
+      "status": "complete"
+    },
+    {
+      "id": "bot-001",
+      "title": "Fix XP API Fetch Calls in Bot",
+      "module": "discord_bot",
+      "description": "Update `src/api.ts` to include `username` or token when calling `/api/user/level`, `/api/user/onboarding-status`, and other endpoints. Currently, requests return 422 errors due to missing required parameters.",
+      "status": "complete"
+    },
+    {
+      "id": "xp-001",
+      "title": "Add Contribution POST Endpoint",
+      "module": "xp_api",
+      "description": "Create a new POST route at `/api/user/contribute` that accepts a contribution event, awards XP, and stores the record in the Contribution and XPEvent models. This will support XP gain via bot commands like `/contribute`.",
+      "status": "complete"
+    },
+    {
+      "id": "bot-002",
+      "title": "Modularize Discord Bot Commands",
+      "module": "discord_bot",
+      "description": "Refactor `/verify`, `/profile`, and `/contribute` commands out of `index.ts` and into separate files in a new `/commands` folder. Implement dynamic loading and registration of commands based on Discord.js v14 or your current bot handler.",
+      "status": "complete"
+    },
+    {
+      "id": "frontend-001",
+      "title": "Stub Frontend OAuth Session Component",
+      "module": "frontend",
+      "description": "Add a simple React/Vite component that consumes the Discord OAuth token (if present), displays XP/level via `/api/user/level`, and shows onboarding state. Use environment variables defined in `.env.example` and align with backend API routes.",
+      "status": "complete"
+    }
+  ]
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be recorded in this file.
 - Added `scripts/run_migrations.sh` for running `alembic upgrade head` and
   updated onboarding docs to reference it.
 - Documented installing the project with `pip install -e .` before running tests and updated setup scripts.
+- Added `completedTasks` to `codex.tasks.json` and documented the archiving process.
 - Added Playwright E2E tests and documented how to run them.
 - Clarified Playwright install instructions in `docs/e2e-tests.md` to run
   `npx playwright install --with-deps` inside the `frontend/` directory.

--- a/docs/README.md
+++ b/docs/README.md
@@ -73,6 +73,7 @@ platforms. Please report any issues you encounter on your operating system.
 - [About Potato](about-potato.md) &ndash; the playful backstory of our root vegetable mascot.
 - [Merge checklist](merge-checklist.md) &ndash; steps maintainers use before merging.
 - [Changelog](CHANGELOG.md) &ndash; record notable updates for each release.
+- [Task management](task-management.md) &ndash; archive completed items in `codex.tasks.json`.
 - [Doc QA onboarding](doc-quality-onboarding.md) &ndash; quickstart for documentation checks.
 - [Network troubleshooting](network-troubleshooting.md#pre-commit-nodeenv-ssl-errors)
   &ndash; work around pre-commit `nodeenv` SSL errors and other network restrictions.

--- a/docs/task-management.md
+++ b/docs/task-management.md
@@ -1,0 +1,9 @@
+# Task Management
+
+This project tracks work items in `codex.tasks.json`. Active tasks live under the `tasks` array. When a task's `status` is set to `complete`, move it to the `completedTasks` array to keep the main list short.
+
+1. Open `codex.tasks.json`.
+2. Move any finished entries into `completedTasks`.
+3. Commit the changes alongside your code updates.
+
+Keeping completed items separate helps Codex automation and maintainers review progress quickly.


### PR DESCRIPTION
## Summary
- add `completedTasks` to codex.tasks.json
- document archiving in docs/task-management.md
- link new docs from README
- log update in changelog

## Testing
- `ruff check .`
- `pytest -q`
- `bash scripts/check_docs.sh` *(fails: Vale download issue)*

------
https://chatgpt.com/codex/tasks/task_e_685cb8ddbe508320b91628c9840eaf6d