### PR TITLE
Grant CI issue permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
     push:
     pull_request:
 
+permissions:
+    issues: write
+
 jobs:
     test:
         runs-on: ubuntu-latest

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -371,6 +371,7 @@ All notable changes to this project will be recorded in this file.
 - Documented the 95% coverage policy in `docs/doc-quality-onboarding.md`.
 - Documented that CI failure issues use the built-in `GITHUB_TOKEN`; no personal token is required unless `permissions:` removes `issues: write`.
 - Added `cleanup-ci-failure.yml` workflow to close stale `ci-failure` issues nightly and documented the job in `docs/README.md`.
+- Granted `issues: write` permission in `ci.yml` so forks can open and close CI failure issues with the built-in token.
 
 ## [0.1.0] - 2025-06-14
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -157,5 +157,5 @@ See [doc-quality-onboarding.md](doc-quality-onboarding.md) for a step-by-step gu
 4. Review [sample-pr.md](sample-pr.md) for an end-to-end example.
 5. See the Codex CI Monitoring Policy in [../AGENTS.md](../AGENTS.md) for how failed CI jobs automatically create tasks.
 6. When CI fails, an issue titled `CI Failures for <sha>` is opened or updated with a summary of the failing tests and links to the artifacts.
-7. The workflow uses GitHub's built-in `GITHUB_TOKEN` to manage CI failure issues. No personal token is required unless you override permissions with a `permissions:` block (include `issues: write`).
+7. The CI workflow grants `issues: write` permission to the built-in `GITHUB_TOKEN` so it can open and close CI failure issues on forks.
 8. A nightly job (`cleanup-ci-failure.yml`) closes any open `ci-failure` issues so the board stays tidy.


### PR DESCRIPTION
## Summary
- allow the workflow token to manage issues
- clarify the permission in the docs
- log the change

## Testing
- `bash scripts/run_tests.sh` *(fails: `npm ci` lockfile mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68644216a9708320a0a77e1cda483c1c