### PR TITLE
Update GitHub CLI install in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,17 @@ jobs:
         steps:
             - uses: actions/checkout@v3
             - name: Install GitHub CLI
+              shell: bash
               run: |
-                  curl -fsSL https://github.com/cli/cli/releases/latest/download/gh-install.sh | sudo bash
+                  set -e
+                  if [ "$RUNNER_OS" = "Windows" ]; then
+                      choco install gh --no-progress --yes
+                  elif [ "$RUNNER_OS" = "macOS" ]; then
+                      brew install gh
+                  else
+                      sudo apt-get update
+                      sudo apt-get install -y --no-install-recommends gh
+                  fi
             - name: Set up Python
               uses: actions/setup-python@v4
               with:

--- a/.github/workflows/cleanup-ci-failure.yml
+++ b/.github/workflows/cleanup-ci-failure.yml
@@ -8,8 +8,17 @@ jobs:
       issues: write
     steps:
       - name: Install GitHub CLI
+        shell: bash
         run: |
-          curl -fsSL https://github.com/cli/cli/releases/latest/download/gh-install.sh | sudo bash
+          set -e
+          if [ "$RUNNER_OS" = "Windows" ]; then
+              choco install gh --no-progress --yes
+          elif [ "$RUNNER_OS" = "macOS" ]; then
+              brew install gh
+          else
+              sudo apt-get update
+              sudo apt-get install -y --no-install-recommends gh
+          fi
       - run: |
           for n in $(gh issue list --label ci-failure --state open --json number --jq '.[].number'); do
             gh issue close "$n" --reason completed

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be recorded in this file.
 - Documented the 95% coverage requirement and how to run Python and JavaScript coverage tests in `tests/README.md`.
 - Documented manual cleanup of `ci-failure` issues in `docs/ci-failure-issues.md`.
 - CI workflow now closes every open `ci-failure` issue once the pipeline succeeds.
-- CI workflows install the latest GitHub CLI using a cross-platform script.
+- Replaced `gh-install.sh` with a cross-platform GitHub CLI installation script.
 
 - Clarified README instructions to stop the server with Ctrl+C.
 - Removed unused `REDIS_URL`, `LOG_LEVEL`, and `API_KEY` from `.env.example` and


### PR DESCRIPTION
## Summary
- use a cross-platform script to install the GitHub CLI
- document the new installation script in the changelog

## Testing
- `bash scripts/run_tests.sh`
- `pre-commit run --files .github/workflows/ci.yml .github/workflows/cleanup-ci-failure.yml docs/CHANGELOG.md` *(fails: pathspec 'v3.6.2' did not match any file(s))*

------
https://chatgpt.com/codex/tasks/task_e_6864a06d242883209f838538305246f1