### PR TITLE
Configure Codex runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,11 +106,15 @@ All workflows install the GitHub CLI via the reusable `.github/actions/setup-gh-
 
 ## Codex Runs
 
-Codex uses its own compose file. To invoke it manually:
+Codex uses its own compose file. Export your credentials and start the runner:
 
 ```bash
-docker compose -f docker-compose.codex.yml up
+GITHUB_TOKEN=<token> OPENAI_API_KEY=<key> \
+  docker compose -f docker-compose.codex.yml up
 ```
+
+The container reads `codex.ci.yml` and `codex.automation.bundle.json` from the
+project root.
 
 ## Production Deployment
 

--- a/docker-compose.codex.yml
+++ b/docker-compose.codex.yml
@@ -1,4 +1,14 @@
 services:
   codex:
-    image: alpine:latest
-    command: ["echo", "codex mode"]
+    image: ghcr.io/openai/codex-universal
+    volumes:
+      - .:/workspace
+    environment:
+      GITHUB_TOKEN: ${GITHUB_TOKEN}
+      OPENAI_API_KEY: ${OPENAI_API_KEY}
+    command:
+      - /opt/codex/run.sh
+      - --ci-config
+      - /workspace/codex.ci.yml
+      - --bundle
+      - /workspace/codex.automation.bundle.json

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable changes to this project will be recorded in this file.
 - CI now lints commit messages with `scripts/check_commit_messages.sh`.
 - Documented policy against rewriting commit history or force-pushing after commits are pushed.
 
+- Updated `docker-compose.codex.yml` with the Codex runner image and documented manual invocation under "Codex Runs".
+
 - Clarified README instructions to stop the server with Ctrl+C.
 - Removed unused `REDIS_URL`, `LOG_LEVEL`, and `API_KEY` from `.env.example` and
   documented `CORS_ALLOW_ORIGINS` and `DISCORD_REDIRECT_URI` in `docs/Agents.md`


### PR DESCRIPTION
## Summary
- use the Codex universal image in `docker-compose.codex.yml`
- document how to start the runner and supply credentials
- log the change in `CHANGELOG.md`

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6864c815b4488320a8f14d4eda6fce4d