### PR TITLE
docs: Document CI failure issue cleanup steps

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be recorded in this file.
 ## [Unreleased]
 - Added `tests/README.md` describing how to install project requirements before running `pytest` so modules like `fastapi` are available.
 - Documented the 95% coverage requirement and how to run Python and JavaScript coverage tests in `tests/README.md`.
+- Documented manual cleanup of `ci-failure` issues in `docs/ci-failure-issues.md`.
 
 - Clarified README instructions to stop the server with Ctrl+C.
 - Removed unused `REDIS_URL`, `LOG_LEVEL`, and `API_KEY` from `.env.example` and

--- a/docs/README.md
+++ b/docs/README.md
@@ -93,6 +93,8 @@ platforms. Please report any issues you encounter on your operating system.
   &ndash; work around pre-commit `nodeenv` SSL errors and other network restrictions.
 - [Troubleshooting guide](troubleshooting.md)
   &ndash; quick fixes for setup problems and failing CI jobs.
+- [CI failure issue management](ci-failure-issues.md)
+  &ndash; how automatic cleanup works and how to close old issues.
 - [Offline setup](offline-setup.md) &ndash; download Python wheels and npm packages on another machine.
 - [Security audit](security-audit-2025-07-01.md) &ndash; latest dependency check results.
 - [Environment variables](env.md) &ndash; explanation of `.env` settings and the role-based permission system.

--- a/docs/ci-failure-issues.md
+++ b/docs/ci-failure-issues.md
@@ -1,0 +1,46 @@
+# Managing CI Failure Issues
+
+When the CI workflow fails, it opens or updates an issue titled `CI Failures for <sha>` with a summary of the failing tests. The workflow closes the issue automatically once the same commit passes CI.
+
+## Automatic Cleanup
+
+- `ci.yml` searches for an open failure issue matching the commit SHA whenever the pipeline succeeds.
+- If found, the workflow comments on the issue and closes it using the built-in `GITHUB_TOKEN`.
+
+## Clearing Old Issues
+
+Past failures may leave old `ci-failure` issues open. You can close them in bulk with the GitHub CLI:
+
+```bash
+export GH_TOKEN=your_personal_token
+for n in $(gh issue list --label ci-failure --state open --json number --jq '.[].number'); do
+  gh issue close "$n" --reason completed
+  echo "Closed CI-failure issue #$n"
+done
+```
+
+## One-Time Cleanup Workflow
+
+Add a workflow file to run the same commands on GitHub:
+
+```yaml
+name: Bulk Close CI-failure Issues
+
+on:
+  workflow_dispatch:
+
+jobs:
+  close-ci-failure-issues:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Bulk close all open ci-failure issues
+        run: |
+          for n in $(gh issue list --label ci-failure --state open --json number --jq '.[].number'); do
+            gh issue close "$n" --reason completed
+            echo "Closed CI-failure issue #$n"
+          done
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+Trigger the workflow from the **Actions** tab using the **Run workflow** button. Schedule it with a `schedule:` trigger if you want regular cleanup.


### PR DESCRIPTION
## Summary
- add doc explaining how to close leftover CI failure issues
- link the doc from the documentation index
- mention the new guide in the changelog

## Testing
- `bash scripts/check_docs.sh`
- `bash scripts/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68644212e1288320874cd99d8d8d5edc