### PR TITLE
Add coverage summary comment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,31 @@ jobs:
               with:
                   name: jest-log
                   path: bot/jest.log
+            - name: Generate coverage summary
+              run: |
+                  python scripts/post_coverage_comment.py coverage-summary.md
+                  echo "\n[Full coverage reports](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})" >> coverage-summary.md
+            - name: Upload coverage summary
+              if: always()
+              uses: actions/upload-artifact@v4
+              with:
+                  name: coverage-summary
+                  path: coverage-summary.md
+            - name: Upload coverage data
+              if: always()
+              uses: actions/upload-artifact@v4
+              with:
+                  name: coverage-data
+                  path: |
+                      bot/coverage
+                      frontend/coverage
+                      .coverage
+            - name: Post coverage comment
+              if: github.event_name == 'pull_request'
+              uses: peter-evans/create-or-update-comment@v4
+              with:
+                  issue-number: ${{ github.event.pull_request.number }}
+                  body-file: coverage-summary.md
             - name: Wait for auth service before header check
               run: |
                   for i in {1..30}; do

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be recorded in this file.
 ## [Unreleased]
 
 - CI failures now trigger an issue summarizing failing tests with links to the run artifacts.
+- CI now posts a coverage summary on pull requests using `scripts/post_coverage_comment.py` and uploads the full reports as an artifact.
 
 - Updated Login component test to stub `import.meta.env.VITE_AUTH_URL` with `vi.stubEnv`.
 - Added `data-testid` attributes to user info in `Login.tsx` and updated

--- a/docs/README.md
+++ b/docs/README.md
@@ -57,6 +57,9 @@ If you're setting up a fresh Ubuntu machine, follow [ubuntu-setup.md](ubuntu-set
 
     Then set `LANGUAGETOOL_URL=http://localhost:8010/v2`.
 
+17. CI posts a coverage summary on pull requests. Run
+    `python scripts/post_coverage_comment.py` to generate the table locally.
+
 The compose files define common service settings using YAML anchors. Each
 environment file overrides differences like `env_file` or exposed ports below the
 `<<` merge key.

--- a/scripts/post_coverage_comment.py
+++ b/scripts/post_coverage_comment.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Generate a Markdown coverage summary table.
+
+Reads Vitest/Jest `coverage-summary.json` files and the pytest `.coverage` data
+file. Outputs a Markdown table with coverage percentages for each test suite.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import sys
+
+from coverage import Coverage
+
+
+def read_js_coverage(path: str) -> float | None:
+    """Return line coverage percentage from a coverage-summary.json file."""
+    if not os.path.exists(path):
+        return None
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        return float(data["total"]["lines"]["pct"])
+    except Exception:
+        return None
+
+
+def read_py_coverage(path: str = ".coverage") -> float | None:
+    """Return total coverage percentage from a coverage data file."""
+    if not os.path.exists(path):
+        return None
+    cov = Coverage(data_file=path)
+    cov.load()
+    buf = io.StringIO()
+    percent = cov.report(file=buf)
+    return float(percent)
+
+
+def generate_table(results: dict[str, float]) -> str:
+    header = "| Suite | Coverage |\n| --- | ---: |\n"
+    rows = [f"| {name} | {pct:.1f}% |" for name, pct in results.items()]
+    return header + "\n".join(rows) + "\n"
+
+
+def main() -> None:
+    output_path = sys.argv[1] if len(sys.argv) > 1 else None
+
+    results: dict[str, float] = {}
+
+    py_cov = read_py_coverage()
+    if py_cov is not None:
+        results["Backend"] = py_cov
+
+    js_paths = {
+        "Frontend": "frontend/coverage/coverage-summary.json",
+        "Bot": "bot/coverage/coverage-summary.json",
+    }
+    for name, path in js_paths.items():
+        pct = read_js_coverage(path)
+        if pct is not None:
+            results[name] = pct
+
+    if not results:
+        print("No coverage data found", file=sys.stderr)
+        sys.exit(1)
+
+    table = generate_table(results)
+
+    if output_path:
+        with open(output_path, "w", encoding="utf-8") as f:
+            f.write(table)
+    else:
+        print(table)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- parse coverage reports and generate a Markdown table
- post the table to pull requests
- document coverage comment functionality
- record the change in the changelog

## Testing
- `ruff check .`
- `pytest -q`
- `bash scripts/check_docs.sh`

------
https://chatgpt.com/codex/tasks/task_e_6862c8066aa48320831b46aa4d777d6f