### PR TITLE
Create append_coverage_summary script

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be recorded in this file.
 - CI workflow now uploads `playwright.log` and summarizes failing Playwright tests in the CI failure issue.
 - CI now posts a coverage summary on pull requests using `scripts/post_coverage_comment.py` and uploads the full reports as an artifact.
 - Fixed newline formatting in the coverage summary by quoting the `printf` command with double quotes.
+- Added `scripts/append_coverage_summary.sh` to append the coverage link with proper newline handling.
 
 - Updated Login component test to stub `import.meta.env.VITE_AUTH_URL` with `vi.stubEnv`.
 - Added `data-testid` attributes to user info in `Login.tsx` and updated

--- a/scripts/append_coverage_summary.sh
+++ b/scripts/append_coverage_summary.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env sh
+# Append coverage summary and link to summary.md
+# Uses environment variables set by coverage tools or CI.
+
+COVERED_LINES=${COVERED_LINES:-}
+TOTAL_LINES=${TOTAL_LINES:-}
+COVERAGE_PERCENT=${COVERAGE_PERCENT:-}
+COVERED_BRANCHES=${COVERED_BRANCHES:-}
+TOTAL_BRANCHES=${TOTAL_BRANCHES:-}
+BRANCH_PERCENT=${BRANCH_PERCENT:-}
+OUTPUT_FILE=${1:-summary.md}
+
+{
+  echo ""
+  echo "### 📊 Coverage Summary"
+  echo ""
+  if [ -n "$COVERED_LINES" ] && [ -n "$TOTAL_LINES" ]; then
+    echo "- **Lines:** ${COVERED_LINES}/${TOTAL_LINES} (${COVERAGE_PERCENT}%)"
+  fi
+  if [ -n "$COVERED_BRANCHES" ] && [ -n "$TOTAL_BRANCHES" ]; then
+    echo "- **Branches:** ${COVERED_BRANCHES}/${TOTAL_BRANCHES} (${BRANCH_PERCENT}%)"
+  fi
+  printf "\n[Full coverage reports](%s/%s/actions/runs/%s)\n" \
+    "${GITHUB_SERVER_URL:-https://github.com}" \
+    "${GITHUB_REPOSITORY:-}" \
+    "${GITHUB_RUN_ID:-}"
+} >> "$OUTPUT_FILE"


### PR DESCRIPTION
## Summary
- add a helper script for appending coverage info
- document the script in the changelog

## Testing
- `bash scripts/check_docs.sh` *(fails: Unable to download Vale)*
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `npm test` in `bot/` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862f447bed88320a2d4f25c510174dd