### PR TITLE
Clarify server stop instruction

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be recorded in this file.
 
 ## [Unreleased]
+- Clarified README instructions to stop the server with Ctrl+C.
 
 - Added `scripts/check_dependencies.sh` and documented running it from `docs/README.md` and `docs/doc-quality-onboarding.md`.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,7 @@ If you're setting up a fresh Ubuntu machine, follow [ubuntu-setup.md](ubuntu-set
    This launches the auth, bot, XP API, frontend, and Postgres services.
    The `frontend/` folder now hosts a React app built with Vite.
 6. Run `bash scripts/run_migrations.sh` to apply the initial database migration.
-7. Alternatively, run `devonboarder-server` to start the app without Docker. Stop it with Ctrl+C.
+7. Alternatively, run `devonboarder-server` to start the app without Docker. Stop the server with Ctrl+C.
 8. Visit `http://localhost:8000` to see the greeting server.
 9. Run `devonboarder-api` to start the user API at `http://localhost:8001`.
    This command requires `uvicorn`.


### PR DESCRIPTION
## Summary
- clarify README step for stopping the server
- note the clarification in the changelog

## Testing
- `ruff check .`
- `pytest -q`
- `bash scripts/check_docs.sh`


------
https://chatgpt.com/codex/tasks/task_e_68636b7d7684832081efabccad256299