### PR TITLE
Fix CI failure auto-close

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,26 +237,13 @@ jobs:
               with:
                   name: ci-failure-issue
                   path: ci_failure_issue.txt
-            - name: Download CI failure issue artifact
-              if: success()
-              uses: actions/download-artifact@v4
-              with:
-                  name: ci-failure-issue
-                  path: .
-                  if-no-files-found: ignore
-            - name: Set CI failure issue env var
-              if: success()
-              run: |
-                  if [ -f ci_failure_issue.txt ]; then
-                      echo "CI_FAILURE_ISSUE_NUMBER=$(cat ci_failure_issue.txt)" >> "$GITHUB_ENV"
-                  fi
-            - name: Comment on CI failure issue
-              if: success() && env.CI_FAILURE_ISSUE_NUMBER != ''
-              run: gh issue comment ${{ env.CI_FAILURE_ISSUE_NUMBER }} --body "CI run ${{ github.run_id }} for `${{ github.sha }}` succeeded. Closing this issue."
-              env:
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-            - name: Close CI failure issue
-              if: success() && env.CI_FAILURE_ISSUE_NUMBER != ''
-              run: gh issue close ${{ env.CI_FAILURE_ISSUE_NUMBER }}
-              env:
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              - name: Close CI failure issue
+                if: success()
+                run: |
+                    ISSUE=$(gh issue list --state open --search "CI Failures for ${{ github.sha }} in:title" --json number --jq '.[0].number')
+                    if [ -n "$ISSUE" ]; then
+                        gh issue comment "$ISSUE" --body "CI run ${{ github.run_id }} for \`${{ github.sha }}\` succeeded. Closing this issue."
+                        gh issue close "$ISSUE"
+                    fi
+                env:
+                    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -362,6 +362,7 @@ All notable changes to this project will be recorded in this file.
 
 - CI workflow now uses the GitHub CLI for issue automation tasks instead of third-party actions.
 - Improved CI failure issue detection to search titles for the current commit SHA.
+- CI workflow now closes any open CI failure issue for the current commit by searching titles rather than using artifacts.
 - Added `DISCORD_API_TIMEOUT` environment variable and enforced HTTP timeouts when contacting Discord APIs.
 - Added `license = {text = "MIT"}` to `pyproject.toml`.
 - Dependabot now monitors `/frontend` and `/bot` for npm updates.


### PR DESCRIPTION
## Summary
- close CI failure issue by searching open issues for current commit
- document updated closing logic in changelog

## Testing
- `ruff check .`
- `pytest -q`
- `bash scripts/check_docs.sh` *(fails: Vale not found)*

------
https://chatgpt.com/codex/tasks/task_e_68642ddc4f208320b4694d634f4f6a52