### PR TITLE
Update Codex tasks and schedule milestones

### DIFF
--- a/codex.plan.md
+++ b/codex.plan.md
@@ -3,7 +3,7 @@ project: "DevOnboarder"
 phase: "MVP"
 status: "active"
 version: "v0.3.0"
-updated: "21 June 2025 08:25 (EST)"
+updated: "04 July 2025 10:00 (EST)"
 ---
 
 # DevOnboarder – Codex Execution Plan
@@ -56,6 +56,16 @@ This document defines the roadmap and execution logic for Codex tasks during the
   - Show level, XP, onboarding state
   - Display “Start Onboarding” if phase is `intro`
   - Show Discord username/avatar from JWT payload
+
+---
+
+## 📆 Upcoming Milestones
+
+| Date       | Task ID         | Target Version |
+| ---------- | --------------- | -------------- |
+| 2025-07-05 | integration-001 | v0.4.0 |
+| 2025-07-12 | feedback-001    | v0.5.0 |
+| 2025-07-19 | feedback-002    | v0.5.0 |
 
 ---
 

--- a/codex.tasks.json
+++ b/codex.tasks.json
@@ -5,21 +5,24 @@
       "title": "Implement Discord Integration agent",
       "module": "discord_integration",
       "description": "Create `/oauth` and `/roles` routes for Discord account linking and role lookup.",
-      "status": "deferred"
+      "status": "deferred",
+      "milestone": "v0.4.0"
     },
     {
       "id": "feedback-001",
       "title": "Implement Feedback Dashboard API",
       "module": "feedback_service",
       "description": "Add endpoints for submitting feedback, tracking status, and generating analytics as outlined in docs/prd/feedback-dashboard.md.",
-      "status": "planned"
+      "status": "planned",
+      "milestone": "v0.5.0"
     },
     {
       "id": "feedback-002",
       "title": "Create Feedback Dashboard UI",
       "module": "frontend",
       "description": "Build React components for the submission form, status board, and analytics snapshot per docs/prd/feedback-dashboard.md.",
-      "status": "planned"
+      "status": "planned",
+      "milestone": "v0.5.0"
     }
   ],
   "completedTasks": [


### PR DESCRIPTION
## Summary
- schedule Discord Integration and Feedback Dashboard tasks
- record upcoming milestones in `codex.plan.md`

## Testing
- `bash scripts/run_tests.sh`
- `pre-commit run --files codex.plan.md codex.tasks.json` *(fails: error checking out hook)*

------
https://chatgpt.com/codex/tasks/task_e_6864cc4498cc83208d8e24eba173b70d