### PR TITLE
Fix Playwright OAuth E2E timing

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be recorded in this file.
 
 - Added `data-testid` attributes to user info in `Login.tsx` and updated
   the Playwright tests and documentation.
+- Updated the OAuth Playwright test to wait for the dev server and added
+  troubleshooting tips to `docs/e2e-tests.md`.
 - The base Dockerfile now runs `pip install --root-user-action=ignore` to
   suppress warnings when installing packages as root. Documented this
   behavior in `docs/env.md`.

--- a/docs/e2e-tests.md
+++ b/docs/e2e-tests.md
@@ -33,3 +33,11 @@ The configuration at `frontend/playwright.config.ts` automatically launches the 
 User details rendered by `Login.tsx` expose `data-testid` attributes
 (`user-welcome`, `user-level`, and `onboarding-status`) so tests can
 select elements reliably.
+
+## Troubleshooting
+
+If the tests fail with a timeout on `toContainText`, the Vite dev server may not
+be fully compiled before Playwright navigates to the page. Ensure the dev server
+responds on <http://localhost:3000> by loading it in a browser or hitting the
+root URL with `curl` before running the tests. Re-running `npx playwright
+install` can also fix missing browser errors.

--- a/frontend/e2e/oauth.spec.ts
+++ b/frontend/e2e/oauth.spec.ts
@@ -32,6 +32,8 @@ test('login flow shows user info', async ({ page }) => {
     })
   );
 
+  // Ensure the Vite dev server is ready before hitting the callback route
+  await page.goto('/', { waitUntil: 'networkidle' });
   await page.goto('/login/discord/callback?code=abc');
 
   await expect(page.getByTestId('user-welcome')).toContainText('tester');


### PR DESCRIPTION
## Summary
- wait for Vite server before running OAuth callback test
- document Playwright troubleshooting tips
- note OAuth E2E change in changelog

## Testing Steps
- `ruff check .`
- `pytest -q`
- `bash scripts/check_docs.sh`
- `pre-commit run --files docs/CHANGELOG.md docs/e2e-tests.md frontend/e2e/oauth.spec.ts` *(fails: SSL certificate verify failed)*
- `npm ci` *(fails: cdn.playwright.dev blocked)*


------
https://chatgpt.com/codex/tasks/task_e_685ccd7d7c408320a27c53b7618a4d86