### PR TITLE
Add feedback dashboard tasks

### DIFF
--- a/codex.tasks.json
+++ b/codex.tasks.json
@@ -6,6 +6,20 @@
       "module": "discord_integration",
       "description": "Create `/oauth` and `/roles` routes for Discord account linking and role lookup.",
       "status": "deferred"
+    },
+    {
+      "id": "feedback-001",
+      "title": "Implement Feedback Dashboard API",
+      "module": "feedback_service",
+      "description": "Add endpoints for submitting feedback, tracking status, and generating analytics as outlined in docs/prd/feedback-dashboard.md.",
+      "status": "planned"
+    },
+    {
+      "id": "feedback-002",
+      "title": "Create Feedback Dashboard UI",
+      "module": "frontend",
+      "description": "Build React components for the submission form, status board, and analytics snapshot per docs/prd/feedback-dashboard.md.",
+      "status": "planned"
     }
   ],
   "completedTasks": [

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -320,6 +320,7 @@ All notable changes to this project will be recorded in this file.
 
 - Fixed spacing in the Git guidelines pre-PR checklist.
 - Updated `Codex_Contributor_Dashboard.md` to mark the frontend module in progress.
+- Planned feedback dashboard with backend API and React UI as described in `docs/prd/feedback-dashboard.md`.
 
 ## [0.1.0] - 2025-06-14
 


### PR DESCRIPTION
## Summary
- document a new Feedback Dashboard feature in the changelog
- add open tasks for the feedback dashboard API and UI

## Testing
- `bash scripts/run_tests.sh`
- `bash scripts/check_docs.sh`

------
https://chatgpt.com/codex/tasks/task_e_6862dc6acc5c8320be27b329b325c748