### PR TITLE
Document deferral for Discord integration

### DIFF
--- a/codex.tasks.json
+++ b/codex.tasks.json
@@ -1,5 +1,13 @@
 {
-  "tasks": [],
+  "tasks": [
+    {
+      "id": "integration-001",
+      "title": "Implement Discord Integration agent",
+      "module": "discord_integration",
+      "description": "Create `/oauth` and `/roles` routes for Discord account linking and role lookup.",
+      "status": "deferred"
+    }
+  ],
   "completedTasks": [
     {
       "id": "auth-001",

--- a/docs/Agents.md
+++ b/docs/Agents.md
@@ -37,7 +37,7 @@ This document defines all agents (services, bots, integrations, and guards) in t
 | Agent Name          | Endpoint(s)                      | Port | Healthcheck | Depends On | Status   |
 | ------------------- | -------------------------------- | ---- | ----------- | ---------- | -------- |
 | Auth Server         | `/api/*`, `/health`              | 8002 | `/health`   | db         | updating |
-| Discord Integration | `/oauth`, `/roles`               | 8081 | `TBD`       | Auth, db   | planned  |
+| Discord Integration | `/oauth`, `/roles`               | 8081 | `TBD`       | Auth, db   | deferred |
 | Frontend Agent      | `/`, `/session`                  | 3000 | N/A         | Auth       | stable   |
 | XP API              | `/xp`, `/health`                 | 8001 | `/health`   | db         | verify   |
 | Database (Postgres) | N/A                              | 5432 | docker      | N/A        | stable   |
@@ -87,9 +87,11 @@ This document defines all agents (services, bots, integrations, and guards) in t
 
 ## Discord Integration Agent
 
-**Purpose:** Handles all Discord-specific OAuth flows and role lookups.
+**Status:** Deferred – planned endpoints `/oauth` and `/roles` are not yet implemented.
 
-**Key Files:** Backend utilities in `src/utils/discord.ts`, frontend helpers in `src/lib/auth/discord.ts`
+**Purpose:** Handles Discord OAuth flows and role lookups once the service is built.
+
+**Key Files:** To be determined when development resumes.
 
 ---
 
@@ -206,7 +208,7 @@ Use a small loop in your workflow to wait for the auth service before running te
 | ------------------- | ----------- | -------------- | ---------------- |
 | Auth Server         | Yes         | Yes            | Yes              |
 | Frontend            | Yes         | Yes            | Yes              |
-| Discord Integration | Partial     | No             | No               |
+| Discord Integration | N/A         | No             | No               |
 | XP API              | Yes         | Yes            | Yes              |
 | Webhook/Bot Agent   | Optional    | No             | Optional         |
 | Database (Postgres) | Yes         | Yes            | Yes              |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be recorded in this file.
 ## [Unreleased]
 
 - Checked off completed tasks in `docs/Agents.md` for `/health` endpoints, Docker healthchecks, and CI polling.
+- Marked the Discord Integration agent as deferred and added a tracking task.
 
 - CI failures now trigger an issue summarizing failing tests with links to the run artifacts.
 - CI now posts a coverage summary on pull requests using `scripts/post_coverage_comment.py` and uploads the full reports as an artifact.


### PR DESCRIPTION
## Summary
- defer the Discord Integration agent documentation
- track deferred work in `codex.tasks.json`
- record the decision in the changelog

## Testing
- `ruff check .`
- `pytest -q`
- `bash scripts/check_docs.sh`

------
https://chatgpt.com/codex/tasks/task_e_6862d839ae4c8320926e7c805579f1d6