### PR TITLE
Add Trivy image scanning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,8 @@ jobs:
               run: ./scripts/generate-secrets.sh
             - name: Build containers
               run: docker compose -f docker-compose.ci.yaml --env-file .env.dev build
+            - name: Scan images with Trivy
+              run: bash scripts/trivy_scan.sh docker-compose.ci.yaml
             - name: Start docker compose
               run: docker compose -f docker-compose.ci.yaml --env-file .env.dev up -d
             - name: Wait for auth service

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,10 @@ All notable changes to this project will be recorded in this file.
 - Added `pip-audit` and `npm audit --production` security checks run via `scripts/security_audit.sh` and invoked in CI. Results are stored in `docs/security-audit-2025-07-01.md`.
 - Marked the Discord Integration agent as deferred and added a tracking task.
 
+- Added `scripts/trivy_scan.sh` and a CI step that scans Docker images with
+  Trivy, failing on high or critical vulnerabilities. Documented offline
+  installation steps in `docs/offline-setup.md`.
+
 - Moved XP API code into a dedicated `xp/api` package and updated tests and the
   `devonboarder-api` entrypoint.
 

--- a/docs/offline-setup.md
+++ b/docs/offline-setup.md
@@ -58,3 +58,24 @@ Some environments block direct access to package registries. Use another machine
    ```
 
 After installing dependencies, run the usual setup commands such as `make deps` or `pre-commit install`.
+
+## Trivy
+
+1. On a machine with internet access, download the Trivy binary:
+
+   ```bash
+   mkdir -p ~/devonboarder-offline/trivy
+   curl -L -o ~/devonboarder-offline/trivy/trivy.tar.gz \
+     https://github.com/aquasecurity/trivy/releases/download/v0.47.0/trivy_0.47.0_Linux-64bit.tar.gz
+   tar -xzf ~/devonboarder-offline/trivy/trivy.tar.gz -C ~/devonboarder-offline/trivy
+   ```
+
+2. Copy the `devonboarder-offline` folder to your offline machine.
+
+3. Install the binary in your `PATH`:
+
+   ```bash
+   sudo install -m 755 /path/to/devonboarder-offline/trivy/trivy /usr/local/bin/trivy
+   ```
+
+Use `scripts/trivy_scan.sh` to scan the images built with `docker-compose.ci.yaml`.

--- a/scripts/trivy_scan.sh
+++ b/scripts/trivy_scan.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+COMPOSE_FILE=${1:-docker-compose.ci.yaml}
+TRIVY_VERSION=${TRIVY_VERSION:-0.47.0}
+TRIVY_CMD=${TRIVY_CMD:-trivy}
+
+if ! command -v "$TRIVY_CMD" >/dev/null 2>&1; then
+  echo "Trivy not found; installing version $TRIVY_VERSION..."
+  curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b . "$TRIVY_VERSION"
+  TRIVY_CMD=./trivy
+fi
+
+# Scan each built image referenced by the compose file
+for image in $(docker compose -f "$COMPOSE_FILE" images -q); do
+  echo "Scanning $image"
+  "$TRIVY_CMD" image --exit-code 1 --severity HIGH,CRITICAL "$image"
+  echo
+done


### PR DESCRIPTION
## Summary
- scan built containers with Trivy
- support offline Trivy installation
- mention Trivy in the changelog

## Testing
- `ruff check .`
- `pytest -q`
- `bash scripts/check_docs.sh`
- `pre-commit run --files .github/workflows/ci.yml docs/CHANGELOG.md docs/offline-setup.md scripts/trivy_scan.sh` *(fails: SSL CERTIFICATE_VERIFY_FAILED)*

------
https://chatgpt.com/codex/tasks/task_e_68638f455bb083208d4e898953de0b34