### PR TITLE
Add pip root-user-action flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,9 @@ FROM python:3.13-slim
 WORKDIR /app
 
 COPY requirements-dev.txt ./
-RUN pip install --no-cache-dir -r requirements-dev.txt
+RUN pip install --no-cache-dir --root-user-action=ignore -r requirements-dev.txt
 
 COPY . ./
-RUN pip install --no-cache-dir .
+RUN pip install --no-cache-dir --root-user-action=ignore .
 
 CMD ["devonboarder"]

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be recorded in this file.
 
 - Added `data-testid` attributes to user info in `Login.tsx` and updated
   the Playwright tests and documentation.
+- The base Dockerfile now runs `pip install --root-user-action=ignore` to
+  suppress warnings when installing packages as root. Documented this
+  behavior in `docs/env.md`.
 - Set the Vite dev server to listen on port `3000` and ensured all documentation
   and compose files reference the same port.
 

--- a/docs/env.md
+++ b/docs/env.md
@@ -101,3 +101,7 @@ dependencies with `npm ci` and run the development servers. When running the
 frontend outside Docker, follow [../frontend/README.md](../frontend/README.md)
 and install packages with `pnpm install` (or `npm ci` for a clean install) before
 starting `npm run dev`.
+
+The base `Dockerfile` installs Python packages with `pip install --root-user-action=ignore`
+to silence warnings when running as the root user. If you create your own image,
+you can activate a virtual environment instead of using this flag.


### PR DESCRIPTION
## Summary
- update Dockerfile pip install commands with `--root-user-action=ignore`
- explain the rationale in the environment documentation
- record the Dockerfile change in the changelog

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685cc1d6795483209336db818c1f2dd6