### PR TITLE
Add GH CLI install script and docs

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be recorded in this file.
 
 ## [Unreleased]
+- Added `scripts/install_gh_cli.sh` for local GitHub CLI installation and referenced it in the docs.
 - Added `tests/README.md` describing how to install project requirements before running `pytest` so modules like `fastapi` are available.
 - Documented the 95% coverage requirement and how to run Python and JavaScript coverage tests in `tests/README.md`.
 - Documented manual cleanup of `ci-failure` issues in `docs/ci-failure-issues.md`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -68,6 +68,8 @@ Then set `LANGUAGETOOL_URL=http://localhost:8010/v2`.
     `COVERED_BRANCHES`, `TOTAL_BRANCHES`, and `BRANCH_PERCENT`.
     Pass an optional output filename as the first argument
     (defaults to `summary.md`).
+20. Install the GitHub CLI with `./scripts/install_gh_cli.sh` if you plan to run
+    scripts that use `gh` locally.
 
 The compose files define common service settings using YAML anchors. Each
 environment file overrides differences like `env_file` or exposed ports below the

--- a/docs/ci-failure-issues.md
+++ b/docs/ci-failure-issues.md
@@ -11,6 +11,7 @@ When the CI workflow fails, it opens or updates an issue titled `CI Failures for
 Past failures may leave old `ci-failure` issues open. You can close them in bulk with the GitHub CLI:
 
 > **Note**: These examples require GitHub CLI v2 or later for the `--json` and `--jq` flags.
+> Run `./scripts/install_gh_cli.sh` to install the CLI if it isn't already available.
 
 ```bash
 export GH_TOKEN=your_personal_token

--- a/scripts/install_gh_cli.sh
+++ b/scripts/install_gh_cli.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Install the GitHub CLI on Linux, macOS, or Windows
+set -euo pipefail
+
+if command -v gh >/dev/null 2>&1; then
+    echo "GitHub CLI already installed at $(which gh)"
+    gh --version
+    exit 0
+fi
+
+os="$(uname -s)"
+case "$os" in
+    Linux*)
+        if [ -f /etc/debian_version ]; then
+            sudo mkdir -p -m 0755 /etc/apt/keyrings
+            curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+              | sudo dd of=/etc/apt/keyrings/githubcli-archive-keyring.gpg
+            sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
+            echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+              | sudo tee /etc/apt/sources.list.d/github-cli.list >/dev/null
+            sudo apt-get update
+            sudo apt-get install -y gh
+        else
+            echo "Unsupported Linux distribution. Install GitHub CLI manually." >&2
+            exit 1
+        fi
+        ;;
+    Darwin*)
+        brew install gh
+        ;;
+    MINGW*|MSYS*|CYGWIN*|Windows*)
+        choco install gh --no-progress --yes
+        ;;
+    *)
+        echo "Unsupported OS: $os" >&2
+        exit 1
+        ;;
+esac
+
+which gh
+gh --version


### PR DESCRIPTION
## Summary
- script cross-platform GitHub CLI install for local use
- document new script in onboarding docs
- mention the helper in CI failure doc

## Testing
- `./scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6864bdca9c408320bdf36496b5226326