### PR TITLE
Fix newline quoting for coverage summary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
             - name: Generate coverage summary
               run: |
                   python scripts/post_coverage_comment.py coverage-summary.md
-                  printf '\n[Full coverage reports](%s/%s/actions/runs/%s)\n' \
+                  printf "\n[Full coverage reports](%s/%s/actions/runs/%s)\n" \
                     "${{ github.server_url }}" "${{ github.repository }}" "${{ github.run_id }}" \
                     >> coverage-summary.md
             - name: Upload coverage summary

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be recorded in this file.
 - CI failures now trigger an issue summarizing failing tests with links to the run artifacts.
 - CI workflow now uploads `playwright.log` and summarizes failing Playwright tests in the CI failure issue.
 - CI now posts a coverage summary on pull requests using `scripts/post_coverage_comment.py` and uploads the full reports as an artifact.
-- Coverage summary now uses `printf` so the newline before the link renders correctly.
+- Fixed newline formatting in the coverage summary by quoting the `printf` command with double quotes.
 
 - Updated Login component test to stub `import.meta.env.VITE_AUTH_URL` with `vi.stubEnv`.
 - Added `data-testid` attributes to user info in `Login.tsx` and updated


### PR DESCRIPTION
## Summary
- fix quoting in coverage summary step to print newline properly
- document coverage summary newline fix in changelog

## Testing
- `ruff check .`
- `pytest -q`
- `bash scripts/check_docs.sh` *(fails: Vale missing)*

------
https://chatgpt.com/codex/tasks/task_e_6862f097b43c8320ac6196c2a84130a6