### PR TITLE
Update CI to log playwright failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,10 +100,16 @@ jobs:
               run: npx playwright install --with-deps
               working-directory: frontend
             - name: Run E2E tests
-              run: npm run test:e2e
+              run: npm run test:e2e 2>&1 | tee playwright.log
               working-directory: frontend
               env:
                   AUTH_URL: http://localhost:8002
+            - name: Upload playwright log
+              if: always()
+              uses: actions/upload-artifact@v4
+              with:
+                  name: playwright-log
+                  path: frontend/playwright.log
             - name: Upload coverage to Codecov
               uses: codecov/codecov-action@v3
             - name: Install bot dependencies

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be recorded in this file.
 - Marked the Discord Integration agent as deferred and added a tracking task.
 
 - CI failures now trigger an issue summarizing failing tests with links to the run artifacts.
+- CI workflow now uploads `playwright.log` and summarizes failing Playwright tests in the CI failure issue.
 - CI now posts a coverage summary on pull requests using `scripts/post_coverage_comment.py` and uploads the full reports as an artifact.
 
 - Updated Login component test to stub `import.meta.env.VITE_AUTH_URL` with `vi.stubEnv`.

--- a/scripts/summarize_ci_failures.py
+++ b/scripts/summarize_ci_failures.py
@@ -59,6 +59,13 @@ def main() -> None:
             lines.append(f"- {item}")
         lines.append("")
 
+    playwright_fails = parse_log(Path("frontend") / "playwright.log")
+    if playwright_fails:
+        lines.append("## Playwright Failures")
+        for item in playwright_fails[:5]:
+            lines.append(f"- {item}")
+        lines.append("")
+
     jest_fails = parse_log(Path("bot") / "jest.log")
     if jest_fails:
         lines.append("## Jest Failures")


### PR DESCRIPTION
## Summary
- save E2E output to `playwright.log` and upload it from CI
- summarize failing Playwright tests in `scripts/summarize_ci_failures.py`
- document the new artifact and summary in the changelog

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6862e32d20c883208e80acbb2e8efbdc