### PR TITLE
Close all ci-failure issues on success

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,13 +240,13 @@ jobs:
               with:
                   name: ci-failure-issue
                   path: ci_failure_issue.txt
-              - name: Close CI failure issue
-                if: success()
-                run: |
-                    ISSUE=$(gh issue list --state open --search "CI Failures for ${{ github.sha }} in:title" --json number --jq '.[0].number')
-                    if [ -n "$ISSUE" ]; then
-                        gh issue comment "$ISSUE" --body "CI run ${{ github.run_id }} for \`${{ github.sha }}\` succeeded. Closing this issue."
-                        gh issue close "$ISSUE"
-                    fi
-                env:
+            - name: Close CI failure issue
+              if: success()
+              run: |
+                    ISSUES=$(gh issue list --label ci-failure --state open --json number --jq '.[].number')
+                    for ISSUE in $ISSUES; do
+                      gh issue comment "$ISSUE" --body "CI run ${{ github.run_id }} passed. Closing."
+                      gh issue close "$ISSUE"
+                    done
+              env:
                     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be recorded in this file.
 - Added `tests/README.md` describing how to install project requirements before running `pytest` so modules like `fastapi` are available.
 - Documented the 95% coverage requirement and how to run Python and JavaScript coverage tests in `tests/README.md`.
 - Documented manual cleanup of `ci-failure` issues in `docs/ci-failure-issues.md`.
+- CI workflow now closes every open `ci-failure` issue once the pipeline succeeds.
 
 - Clarified README instructions to stop the server with Ctrl+C.
 - Removed unused `REDIS_URL`, `LOG_LEVEL`, and `API_KEY` from `.env.example` and

--- a/docs/README.md
+++ b/docs/README.md
@@ -159,5 +159,5 @@ See [doc-quality-onboarding.md](doc-quality-onboarding.md) for a step-by-step gu
 4. Review [sample-pr.md](sample-pr.md) for an end-to-end example.
 5. See the Codex CI Monitoring Policy in [../AGENTS.md](../AGENTS.md) for how failed CI jobs automatically create tasks.
 6. When CI fails, an issue titled `CI Failures for <sha>` is opened or updated with a summary of the failing tests and links to the artifacts.
-7. The CI workflow grants `issues: write` permission to the built-in `GITHUB_TOKEN` so it can open and close CI failure issues on forks.
+7. The CI workflow uses the built-in `GITHUB_TOKEN` with `issues: write` permission. When the pipeline succeeds, it closes every open `ci-failure` issue.
 8. A nightly job (`cleanup-ci-failure.yml`) closes any open `ci-failure` issues so the board stays tidy.

--- a/docs/ci-failure-issues.md
+++ b/docs/ci-failure-issues.md
@@ -1,11 +1,10 @@
 # Managing CI Failure Issues
 
-When the CI workflow fails, it opens or updates an issue titled `CI Failures for <sha>` with a summary of the failing tests. The workflow closes the issue automatically once the same commit passes CI.
+When the CI workflow fails, it opens or updates an issue titled `CI Failures for <sha>` with a summary of the failing tests. The workflow closes all open `ci-failure` issues once any CI run succeeds.
 
 ## Automatic Cleanup
 
-- `ci.yml` searches for an open failure issue matching the commit SHA whenever the pipeline succeeds.
-- If found, the workflow comments on the issue and closes it using the built-in `GITHUB_TOKEN`.
+- `ci.yml` closes every open `ci-failure` issue whenever the pipeline succeeds using the built-in `GITHUB_TOKEN`.
 
 ## Clearing Old Issues
 


### PR DESCRIPTION
## Summary
- ensure the workflow closes every open `ci-failure` issue on success
- document the new behavior in `docs/ci-failure-issues.md` and `docs/README.md`
- record the change in the changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686446c28c84832093b30616ba281abe