### PR TITLE
Add axe-core accessibility checks to Playwright tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,12 +107,21 @@ jobs:
               working-directory: frontend
               env:
                   AUTH_URL: http://localhost:8002
+            - name: Run accessibility tests
+              run: npm run test:a11y 2>&1 | tee a11y.log
+              working-directory: frontend
             - name: Upload playwright log
               if: always()
               uses: actions/upload-artifact@v4
               with:
                   name: playwright-log
                   path: frontend/playwright.log
+            - name: Upload accessibility log
+              if: always()
+              uses: actions/upload-artifact@v4
+              with:
+                  name: a11y-log
+                  path: frontend/a11y.log
             - name: Upload coverage to Codecov
               uses: codecov/codecov-action@v3
             - name: Install bot dependencies

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -98,6 +98,7 @@ All notable changes to this project will be recorded in this file.
 - CI workflow now records pytest results and uploads them as an artifact.
 - CI workflow now uses `actions/upload-artifact@v4`.
 - Documented where to download the `pytest-results.xml` artifact in the doc-quality onboarding guide.
+- Added Playwright accessibility tests using `@axe-core/playwright` with a new `npm run test:a11y` script.
 - Added a `make test` target that installs dev requirements before running tests.
 - Documented installing `requirements-dev.txt` prior to running `pytest`.
 - LanguageTool checks now skip files that exceed the request size limit instead of failing.

--- a/docs/e2e-tests.md
+++ b/docs/e2e-tests.md
@@ -25,6 +25,14 @@ These tests exercise the OAuth login flow and assume the dev services are runnin
    npm run test:e2e
    ```
 
+4. Run accessibility checks:
+
+   ```bash
+   npm run test:a11y
+   ```
+
+   This uses `@axe-core/playwright` to report any accessibility violations.
+
    The tests read the auth service URL from the `AUTH_URL` environment variable,
    defaulting to `http://localhost:8002` when unset.
 

--- a/frontend/e2e/accessibility.spec.ts
+++ b/frontend/e2e/accessibility.spec.ts
@@ -1,0 +1,8 @@
+import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+
+test('home page is accessible', async ({ page }) => {
+    await page.goto('/');
+    const results = await new AxeBuilder({ page }).analyze();
+    expect(results.violations).toEqual([]);
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
                 "react-dom": "^18.3.1"
             },
             "devDependencies": {
+                "@axe-core/playwright": "^4.10.2",
                 "@playwright/test": "^1.53.1",
                 "@testing-library/jest-dom": "^6.6.3",
                 "@testing-library/react": "^16.3.0",
@@ -69,6 +70,19 @@
             "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
             "dev": true,
             "license": "ISC"
+        },
+        "node_modules/@axe-core/playwright": {
+            "version": "4.10.2",
+            "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.10.2.tgz",
+            "integrity": "sha512-6/b5BJjG6hDaRNtgzLIfKr5DfwyiLHO4+ByTLB0cJgWSM8Ll7KqtdblIS6bEkwSF642/Ex91vNqIl3GLXGlceg==",
+            "dev": true,
+            "license": "MPL-2.0",
+            "dependencies": {
+                "axe-core": "~4.10.3"
+            },
+            "peerDependencies": {
+                "playwright-core": ">= 1.0.0"
+            }
         },
         "node_modules/@babel/code-frame": {
             "version": "7.27.1",
@@ -2072,6 +2086,16 @@
             "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/axe-core": {
+            "version": "4.10.3",
+            "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.3.tgz",
+            "integrity": "sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==",
+            "dev": true,
+            "license": "MPL-2.0",
+            "engines": {
+                "node": ">=4"
+            }
         },
         "node_modules/balanced-match": {
             "version": "1.0.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,36 +1,38 @@
 {
-  "name": "devonboarder-frontend",
-  "version": "0.1.0",
-  "license": "MIT",
-  "private": true,
-  "scripts": {
-    "dev": "vite",
-    "build": "vite build",
-    "preview": "vite preview",
-    "start": "vite",
-    "test": "vitest run",
-    "coverage": "vitest run --coverage",
-    "test:e2e": "playwright test",
-    "lint": "eslint \"src/**/*.{js,ts,tsx}\"",
-    "format": "prettier --write \"src/**/*.{js,ts,tsx}\""
-  },
-  "dependencies": {
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1"
-  },
-  "devDependencies": {
-    "@playwright/test": "^1.53.1",
-    "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.3.0",
-    "@types/react": "^18.3.23",
-    "@types/react-dom": "^18.3.7",
-    "@vitejs/plugin-react": "^4.6.0",
-    "@vitest/coverage-v8": "^3.2.4",
-    "eslint": "^9.30.0",
-    "jsdom": "^26.1.0",
-    "prettier": "^3.6.2",
-    "typescript": "^5.8.3",
-    "vite": "^7.0.0",
-    "vitest": "^3.2.4"
-  }
+    "name": "devonboarder-frontend",
+    "version": "0.1.0",
+    "license": "MIT",
+    "private": true,
+    "scripts": {
+        "dev": "vite",
+        "build": "vite build",
+        "preview": "vite preview",
+        "start": "vite",
+        "test": "vitest run",
+        "coverage": "vitest run --coverage",
+        "test:e2e": "playwright test",
+        "test:a11y": "playwright test e2e/accessibility.spec.ts",
+        "lint": "eslint \"src/**/*.{js,ts,tsx}\"",
+        "format": "prettier --write \"src/**/*.{js,ts,tsx}\""
+    },
+    "dependencies": {
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1"
+    },
+    "devDependencies": {
+        "@playwright/test": "^1.53.1",
+        "@axe-core/playwright": "^4.10.2",
+        "@testing-library/jest-dom": "^6.6.3",
+        "@testing-library/react": "^16.3.0",
+        "@types/react": "^18.3.23",
+        "@types/react-dom": "^18.3.7",
+        "@vitejs/plugin-react": "^4.6.0",
+        "@vitest/coverage-v8": "^3.2.4",
+        "eslint": "^9.30.0",
+        "jsdom": "^26.1.0",
+        "prettier": "^3.6.2",
+        "typescript": "^5.8.3",
+        "vite": "^7.0.0",
+        "vitest": "^3.2.4"
+    }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,10 +1,10 @@
 import Login from './components/Login';
 
 export default function App() {
-  return (
-    <div>
-      <h1>DevOnboarder</h1>
-      <Login />
-    </div>
-  );
+    return (
+        <main>
+            <h1>DevOnboarder</h1>
+            <Login />
+        </main>
+    );
 }


### PR DESCRIPTION
## Summary
- integrate `@axe-core/playwright` with new a11y spec
- document `npm run test:a11y` in docs
- run a11y tests in CI and upload log
- wrap main content in `<main>` to satisfy accessibility rule
- update changelog

## Testing
- `pre-commit run --files .github/workflows/ci.yml docs/CHANGELOG.md docs/e2e-tests.md frontend/package.json frontend/package-lock.json frontend/e2e/accessibility.spec.ts` *(failed: SSL certificate verification)*
- `pytest -q`
- `npm run coverage` *(failed: coverage below threshold)*
- `npx playwright install --with-deps`
- `npm run test:e2e` *(failed: login flow timeout)*
- `npm run test:a11y`

------
https://chatgpt.com/codex/tasks/task_e_6863897f20a08320b9a7e2cb16aab13d