### PR TITLE
Add CI failure cleanup workflow

### DIFF
--- a/.github/workflows/cleanup-ci-failure.yml
+++ b/.github/workflows/cleanup-ci-failure.yml
@@ -1,0 +1,15 @@
+on:
+  schedule:
+    - cron: '0 0 * * *'
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - run: |
+          for n in $(gh issue list --label ci-failure --state open --json number --jq '.[].number'); do
+            gh issue close "$n" --reason completed
+          done
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -370,6 +370,7 @@ All notable changes to this project will be recorded in this file.
 - Aligned Prettier version 3.6.2 across configuration and docs.
 - Documented the 95% coverage policy in `docs/doc-quality-onboarding.md`.
 - Documented that CI failure issues use the built-in `GITHUB_TOKEN`; no personal token is required unless `permissions:` removes `issues: write`.
+- Added `cleanup-ci-failure.yml` workflow to close stale `ci-failure` issues nightly and documented the job in `docs/README.md`.
 
 ## [0.1.0] - 2025-06-14
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -158,3 +158,4 @@ See [doc-quality-onboarding.md](doc-quality-onboarding.md) for a step-by-step gu
 5. See the Codex CI Monitoring Policy in [../AGENTS.md](../AGENTS.md) for how failed CI jobs automatically create tasks.
 6. When CI fails, an issue titled `CI Failures for <sha>` is opened or updated with a summary of the failing tests and links to the artifacts.
 7. The workflow uses GitHub's built-in `GITHUB_TOKEN` to manage CI failure issues. No personal token is required unless you override permissions with a `permissions:` block (include `issues: write`).
+8. A nightly job (`cleanup-ci-failure.yml`) closes any open `ci-failure` issues so the board stays tidy.


### PR DESCRIPTION
## Summary
- close stale CI failure issues each night via GitHub CLI
- document the cleanup job in the contributor docs
- record the workflow in the changelog

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68643eabce808320b2157820414edc1f