### PR TITLE
Remove API_KEY from secrets script

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be recorded in this file.
 - Replaced `node-fetch` with the global `fetch` in the Discord bot and updated tests.
 - Prettier now runs only via the pre-commit mirror. Removed duplicate `npm run format` hooks from `.pre-commit-config.yaml`.
 - Upgraded React packages to 19.1.0 and `dotenv` to 17.0.1.
+- Removed the `API_KEY` generation step from `scripts/generate-secrets.sh`.
 
 - Added `scripts/check_dependencies.sh` and documented running it from `docs/README.md` and `docs/doc-quality-onboarding.md`.
 

--- a/scripts/generate-secrets.sh
+++ b/scripts/generate-secrets.sh
@@ -20,6 +20,5 @@ cp .env.example "$ENV_FILE"
 write_env "JWT_SECRET_KEY" "$(openssl rand -hex 32)"
 write_env "DISCORD_CLIENT_SECRET" "$(openssl rand -base64 24 | tr '/+' '_-')"
 write_env "DISCORD_BOT_TOKEN" "$(openssl rand -hex 32)"
-write_env "API_KEY" "$(openssl rand -hex 20)"
 
 echo "✅ Generated secrets in $ENV_FILE"


### PR DESCRIPTION
## Summary
- stop generating API_KEY in `generate-secrets.sh`
- document the change in `CHANGELOG`

## Testing
- `pre-commit run --files scripts/generate-secrets.sh docs/CHANGELOG.md` *(fails: calledProcessError checkout v3.6.2)*
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686426a5a25c83209938fddeb806ac1e