### PR TITLE
Update frontend status on dashboard

### DIFF
--- a/Codex_Contributor_Dashboard.md
+++ b/Codex_Contributor_Dashboard.md
@@ -19,7 +19,7 @@ This dashboard provides a live snapshot of module status, responsibilities, and 
 | **auth_service** | `services/auth_service`    | Implement Discord OAuth2 login and session issuance.               | ✅ Complete      |
 | **xp_api**       | `services/xp_api`          | Fix XP endpoint logic and add contribution POST route.             | ✅ Complete      |
 | **discord_bot**  | `bot`                      | Modularize commands and integrate token-based API calls.           | ✅ Complete      |
-| **frontend**     | `frontend`                 | Scaffold OAuth callback, onboarding UI, and XP dashboard.         | ⏳ Not Started   |
+| **frontend**     | `frontend`                 | Scaffold OAuth callback, onboarding UI, and XP dashboard.         | 🚧 In Progress   |
 | **infra_docs**   | `infra`                    | Environment templates, Docker Compose, CI/CD scripts.             | ✅ Complete      |
 | **codex_docs**   | `codex`                    | Codex plan, tasks, and automation metadata files.                  | ✅ Complete      |
 | **project_docs** | `docs`                     | General docs, merge guides, changelog, and onboarding markdown.    | ✅ Complete      |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -318,6 +318,7 @@ All notable changes to this project will be recorded in this file.
   variable in `docs/e2e-tests.md` and set it in CI.
 
 - Fixed spacing in the Git guidelines pre-PR checklist.
+- Updated `Codex_Contributor_Dashboard.md` to mark the frontend module in progress.
 
 ## [0.1.0] - 2025-06-14
 


### PR DESCRIPTION
## Summary
- mark frontend module as in progress
- record dashboard update in the changelog

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6862d518e1688320b95cce9ba1d17048