### PR TITLE
Update run_tests script

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -296,6 +296,8 @@ All notable changes to this project will be recorded in this file.
 - Rewrote the repository README with a concise introduction and quickstart linking to `docs/README.md` and removed Vale instructions.
 - Added a package docstring to `src/routes/__init__.py` summarizing the routes module.
 - `scripts/run_tests.sh` now always installs development requirements before running tests to ensure packages like PyYAML are available.
+- `scripts/run_tests.sh` installs bot dependencies with `npm ci --prefix bot` before running Jest and
+  installs frontend dependencies with `npm ci --prefix frontend` when frontend tests exist.
 - Added `DISCORD_REDIRECT_URI` placeholder to `.env.example` and documented it under Secrets.
 - Playwright tests now read `AUTH_URL` to locate the auth service. Documented the
   variable in `docs/e2e-tests.md` and set it in CI.

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -13,5 +13,14 @@ fi
 ruff check .
 pytest -q
 if [ -d bot ] && [ -f bot/package.json ]; then
+    npm ci --prefix bot
     (cd bot && npm test)
+fi
+
+# Optionally run frontend tests when they exist
+if [ -d frontend ] && [ -f frontend/package.json ]; then
+    if grep -q "\"test\"" frontend/package.json; then
+        npm ci --prefix frontend
+        (cd frontend && npm test)
+    fi
 fi


### PR DESCRIPTION
## Summary
- ensure npm dependencies are installed before running bot tests
- install frontend deps when tests exist
- note updated behavior in the changelog

## Testing
- `scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685cbe7ad2988320a83586775640ba9a