### PR TITLE
Fix coverage summary step environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,10 @@ jobs:
                   name: jest-log
                   path: bot/jest.log
             - name: Generate coverage summary
+              env:
+                  GITHUB_SERVER_URL: ${{ github.server_url }}
+                  GITHUB_REPOSITORY: ${{ github.repository }}
+                  GITHUB_RUN_ID: ${{ github.run_id }}
               run: |
                   python scripts/post_coverage_comment.py coverage-summary.md
                   bash scripts/append_coverage_summary.sh coverage-summary.md

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be recorded in this file.
 - Fixed newline formatting in the coverage summary by quoting the `printf` command with double quotes.
 - Added `scripts/append_coverage_summary.sh` to append the coverage link with proper newline handling.
 - CI workflow now uses this script so the coverage link appears on its own line.
+- CI workflow now exports GitHub variables when generating the coverage summary.
 
 - Updated Login component test to stub `import.meta.env.VITE_AUTH_URL` with `vi.stubEnv`.
 - Added `data-testid` attributes to user info in `Login.tsx` and updated


### PR DESCRIPTION
## Summary
- export GitHub context variables before running the coverage summary script
- document updated workflow change in the changelog

## Testing
- `bash scripts/run_tests.sh`
- `bash scripts/check_docs.sh`

------
https://chatgpt.com/codex/tasks/task_e_6863058edd6c832095bf09a8842b0c78