### PR TITLE
Remove duplicate Prettier hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,21 +39,9 @@ repos:
         language: system
         pass_filenames: false
         working_directory: frontend
-      - id: frontend-prettier
-        name: Frontend Prettier
-        entry: npm run format
-        language: system
-        pass_filenames: false
-        working_directory: frontend
       - id: bot-eslint
         name: Bot ESLint
         entry: npm run lint
-        language: system
-        pass_filenames: false
-        working_directory: bot
-      - id: bot-prettier
-        name: Bot Prettier
-        entry: npm run format
         language: system
         pass_filenames: false
         working_directory: bot

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be recorded in this file.
 - Clarified README instructions to stop the server with Ctrl+C.
 - Added `CORS_ALLOW_ORIGINS` environment variable for configuring CORS.
 - Replaced `node-fetch` with the global `fetch` in the Discord bot and updated tests.
+- Prettier now runs only via the pre-commit mirror. Removed duplicate `npm run format` hooks from `.pre-commit-config.yaml`.
 
 - Added `scripts/check_dependencies.sh` and documented running it from `docs/README.md` and `docs/doc-quality-onboarding.md`.
 


### PR DESCRIPTION
## Summary
- rely on the Prettier mirror hook
- drop local npm `prettier` hooks from pre-commit
- document this simplification in the changelog

## Testing
- `pre-commit run --files .pre-commit-config.yaml docs/CHANGELOG.md` *(fails: SSL error installing nodeenv)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686384fd01208320a3ce1c46235dba99