### PR TITLE
Add CI failure issue automation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,8 +88,14 @@ jobs:
               run: npm ci
               working-directory: frontend
             - name: Run frontend tests with coverage
-              run: npm run coverage --if-present
+              run: npm run coverage --if-present 2>&1 | tee vitest.log
               working-directory: frontend
+            - name: Upload vitest log
+              if: always()
+              uses: actions/upload-artifact@v4
+              with:
+                  name: vitest-log
+                  path: frontend/vitest.log
             - name: Install Playwright browsers
               run: npx playwright install --with-deps
               working-directory: frontend
@@ -104,8 +110,14 @@ jobs:
               run: npm ci
               working-directory: bot
             - name: Run bot tests with coverage
-              run: npm run coverage
+              run: npm run coverage 2>&1 | tee jest.log
               working-directory: bot
+            - name: Upload jest log
+              if: always()
+              uses: actions/upload-artifact@v4
+              with:
+                  name: jest-log
+                  path: bot/jest.log
             - name: Wait for auth service before header check
               run: |
                   for i in {1..30}; do
@@ -133,3 +145,13 @@ jobs:
               with:
                   labels: |
                       🚧 Codex
+            - name: Summarize CI failures
+              if: failure()
+              run: python scripts/summarize_ci_failures.py
+            - name: Create or update CI failure issue
+              if: failure()
+              uses: peter-evans/create-issue-from-file@v5
+              with:
+                  title: CI Failures for ${{ github.sha }}
+                  content-filepath: summary.md
+                  labels: ci-failure

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be recorded in this file.
 
 ## [Unreleased]
 
+- CI failures now trigger an issue summarizing failing tests with links to the run artifacts.
+
 - Updated Login component test to stub `import.meta.env.VITE_AUTH_URL` with `vi.stubEnv`.
 - Added `data-testid` attributes to user info in `Login.tsx` and updated
   the Playwright tests and documentation.

--- a/docs/README.md
+++ b/docs/README.md
@@ -144,3 +144,4 @@ See [doc-quality-onboarding.md](doc-quality-onboarding.md) for a step-by-step gu
 3. Use the pull request template and ensure the checklist passes.
 4. Review [sample-pr.md](sample-pr.md) for an end-to-end example.
 5. See the Codex CI Monitoring Policy in [../AGENTS.md](../AGENTS.md) for how failed CI jobs automatically create tasks.
+6. When CI fails, an issue titled `CI Failures for <sha>` is opened or updated with a summary of the failing tests and links to the artifacts.

--- a/scripts/summarize_ci_failures.py
+++ b/scripts/summarize_ci_failures.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+"""Generate a short CI failure summary for maintainers."""
+
+from __future__ import annotations
+
+import os
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from typing import List
+
+
+def parse_pytest(path: Path) -> List[str]:
+    """Return failing pytest testcase names."""
+    if not path.exists():
+        return []
+    tree = ET.parse(path)
+    fails: List[str] = []
+    for case in tree.iter("testcase"):
+        if case.find("failure") is not None:
+            classname = case.get("classname", "")
+            name = case.get("name", "")
+            if classname:
+                fails.append(f"{classname}::{name}")
+            else:
+                fails.append(name)
+    return fails
+
+
+def parse_log(path: Path) -> List[str]:
+    """Return lines containing 'FAIL' from a test log."""
+    if not path.exists():
+        return []
+    lines = []
+    with path.open() as f:
+        for line in f:
+            if "FAIL" in line:
+                lines.append(line.strip())
+    return lines
+
+
+def main() -> None:
+    repo = os.getenv("GITHUB_REPOSITORY", "")
+    run_id = os.getenv("GITHUB_RUN_ID", "")
+    sha = os.getenv("GITHUB_SHA", "")[:7]
+
+    lines: List[str] = [f"# CI Failure Summary for `{sha}`", ""]
+
+    pyfails = parse_pytest(Path("pytest-results.xml"))
+    if pyfails:
+        lines.append("## Pytest Failures")
+        for name in pyfails[:5]:
+            lines.append(f"- {name}")
+        lines.append("")
+
+    vitest_fails = parse_log(Path("frontend") / "vitest.log")
+    if vitest_fails:
+        lines.append("## Vitest Failures")
+        for item in vitest_fails[:5]:
+            lines.append(f"- {item}")
+        lines.append("")
+
+    jest_fails = parse_log(Path("bot") / "jest.log")
+    if jest_fails:
+        lines.append("## Jest Failures")
+        for item in jest_fails[:5]:
+            lines.append(f"- {item}")
+        lines.append("")
+
+    lines.append(
+        "[Download artifacts](https://github.com/"f"{repo}/actions/runs/{run_id}) "
+        "for full logs."
+    )
+
+    Path("summary.md").write_text("\n".join(lines))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- log vitest and Jest output in CI
- upload these logs as artifacts
- add script to summarize failing tests
- open a "CI Failures" issue with peter-evans action when CI fails
- document the automation in the docs
- note the change in the changelog

## Testing
- `ruff check scripts/summarize_ci_failures.py`
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError)*
- `npm test --prefix bot` *(fails: jest not found)*
- `npm test --prefix frontend` *(fails: vitest not found)*
- `bash scripts/check_docs.sh` *(fails: Vale download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6862c6b83a9083209c6264832eb3d353