### PR TITLE
Update coverage docs

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be recorded in this file.
 
 ## [Unreleased]
 - Added `tests/README.md` describing how to install project requirements before running `pytest` so modules like `fastapi` are available.
+- Documented the 95% coverage requirement and how to run Python and JavaScript coverage tests in `tests/README.md`.
 
 - Clarified README instructions to stop the server with Ctrl+C.
 - Removed unused `REDIS_URL`, `LOG_LEVEL`, and `API_KEY` from `.env.example` and

--- a/tests/README.md
+++ b/tests/README.md
@@ -14,3 +14,16 @@ pytest -q
 ```
 
 Use `make test` to run the linter and all test suites at once.
+
+CI requires every suite to maintain **95%** code coverage. Run the Python tests
+with coverage enabled:
+
+```bash
+pytest --cov=src --cov-fail-under=95
+```
+
+Run JavaScript coverage from the `bot/` and `frontend/` directories:
+
+```bash
+npm run coverage
+```


### PR DESCRIPTION
## Summary
- clarify test coverage requirement in tests/README
- document how to run coverage for Python and JS packages
- log the documentation update in CHANGELOG

## Testing
- `pytest -q`
- `pytest --cov=src --cov-fail-under=95` *(fails: Required test coverage of 95% not reached)*
- `pre-commit run --files tests/README.md docs/CHANGELOG.md` *(fails: nodeenv SSL certificate verify failed)*

------
https://chatgpt.com/codex/tasks/task_e_686412cd2fd88320bdf5eec59923edb0