### PR TITLE
CI reuse GH CLI action

### DIFF
--- a/.github/actions/setup-gh-cli/action.yml
+++ b/.github/actions/setup-gh-cli/action.yml
@@ -1,0 +1,22 @@
+name: Setup GitHub CLI
+runs:
+  using: composite
+  steps:
+    - name: Install GitHub CLI
+      shell: bash
+      run: |
+        set -e
+        if [ "$RUNNER_OS" = "Windows" ]; then
+            choco install gh --no-progress --yes
+        elif [ "$RUNNER_OS" = "macOS" ]; then
+            brew install gh
+        else
+            sudo mkdir -p -m 0755 /etc/apt/keyrings
+            curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg |
+              sudo dd of=/etc/apt/keyrings/githubcli-archive-keyring.gpg
+            sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
+            echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" |
+              sudo tee /etc/apt/sources.list.d/github-cli.list >/dev/null
+            sudo apt-get update
+            sudo apt-get install -y gh
+        fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,26 +15,9 @@ jobs:
 
         steps:
             - uses: actions/checkout@v3
-            - name: Install GitHub CLI
-              shell: bash
-              run: |
-                  set -e
-                  if [ "$RUNNER_OS" = "Windows" ]; then
-                      choco install gh --no-progress --yes
-                  elif [ "$RUNNER_OS" = "macOS" ]; then
-                      brew install gh
-                  else
-                      sudo mkdir -p -m 0755 /etc/apt/keyrings
-                      curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg |
-                        sudo dd of=/etc/apt/keyrings/githubcli-archive-keyring.gpg
-                      sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
-                      echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" |
-                        sudo tee /etc/apt/sources.list.d/github-cli.list >/dev/null
-                      sudo apt-get update
-                      sudo apt-get install -y gh
-                  fi
-            - name: Ensure latest gh is in PATH
-              run: echo "/usr/local/bin" >> $GITHUB_PATH
+            - name: Lint commit messages
+              run: bash scripts/check_commit_messages.sh
+            - uses: ./.github/actions/setup-gh-cli
             - name: Show gh version
               run: |
                   which gh

--- a/.github/workflows/cleanup-ci-failure.yml
+++ b/.github/workflows/cleanup-ci-failure.yml
@@ -7,26 +7,7 @@ jobs:
         permissions:
             issues: write
         steps:
-            - name: Install GitHub CLI
-              shell: bash
-              run: |
-                  set -e
-                  if [ "$RUNNER_OS" = "Windows" ]; then
-                      choco install gh --no-progress --yes
-                  elif [ "$RUNNER_OS" = "macOS" ]; then
-                      brew install gh
-                  else
-                      sudo mkdir -p -m 0755 /etc/apt/keyrings
-                      curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg |
-                        sudo dd of=/etc/apt/keyrings/githubcli-archive-keyring.gpg
-                      sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
-                      echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" |
-                        sudo tee /etc/apt/sources.list.d/github-cli.list >/dev/null
-                      sudo apt-get update
-                      sudo apt-get install -y gh
-                  fi
-            - name: Ensure latest gh is in PATH
-              run: echo "/usr/local/bin" >> $GITHUB_PATH
+            - uses: ./.github/actions/setup-gh-cli
             - name: Show gh version
               run: |
                   which gh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ This repository follows the DevOnboarder protocol. Key points:
 3. **Development Environment**
 - Use the provided container setup and compose files for local development.
 - Ensure all tests pass before submitting a PR.
+- Workflows install the GitHub CLI using the reusable `.github/actions/setup-gh-cli` action.
 
 4. **Contribution Guidelines**
 - Keep pull requests focused and small.

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ devonboarder-auth
 The auth service listens on `http://localhost:8002`.
 
 The CI pipeline uses `docker-compose.ci.yaml` to start the Postgres database during tests.
+All workflows install the GitHub CLI via the reusable `.github/actions/setup-gh-cli` action.
 
 ## Codex Runs
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,9 +7,9 @@ All notable changes to this project will be recorded in this file.
 - Documented the 95% coverage requirement and how to run Python and JavaScript coverage tests in `tests/README.md`.
 - Documented manual cleanup of `ci-failure` issues in `docs/ci-failure-issues.md`.
 - CI workflow now closes every open `ci-failure` issue once the pipeline succeeds.
-- Replaced `gh-install.sh` with a cross-platform GitHub CLI installation script.
-- CI workflows install the latest GitHub CLI from cli.github.com and log the version.
-- They update PATH via `$GITHUB_PATH` so `/usr/local/bin` takes precedence.
+- Added a reusable `.github/actions/setup-gh-cli` action for installing the GitHub CLI.
+- Workflows log the install path with `which gh` and no longer modify `$GITHUB_PATH`.
+- CI now lints commit messages with `scripts/check_commit_messages.sh`.
 - Documented policy against rewriting commit history or force-pushing after commits are pushed.
 
 - Clarified README instructions to stop the server with Ctrl+C.

--- a/docs/git-guidelines.md
+++ b/docs/git-guidelines.md
@@ -78,6 +78,8 @@ pytest -q
 - Keep Prettier pinned to `v3.6.2`. Run
   `pre-commit autoupdate --repo https://github.com/pre-commit/mirrors-prettier`
   to confirm the hook installs correctly.
+- CI lints commit messages using `scripts/check_commit_messages.sh`.
+  Past violations do not require rewriting history.
 - Update `docs/CHANGELOG.md` with a short summary of your change.
 - Update any other relevant documentation under `docs/`.
 - Follow the pull request template in `docs/pull_request_template.md`.

--- a/scripts/check_commit_messages.sh
+++ b/scripts/check_commit_messages.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+regex='^(FEAT|FIX|DOCS|STYLE|REFACTOR|TEST|CHORE)(\([^)]+\))?: .+'
+messages=$(git log --format=%s origin/main..HEAD)
+if [ -z "$messages" ]; then
+  echo "No new commits to lint"
+  exit 0
+fi
+errors=0
+while IFS= read -r msg; do
+  if [[ ! $msg =~ $regex ]]; then
+    echo "::error ::Commit message '$msg' does not follow <type>(<scope>): <subject> format"
+    errors=$((errors+1))
+  fi
+done <<< "$messages"
+if [ $errors -ne 0 ]; then
+  echo "::error ::Found $errors commit message(s) that do not follow the required format."
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- use a composite action for GitHub CLI install
- lint commit messages in CI
- remove PATH modification and log gh location
- document new action and commit linter

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `./scripts/check_docs.sh` *(fails: Unable to download Vale)*

------
https://chatgpt.com/codex/tasks/task_e_6864b7e725248320bc804a00da3ccff2