### PR TITLE
Add dependency checker script

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be recorded in this file.
 
 ## [Unreleased]
 
+- Added `scripts/check_dependencies.sh` and documented running it from `docs/README.md` and `docs/doc-quality-onboarding.md`.
+
 - Checked off completed tasks in `docs/Agents.md` for `/health` endpoints, Docker healthchecks, and CI polling.
 - Marked the Discord Integration agent as deferred and added a tracking task.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -55,11 +55,13 @@ If you're setting up a fresh Ubuntu machine, follow [ubuntu-setup.md](ubuntu-set
     docker run -d --name languagetool -p 8010:8010 silviof/docker-languagetool
     ```
 
-    Then set `LANGUAGETOOL_URL=http://localhost:8010/v2`.
+Then set `LANGUAGETOOL_URL=http://localhost:8010/v2`.
 
-17. CI posts a coverage summary on pull requests. Run
+17. Run `bash scripts/check_dependencies.sh` to verify Jest, Vitest, and Vale are installed.
+
+18. CI posts a coverage summary on pull requests. Run
     `python scripts/post_coverage_comment.py` to generate the table locally.
-18. Append the coverage numbers to a Markdown file with
+19. Append the coverage numbers to a Markdown file with
     `bash scripts/append_coverage_summary.sh`. Set the following
     environment variables before running the script:
     `COVERED_LINES`, `TOTAL_LINES`, `COVERAGE_PERCENT`,

--- a/docs/doc-quality-onboarding.md
+++ b/docs/doc-quality-onboarding.md
@@ -31,6 +31,8 @@ imports resolve correctly.
 * If the script cannot download Vale automatically, manually download `vale_3.12.0_Linux_64-bit.tar.gz` from the [releases page](https://github.com/errata-ai/vale/releases), extract the `vale` binary, and set `VALE_BINARY` to its path.
 * **The project uses Vale 3.12.0. CI installs this version automatically**, but you still need it locally to run the checks before committing.
 
+Run `bash scripts/check_dependencies.sh` to confirm Vale and the Node test tools are installed.
+
 ---
 
 ### Step 3: (Optional) Set Up Local LanguageTool Server

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -13,4 +13,7 @@ fi
 # Run the shared setup script to install all required tools and images
 "$(dirname "$0")/setup-env.sh"
 
+# Optionally check for optional tooling
+"$(dirname "$0")/check_dependencies.sh" || true
+
 echo "Bootstrap complete"

--- a/scripts/check_dependencies.sh
+++ b/scripts/check_dependencies.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Verify optional tools are installed
+set -euo pipefail
+
+missing=0
+
+check_npx_tool() {
+    local tool=$1
+    local install_hint=$2
+    if ! npx --no-install "$tool" --version >/dev/null 2>&1; then
+        echo "$tool not found. $install_hint"
+        missing=1
+    fi
+}
+
+if ! command -v npx >/dev/null 2>&1; then
+    echo "Node.js and npx are required to run Jest and Vitest."
+    missing=1
+else
+    check_npx_tool jest "Run 'npm install' or 'pnpm install' in the bot/ directory."
+    check_npx_tool vitest "Run 'npm install' or 'pnpm install' in the frontend/ directory."
+fi
+
+if ! command -v vale >/dev/null 2>&1; then
+    echo "Vale not found. Install it from https://vale.sh/docs/installation/ or with 'brew install vale'."
+    missing=1
+fi
+
+if [ "$missing" -eq 0 ]; then
+    echo "All optional dependencies installed ✅"
+fi


### PR DESCRIPTION
## Summary
- add `scripts/check_dependencies.sh` for Jest, Vitest and Vale
- mention the script in the documentation
- run the checker from `scripts/bootstrap.sh`
- document the new helper in the changelog

## Testing
- `bash scripts/check_docs.sh`
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6863539bc0d0832081fb0a31af59d038