### PR TITLE
Update docs about GITHUB_TOKEN

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -369,6 +369,7 @@ All notable changes to this project will be recorded in this file.
 - Upgraded React to v19 and dotenv to v17.
 - Aligned Prettier version 3.6.2 across configuration and docs.
 - Documented the 95% coverage policy in `docs/doc-quality-onboarding.md`.
+- Documented that CI failure issues use the built-in `GITHUB_TOKEN`; no personal token is required unless `permissions:` removes `issues: write`.
 
 ## [0.1.0] - 2025-06-14
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -157,3 +157,4 @@ See [doc-quality-onboarding.md](doc-quality-onboarding.md) for a step-by-step gu
 4. Review [sample-pr.md](sample-pr.md) for an end-to-end example.
 5. See the Codex CI Monitoring Policy in [../AGENTS.md](../AGENTS.md) for how failed CI jobs automatically create tasks.
 6. When CI fails, an issue titled `CI Failures for <sha>` is opened or updated with a summary of the failing tests and links to the artifacts.
+7. The workflow uses GitHub's built-in `GITHUB_TOKEN` to manage CI failure issues. No personal token is required unless you override permissions with a `permissions:` block (include `issues: write`).


### PR DESCRIPTION
## Summary
- document that the CI failure issue automation uses the built-in `GITHUB_TOKEN`
- note that no personal token is needed unless overriding permissions

## Testing
- `pre-commit run --files docs/README.md docs/CHANGELOG.md` *(fails: error: pathspec 'v3.6.2' did not match any file)*

------
https://chatgpt.com/codex/tasks/task_e_686435f8cad483208ace0a62fa5e67e1