### PR TITLE
Add stubEnv for Login test

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be recorded in this file.
 
 ## [Unreleased]
 
+- Updated Login component test to stub `import.meta.env.VITE_AUTH_URL` with `vi.stubEnv`.
 - Added `data-testid` attributes to user info in `Login.tsx` and updated
   the Playwright tests and documentation.
 - Updated the OAuth Playwright test to wait for the dev server and added

--- a/frontend/src/components/Login.test.tsx
+++ b/frontend/src/components/Login.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
+import Login from './Login';
+
+const AUTH_URL = 'http://auth.example.com';
+
+describe('Login', () => {
+  beforeEach(() => {
+    vi.stubEnv('VITE_AUTH_URL', AUTH_URL);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('links to the auth service', () => {
+    render(<Login />);
+    const link = screen.getByRole('link', { name: /log in with discord/i });
+    expect(link).toHaveAttribute('href', `${AUTH_URL}/login/discord`);
+  });
+});


### PR DESCRIPTION
# Summary
- stub `VITE_AUTH_URL` in new Login component test using `vi.stubEnv`
- record change in changelog

# Testing Steps
- `ruff check .`
- `pytest -q`
- `bash scripts/check_docs.sh`
- `npm test --silent` in `frontend/`


------
https://chatgpt.com/codex/tasks/task_e_6862b9a3177c8320b415a39ab4d6d28e