### PR TITLE
Add troubleshooting documentation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be recorded in this file.
   `frontend/README.md` for details.
 - Clarified `frontend/README.md` to install dependencies with `pnpm` or `npm`, commit the lockfile, and run `npm run dev`.
 - Added `docs/offline-setup.md` explaining how to install dependencies without internet access and linked it from the onboarding docs.
+- Added `docs/troubleshooting.md` summarizing setup and CI problems and linked it from the docs README.
 - Added a module-level docstring to `src/devonboarder/cli.py` describing CLI usage.
 - Added a "Project Statement" section to the README highlighting the project's purpose.
 - Added `scripts/run_migrations.sh` for running `alembic upgrade head` and

--- a/docs/README.md
+++ b/docs/README.md
@@ -77,6 +77,8 @@ platforms. Please report any issues you encounter on your operating system.
 - [Doc QA onboarding](doc-quality-onboarding.md) &ndash; quickstart for documentation checks.
 - [Network troubleshooting](network-troubleshooting.md#pre-commit-nodeenv-ssl-errors)
   &ndash; work around pre-commit `nodeenv` SSL errors and other network restrictions.
+- [Troubleshooting guide](troubleshooting.md)
+  &ndash; quick fixes for setup problems and failing CI jobs.
 - [Offline setup](offline-setup.md) &ndash; download Python wheels and npm packages on another machine.
 - [Security audit](security-audit-2025-06-21.md) &ndash; latest dependency check results.
 - [Environment variables](env.md) &ndash; explanation of `.env` settings and the role-based permission system.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,25 @@
+# Troubleshooting Guide
+
+Development setups and CI runs sometimes fail in surprising ways. This page collects quick fixes for the most common problems.
+
+## Failed pre-commit hooks
+
+- Ensure you have run `pre-commit install` so git hooks execute automatically.
+- If the Node.js download fails during the Prettier hook, see [Network troubleshooting](network-troubleshooting.md#pre-commit-nodeenv-ssl-errors).
+- Missing Python packages? Install dev requirements with:
+  ```bash
+  pip install -r requirements-dev.txt
+  ```
+
+## Docker services won't start
+
+- Run `docker compose -f docker-compose.dev.yaml --env-file .env.dev up -d` to rebuild containers.
+- Check container logs with `docker compose logs` for details.
+- If services exit immediately, verify secrets with `./scripts/generate-secrets.sh`.
+
+## CI pipeline failures
+
+- Use `bash scripts/run_tests.sh` locally to reproduce lint and test failures.
+- For network-restricted environments, follow [Offline setup](offline-setup.md) to cache dependencies.
+- If CI cannot download tools or packages, review [Network troubleshooting](network-troubleshooting.md) for proxy tips.
+


### PR DESCRIPTION
## Summary
- document common setup and CI issues in `docs/troubleshooting.md`
- reference the troubleshooting guide from `docs/README.md`
- record the addition in `docs/CHANGELOG.md`

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685cc595711c8320b35ecbd024f93b80