### PR TITLE
Update GitHub CLI install in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,17 @@ jobs:
                   elif [ "$RUNNER_OS" = "macOS" ]; then
                       brew install gh
                   else
+                      sudo mkdir -p -m 0755 /etc/apt/keyrings
+                      curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg |
+                        sudo dd of=/etc/apt/keyrings/githubcli-archive-keyring.gpg
+                      sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
+                      echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" |
+                        sudo tee /etc/apt/sources.list.d/github-cli.list >/dev/null
                       sudo apt-get update
-                      sudo apt-get install -y --no-install-recommends gh
+                      sudo apt-get install -y gh
                   fi
+            - name: Show gh version
+              run: gh --version
             - name: Set up Python
               uses: actions/setup-python@v4
               with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,12 @@ jobs:
                       sudo apt-get update
                       sudo apt-get install -y gh
                   fi
+            - name: Ensure latest gh is in PATH
+              run: echo "/usr/local/bin" >> "$GITHUB_PATH"
             - name: Show gh version
-              run: gh --version
+              run: |
+                  which gh
+                  gh --version
             - name: Set up Python
               uses: actions/setup-python@v4
               with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
                       sudo apt-get install -y gh
                   fi
             - name: Ensure latest gh is in PATH
-              run: echo "/usr/local/bin" >> "$GITHUB_PATH"
+              run: echo "/usr/local/bin" >> $GITHUB_PATH
             - name: Show gh version
               run: |
                   which gh

--- a/.github/workflows/cleanup-ci-failure.yml
+++ b/.github/workflows/cleanup-ci-failure.yml
@@ -25,8 +25,12 @@ jobs:
                       sudo apt-get update
                       sudo apt-get install -y gh
                   fi
+            - name: Ensure latest gh is in PATH
+              run: echo "/usr/local/bin" >> "$GITHUB_PATH"
             - name: Show gh version
-              run: gh --version
+              run: |
+                  which gh
+                  gh --version
             - run: |
                   for n in $(gh issue list --label ci-failure --state open --json number --jq '.[].number'); do
                     gh issue close "$n" --reason completed

--- a/.github/workflows/cleanup-ci-failure.yml
+++ b/.github/workflows/cleanup-ci-failure.yml
@@ -16,9 +16,17 @@ jobs:
                   elif [ "$RUNNER_OS" = "macOS" ]; then
                       brew install gh
                   else
+                      sudo mkdir -p -m 0755 /etc/apt/keyrings
+                      curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg |
+                        sudo dd of=/etc/apt/keyrings/githubcli-archive-keyring.gpg
+                      sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
+                      echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" |
+                        sudo tee /etc/apt/sources.list.d/github-cli.list >/dev/null
                       sudo apt-get update
-                      sudo apt-get install -y --no-install-recommends gh
+                      sudo apt-get install -y gh
                   fi
+            - name: Show gh version
+              run: gh --version
             - run: |
                   for n in $(gh issue list --label ci-failure --state open --json number --jq '.[].number'); do
                     gh issue close "$n" --reason completed

--- a/.github/workflows/cleanup-ci-failure.yml
+++ b/.github/workflows/cleanup-ci-failure.yml
@@ -26,7 +26,7 @@ jobs:
                       sudo apt-get install -y gh
                   fi
             - name: Ensure latest gh is in PATH
-              run: echo "/usr/local/bin" >> "$GITHUB_PATH"
+              run: echo "/usr/local/bin" >> $GITHUB_PATH
             - name: Show gh version
               run: |
                   which gh

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,9 +8,8 @@ All notable changes to this project will be recorded in this file.
 - Documented manual cleanup of `ci-failure` issues in `docs/ci-failure-issues.md`.
 - CI workflow now closes every open `ci-failure` issue once the pipeline succeeds.
 - Replaced `gh-install.sh` with a cross-platform GitHub CLI installation script.
-- CI workflows install the latest GitHub CLI using a cross-platform script.
-- CI workflows now install GitHub CLI from cli.github.com and log the version.
-- CI workflows ensure the latest GitHub CLI is used by adding /usr/local/bin to PATH.
+- CI workflows install the latest GitHub CLI from cli.github.com and log the version.
+- They update PATH via `$GITHUB_PATH` so `/usr/local/bin` takes precedence.
 - Documented policy against rewriting commit history or force-pushing after commits are pushed.
 
 - Clarified README instructions to stop the server with Ctrl+C.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be recorded in this file.
 - Replaced `gh-install.sh` with a cross-platform GitHub CLI installation script.
 - CI workflows install the latest GitHub CLI using a cross-platform script.
 - CI workflows now install GitHub CLI from cli.github.com and log the version.
+- CI workflows ensure the latest GitHub CLI is used by adding /usr/local/bin to PATH.
 - Documented policy against rewriting commit history or force-pushing after commits are pushed.
 
 - Clarified README instructions to stop the server with Ctrl+C.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be recorded in this file.
 - CI workflow now closes every open `ci-failure` issue once the pipeline succeeds.
 - Replaced `gh-install.sh` with a cross-platform GitHub CLI installation script.
 - CI workflows install the latest GitHub CLI using a cross-platform script.
+- CI workflows now install GitHub CLI from cli.github.com and log the version.
 - Documented policy against rewriting commit history or force-pushing after commits are pushed.
 
 - Clarified README instructions to stop the server with Ctrl+C.


### PR DESCRIPTION
## Summary
- install GitHub CLI from cli.github.com packages for cross-platform support
- log installed GitHub CLI version
- document workflow update in changelog

## Testing
- `ruff check .`
- `pytest -q`
- `bash scripts/check_docs.sh` *(fails: Vale not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6864a8afc0fc832092bb08d26813a359