### PR TITLE
Update offline setup for bot

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -35,6 +35,7 @@ All notable changes to this project will be recorded in this file.
   `frontend/README.md` for details.
 - Clarified `frontend/README.md` to install dependencies with `pnpm` or `npm`, commit the lockfile, and run `npm run dev`.
 - Added `docs/offline-setup.md` explaining how to install dependencies without internet access and linked it from the onboarding docs.
+- Extended the offline setup guide with steps for caching and installing npm packages in `bot/`.
 - Added `docs/troubleshooting.md` summarizing setup and CI problems and linked it from the docs README.
 - Added a module-level docstring to `src/devonboarder/cli.py` describing CLI usage.
 - Added a "Project Statement" section to the README highlighting the project's purpose.

--- a/docs/offline-setup.md
+++ b/docs/offline-setup.md
@@ -38,4 +38,23 @@ Some environments block direct access to package registries. Use another machine
    npm ci --offline --cache /path/to/devonboarder-offline/npm
    ```
 
+## Bot npm packages
+
+1. On the online machine, cache the bot dependencies:
+
+   ```bash
+   mkdir -p ~/devonboarder-offline/npm
+   cd bot
+   npm ci --cache ~/devonboarder-offline/npm
+   ```
+
+2. Copy the `devonboarder-offline` folder to your offline machine.
+
+3. Install the bot dependencies from the cache:
+
+   ```bash
+   cd bot
+   npm ci --offline --cache /path/to/devonboarder-offline/npm
+   ```
+
 After installing dependencies, run the usual setup commands such as `make deps` or `pre-commit install`.


### PR DESCRIPTION
## Summary
- document npm caching for the bot directory
- log this doc update in the changelog

## Testing
- `bash scripts/run_tests.sh`
- `bash scripts/check_docs.sh`

------
https://chatgpt.com/codex/tasks/task_e_686361361b708320b577c13963e852bd