### PR TITLE
Add outreach materials and feedback log

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,9 @@ docker compose -f docker-compose.prod.yaml --env-file .env.prod up -d
 
 Licensed under the MIT License. See `LICENSE.md` for details.
 
+## Found DevOnboarder useful?
+If this project helped speed up onboarding, save time, or avoid headaches, please [⭐ star the repo](#) or [open an issue](#) with your feedback. Your input directly shapes future improvements.
+
 ## License
 
 This project is licensed under the MIT License. See LICENSE.md.

--- a/codex/journal/devonboarder_feedback_log.md
+++ b/codex/journal/devonboarder_feedback_log.md
@@ -1,0 +1,20 @@
+# DevOnboarder Feedback Log
+
+## ⭐️ Stars/Forks
+
+- 2025-07-01 — ⭐️ by @user123 ("Fastest onboarding I’ve seen")
+- 2025-07-02 — Forked by @opensourceguy (wants to add Go support)
+
+## Issues/PRs
+
+- 2025-07-03 — Issue #12: "Feature request: Slack integration" (@devteamlead)
+- 2025-07-04 — PR #15: Fixed typo in journaling flow (@casualhacker)
+
+## Mentions
+
+- 2025-07-05 — Mentioned in r/selfhosted weekly thread
+- 2025-07-06 — Shared in Indie Dev Discord "Tool of the Week"
+
+## Testimonials
+
+> "We got three remote interns up to speed in a day, instead of a week. Huge win." — @remoteteamops

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project will be recorded in this file.
 - Added `scripts/check_dependencies.sh` and documented running it from `docs/README.md` and `docs/doc-quality-onboarding.md`.
 
 - Checked off completed tasks in `docs/Agents.md` for `/health` endpoints, Docker healthchecks, and CI polling.
+- Added outreach templates and a feedback log scaffold for community engagement.
 - Added `pip-audit` and `npm audit --production` security checks run via `scripts/security_audit.sh` and invoked in CI. Results are stored in `docs/security-audit-2025-07-01.md`.
 - Marked the Discord Integration agent as deferred and added a tracking task.
 

--- a/docs/outreach-materials.md
+++ b/docs/outreach-materials.md
@@ -1,0 +1,90 @@
+# Outreach Materials
+
+This page collects snippets for promoting DevOnboarder and tracking feedback.
+
+## 1️⃣ GitHub ReadMe CTA (Copy-Paste Ready)
+
+> **Found DevOnboarder useful?**
+> If this helped you speed up onboarding, save time, or avoid headaches — please [⭐️ star the repo](#), or [open an issue](#) with your feedback or suggestions.
+> Your input directly shapes future improvements. Thanks for helping make onboarding suck less!
+
+## 2️⃣ Demo Video Script (60–90 seconds, “Show Don’t Tell” Style)
+
+**[Opening Shot: VSCode open, terminal ready]**
+
+* **Voice/Text overlay:**
+  *"Hey, this is DevOnboarder — a no-BS way to get new devs up and running, fast."*
+
+**[Show: `ask` Command]**
+
+* "Need answers fast? Just type:"
+
+  ```shell
+  devonboarder ask 'How do I set up the local dev server?'
+  ```
+* *Shows answer, points out the snippet drops into the right doc or channel.*
+
+**[Show: `drop` Command]**
+
+* "Found something useful? Drop it straight into the onboarding doc or team channel."
+
+  ```shell
+  devonboarder drop 'Debugging steps for the staging server'
+  ```
+
+**[Show: Journaling / Log Flow]**
+
+* "Everything’s logged automatically, so nobody’s repeating the same Q&A dance every week."
+
+**[Closing Shot: README with star, issue, and feedback CTA visible]**
+
+* "I built this to scratch my own itch. If it helps you, drop a star or open an issue — let’s make onboarding better for all of us."
+
+## 3️⃣ Outreach Message Drafts (Reddit, Discord, etc.)
+
+### Short Community Post
+
+> 🚀 **Built a better onboarding flow for devs — sharing for feedback**
+>
+> Just open-sourced [DevOnboarder](https://github.com/theangrygamershowproductions/DevOnboarder) after getting tired of repeating myself onboarding folks (and myself) for new projects.
+>
+> It hooks into VSCode, Discord, and GitHub.
+>
+> * Instant answers (`ask`)
+> * Fast docs drop-ins (`drop`)
+> * Automatic journaling for repeat questions
+>
+> If onboarding sucks where you are, maybe this fixes it. Feedback or test drives welcome!
+
+### Short Discord DM or Channel Drop
+
+> Just open-sourced a tool I built to make onboarding less painful.
+> [DevOnboarder](https://github.com/theangrygamershowproductions/DevOnboarder) — for indie devs, open source, or anyone onboarding new folks.
+> Always happy for feedback or stars if it helps!
+
+## 4️⃣ Impact/Feedback Log Scaffold
+
+Create `codex/journal/devonboarder_feedback_log.md` and use this format:
+
+```markdown
+# DevOnboarder Feedback Log
+
+## ⭐️ Stars/Forks
+
+- 2025-07-01 — ⭐️ by @user123 ("Fastest onboarding I’ve seen")
+- 2025-07-02 — Forked by @opensourceguy (wants to add Go support)
+
+## Issues/PRs
+
+- 2025-07-03 — Issue #12: "Feature request: Slack integration" (@devteamlead)
+- 2025-07-04 — PR #15: Fixed typo in journaling flow (@casualhacker)
+
+## Mentions
+
+- 2025-07-05 — Mentioned in r/selfhosted weekly thread
+- 2025-07-06 — Shared in Indie Dev Discord "Tool of the Week"
+
+## Testimonials
+
+> "We got three remote interns up to speed in a day, instead of a week. Huge win." — @remoteteamops
+```


### PR DESCRIPTION
## Summary
- add a call for feedback to the README
- create docs/outreach-materials.md with message templates
- add devonboarder_feedback_log to codex/journal
- note outreach materials in the changelog

## Testing
- `ruff check .`
- `pytest -q`
- `bash scripts/check_docs.sh` *(warning: Vale missing)*

------
https://chatgpt.com/codex/tasks/task_e_6864c2cdb5788320bf98b14a7b79b9f7