### PR TITLE
Fix coverage link newline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,9 +127,7 @@ jobs:
             - name: Generate coverage summary
               run: |
                   python scripts/post_coverage_comment.py coverage-summary.md
-                  printf "\n[Full coverage reports](%s/%s/actions/runs/%s)\n" \
-                    "${{ github.server_url }}" "${{ github.repository }}" "${{ github.run_id }}" \
-                    >> coverage-summary.md
+                  bash scripts/append_coverage_summary.sh coverage-summary.md
             - name: Upload coverage summary
               if: always()
               uses: actions/upload-artifact@v4

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be recorded in this file.
 - CI now posts a coverage summary on pull requests using `scripts/post_coverage_comment.py` and uploads the full reports as an artifact.
 - Fixed newline formatting in the coverage summary by quoting the `printf` command with double quotes.
 - Added `scripts/append_coverage_summary.sh` to append the coverage link with proper newline handling.
+- CI workflow now uses this script so the coverage link appears on its own line.
 
 - Updated Login component test to stub `import.meta.env.VITE_AUTH_URL` with `vi.stubEnv`.
 - Added `data-testid` attributes to user info in `Login.tsx` and updated

--- a/scripts/append_coverage_summary.sh
+++ b/scripts/append_coverage_summary.sh
@@ -20,8 +20,9 @@ OUTPUT_FILE=${1:-summary.md}
   if [ -n "$COVERED_BRANCHES" ] && [ -n "$TOTAL_BRANCHES" ]; then
     echo "- **Branches:** ${COVERED_BRANCHES}/${TOTAL_BRANCHES} (${BRANCH_PERCENT}%)"
   fi
-  printf "\n[Full coverage reports](%s/%s/actions/runs/%s)\n" \
-    "${GITHUB_SERVER_URL:-https://github.com}" \
-    "${GITHUB_REPOSITORY:-}" \
-    "${GITHUB_RUN_ID:-}"
 } >> "$OUTPUT_FILE"
+
+printf "\n[Full coverage reports](%s/%s/actions/runs/%s)\n" \
+  "${GITHUB_SERVER_URL:-https://github.com}" \
+  "${GITHUB_REPOSITORY:-}" \
+  "${GITHUB_RUN_ID:-}" >> "$OUTPUT_FILE"


### PR DESCRIPTION
## Summary
- run `append_coverage_summary.sh` from the CI workflow
- ensure the script prints the coverage link separately with `printf`
- document the change

## Testing
- `pre-commit run --files .github/workflows/ci.yml docs/CHANGELOG.md scripts/append_coverage_summary.sh` *(fails: certificate verify failed)*
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6862fdc8bd448320bad270814366a124