### PR TITLE
Update CI to install GitHub CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ jobs:
 
         steps:
             - uses: actions/checkout@v3
+            - name: Install GitHub CLI
+              run: |
+                  curl -fsSL https://github.com/cli/cli/releases/latest/download/gh-install.sh | sudo bash
             - name: Set up Python
               uses: actions/setup-python@v4
               with:

--- a/.github/workflows/cleanup-ci-failure.yml
+++ b/.github/workflows/cleanup-ci-failure.yml
@@ -7,6 +7,9 @@ jobs:
     permissions:
       issues: write
     steps:
+      - name: Install GitHub CLI
+        run: |
+          curl -fsSL https://github.com/cli/cli/releases/latest/download/gh-install.sh | sudo bash
       - run: |
           for n in $(gh issue list --label ci-failure --state open --json number --jq '.[].number'); do
             gh issue close "$n" --reason completed

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be recorded in this file.
 - Documented the 95% coverage requirement and how to run Python and JavaScript coverage tests in `tests/README.md`.
 - Documented manual cleanup of `ci-failure` issues in `docs/ci-failure-issues.md`.
 - CI workflow now closes every open `ci-failure` issue once the pipeline succeeds.
+- CI workflows install the latest GitHub CLI using a cross-platform script.
 
 - Clarified README instructions to stop the server with Ctrl+C.
 - Removed unused `REDIS_URL`, `LOG_LEVEL`, and `API_KEY` from `.env.example` and

--- a/docs/ci-failure-issues.md
+++ b/docs/ci-failure-issues.md
@@ -10,6 +10,8 @@ When the CI workflow fails, it opens or updates an issue titled `CI Failures for
 
 Past failures may leave old `ci-failure` issues open. You can close them in bulk with the GitHub CLI:
 
+> **Note**: These examples require GitHub CLI v2 or later for the `--json` and `--jq` flags.
+
 ```bash
 export GH_TOKEN=your_personal_token
 for n in $(gh issue list --label ci-failure --state open --json number --jq '.[].number'); do


### PR DESCRIPTION
## Summary
- install GitHub CLI in CI workflow before any gh commands
- do the same in the cleanup workflow
- note GitHub CLI v2 requirement for json flags
- record workflow change in changelog

## Testing
- `bash scripts/run_tests.sh` *(fails: npm ci error)*

------
https://chatgpt.com/codex/tasks/task_e_68644dea6a2483209f4aac7c1d9e2d0b