### PR TITLE
Update CI to install GitHub CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ jobs:
 
         steps:
             - uses: actions/checkout@v3
+            - name: Install GitHub CLI
+              run: |
+                  curl -fsSL https://github.com/cli/cli/releases/latest/download/gh-install.sh | sudo bash
             - name: Set up Python
               uses: actions/setup-python@v4
               with:

--- a/.github/workflows/cleanup-ci-failure.yml
+++ b/.github/workflows/cleanup-ci-failure.yml
@@ -7,6 +7,9 @@ jobs:
     permissions:
       issues: write
     steps:
+      - name: Install GitHub CLI
+        run: |
+          curl -fsSL https://github.com/cli/cli/releases/latest/download/gh-install.sh | sudo bash
       - run: |
           for n in $(gh issue list --label ci-failure --state open --json number --jq '.[].number'); do
             gh issue close "$n" --reason completed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,12 @@ docs: Document built-in GITHUB_TOKEN usage for CI failure issues
 
 See [docs/git-guidelines.md](./docs/git-guidelines.md) and the files under [docs/git/](./docs/git/) for additional Git best practices.
 
+## Commit History Policy: No Rewriting or Force-Pushing
+
+- **Commit messages on pushed commits cannot be changed.** Once a commit is pushed to a shared branch, avoid `git commit --amend`, interactive rebases, and `git push --force`.
+- If a commit message is unclear, add context in a new commit or the pull request description instead of rewriting history.
+- This rule preserves repository integrity and auditability.
+
 ## Potato Ignore Policy
 
 "Potato" and `Potato.md` must remain in `.gitignore`, `.dockerignore`, and `.codespell-ignore`.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be recorded in this file.
 - Documented the 95% coverage requirement and how to run Python and JavaScript coverage tests in `tests/README.md`.
 - Documented manual cleanup of `ci-failure` issues in `docs/ci-failure-issues.md`.
 - CI workflow now closes every open `ci-failure` issue once the pipeline succeeds.
+- CI workflows install the latest GitHub CLI using a cross-platform script.
+- Documented policy against rewriting commit history or force-pushing after commits are pushed.
 
 - Clarified README instructions to stop the server with Ctrl+C.
 - Removed unused `REDIS_URL`, `LOG_LEVEL`, and `API_KEY` from `.env.example` and

--- a/docs/ci-failure-issues.md
+++ b/docs/ci-failure-issues.md
@@ -10,6 +10,8 @@ When the CI workflow fails, it opens or updates an issue titled `CI Failures for
 
 Past failures may leave old `ci-failure` issues open. You can close them in bulk with the GitHub CLI:
 
+> **Note**: These examples require GitHub CLI v2 or later for the `--json` and `--jq` flags.
+
 ```bash
 export GH_TOKEN=your_personal_token
 for n in $(gh issue list --label ci-failure --state open --json number --jq '.[].number'); do

--- a/docs/git-guidelines.md
+++ b/docs/git-guidelines.md
@@ -49,6 +49,10 @@ git pull --rebase origin main
 Pull requests are merged using **Squash and merge** to keep history linear.
 Delete the feature branch after the merge completes.
 
+## Commit History Policy
+
+Once commits are pushed to a shared branch, avoid rewriting history. Do not run `git commit --amend`, `git rebase -i`, or `git push --force`. If you need to clarify a message, create a follow-up commit or add details in the pull request description.
+
 ## Pre-PR Checklist
 
  - Before opening a pull request, make sure to:


### PR DESCRIPTION
## Summary
- install GitHub CLI in CI workflow before any gh commands
- do the same in the cleanup workflow
- note GitHub CLI v2 requirement for json flags
- record workflow change in changelog
- document no-force-push policy in AGENTS and contributor guidelines

## Testing
- `bash scripts/run_tests.sh` *(tests pass)*

------
https://chatgpt.com/codex/tasks/task_e_68644dea6a2483209f4aac7c1d9e2d0b