### PR TITLE
docs: replace outdated git TODO checklist

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be recorded in this file.
 - Added `CORS_ALLOW_ORIGINS` environment variable for configuring CORS.
 - Replaced `node-fetch` with the global `fetch` in the Discord bot and updated tests.
 - Prettier now runs only via the pre-commit mirror. Removed duplicate `npm run format` hooks from `.pre-commit-config.yaml`.
+- Replaced the outdated TODO section in `docs/git/Git.md` with a "Maintenance Notes" summary.
 - Upgraded React packages to 19.1.0 and `dotenv` to 17.0.1.
 - Removed the `API_KEY` generation step from `scripts/generate-secrets.sh`.
 

--- a/docs/git/Git.md
+++ b/docs/git/Git.md
@@ -16,7 +16,7 @@
     - [Add a second remote](#add-a-second-remote)
     - [Make a remote fetch-only](#make-a-remote-fetch-only)
     - [Rename a remote](#rename-a-remote)
-  - [TODO](#todo)
+  - [Maintenance Notes](#maintenance-notes)
   - [Git Commit Message SOP](#git-commit-message-sop)
     - [Purpose](#purpose)
     - [Guidelines](#guidelines)
@@ -202,13 +202,16 @@ git remote -v
 
 ---
 
-## TODO
+## Maintenance Notes
 
-- [ ] Verify `.gitignore` is accurate
-- [ ] Follow commit message SOP
-- [ ] Setup submodules when ready
-- [ ] Use Git hooks for linting and formatting
-- [ ] Reference merging and remote workflows in onboarding docs
+The following tasks are now part of our standard workflow:
+
+- `.gitignore` entries are validated by `scripts/check_potato_ignore.sh` and reviewed each release.
+- Commit messages follow the guidelines in [docs/git-guidelines.md](../git-guidelines.md).
+- Pre-commit hooks enforce linting and formatting.
+- Merging and remote management workflows are documented in [docs/git/README.md](./README.md).
+
+Submodule support will be revisited once the frontend and backend repositories stabilize.
 
 ---
 


### PR DESCRIPTION
## Summary
- replace obsolete TODO checklist in `docs/git/Git.md` with a Maintenance Notes section
- mention the update in the changelog

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6864bfee308c8320a7ea57dc2111680f