### PR TITLE
Add MIT license to pyproject

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -360,6 +360,7 @@ All notable changes to this project will be recorded in this file.
 - CI workflow now uses the GitHub CLI for issue automation tasks instead of third-party actions.
 - Improved CI failure issue detection to search titles for the current commit SHA.
 - Added `DISCORD_API_TIMEOUT` environment variable and enforced HTTP timeouts when contacting Discord APIs.
+- Added `license = {text = "MIT"}` to `pyproject.toml`.
 
 ## [0.1.0] - 2025-06-14
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ name = "devonboarder"
 version = "0.1.0"
 description = "Sample trunk-based workflow project"
 readme = "README.md"
+license = {text = "MIT"}
 requires-python = ">=3.13"
 dependencies = [
     "httpx<0.29",


### PR DESCRIPTION
## Summary
- document the MIT license in pyproject
- note the change in the changelog

## Testing Steps
- `python -m build`


------
https://chatgpt.com/codex/tasks/task_e_68640f1f0634832091a804a68dabe1a2