### PR TITLE
Fix newline in coverage summary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,9 @@ jobs:
             - name: Generate coverage summary
               run: |
                   python scripts/post_coverage_comment.py coverage-summary.md
-                  echo "\n[Full coverage reports](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})" >> coverage-summary.md
+                  printf '\n[Full coverage reports](%s/%s/actions/runs/%s)\n' \
+                    "${{ github.server_url }}" "${{ github.repository }}" "${{ github.run_id }}" \
+                    >> coverage-summary.md
             - name: Upload coverage summary
               if: always()
               uses: actions/upload-artifact@v4

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be recorded in this file.
 - CI failures now trigger an issue summarizing failing tests with links to the run artifacts.
 - CI workflow now uploads `playwright.log` and summarizes failing Playwright tests in the CI failure issue.
 - CI now posts a coverage summary on pull requests using `scripts/post_coverage_comment.py` and uploads the full reports as an artifact.
+- Coverage summary now uses `printf` so the newline before the link renders correctly.
 
 - Updated Login component test to stub `import.meta.env.VITE_AUTH_URL` with `vi.stubEnv`.
 - Added `data-testid` attributes to user info in `Login.tsx` and updated


### PR DESCRIPTION
## Summary
- update coverage step to use `printf` so newline is real
- changelog entry about the coverage summary output

## Testing
- `ruff check .`
- `pytest -q`
- `bash scripts/check_docs.sh`

------
https://chatgpt.com/codex/tasks/task_e_6862e879b1ec83209ee4576ad216e0b7