### PR TITLE
Warn when .env.dev misses vars

### DIFF
--- a/docs/Agents.md
+++ b/docs/Agents.md
@@ -196,7 +196,7 @@ Use a small loop in your workflow to wait for the auth service before running te
 - [x] Implement `/health` in Auth
 - [x] Add Docker healthcheck to compose
 - [x] CI workflow update to poll `/health`
-- [ ] Env var audit/cleanup in `.env.dev`
+- [x] Env var audit/cleanup in `.env.dev`
 - [ ] Doc/Agents.md/Changelog update
 - [ ] Retire obsolete scripts
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -385,6 +385,9 @@ All notable changes to this project will be recorded in this file.
 - Added `cleanup-ci-failure.yml` workflow to close stale `ci-failure` issues nightly and documented the job in `docs/README.md`.
 - Granted `issues: write` permission in `ci.yml` so forks can open and close CI failure issues with the built-in token.
 - Noted that new GitHub organization roles require updates to all README files.
+- Verified `.env.dev` matches `.env.example` and added a warning in
+  `scripts/bootstrap.sh` when variables are missing. Marked the env var audit
+  task complete in `docs/Agents.md`.
 
 ## [0.1.0] - 2025-06-14
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -10,6 +10,15 @@ if [ ! -f .env.dev ]; then
     echo "Created .env.dev from .env.example"
 fi
 
+# Warn if .env.dev is missing new variables
+example_vars=$(grep -oE '^[A-Za-z0-9_]+=' .env.example | cut -d= -f1 | sort -u)
+dev_vars=$(grep -oE '^[A-Za-z0-9_]+=' .env.dev | cut -d= -f1 | sort -u)
+missing_vars=$(comm -23 <(printf '%s\n' "$example_vars") <(printf '%s\n' "$dev_vars"))
+if [ -n "$missing_vars" ]; then
+    echo "Warning: .env.dev is missing the following variables:"
+    echo "$missing_vars"
+fi
+
 # Run the shared setup script to install all required tools and images
 "$(dirname "$0")/setup-env.sh"
 


### PR DESCRIPTION
## Summary
- check that `.env.dev` includes all variables in `.env.example`
- warn about missing variables during bootstrap
- mark env var audit as complete in agents doc
- document the change in the changelog

## Testing
- `scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6864ca3325688320a10eda2d46b34138