### PR TITLE
Add workflow to auto-close Codex issues after merge

### DIFF
--- a/.github/workflows/close-codex-issues.yml
+++ b/.github/workflows/close-codex-issues.yml
@@ -1,0 +1,32 @@
+name: Close Codex Issues
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  issues: write
+
+jobs:
+  close:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/actions/setup-gh-cli
+      - name: Show gh version
+        run: |
+          which gh
+          gh --version
+      - name: Close referenced Codex issues
+        run: |
+          echo "${{ github.event.pull_request.body }}" | grep -oE 'Fixes #[0-9]+' | sed 's/Fixes #//' > issues.txt || true
+          gh_bin=$(which gh)
+          for ISSUE in $(cat issues.txt); do
+            AUTHOR=$($gh_bin api repos/${{ github.repository }}/issues/$ISSUE --jq '.user.login')
+            if [ "$AUTHOR" = "codex[bot]" ]; then
+              $gh_bin issue comment "$ISSUE" --body "Closed via merge of #${{ github.event.pull_request.number }}."
+              $gh_bin issue close "$ISSUE" --reason completed
+            fi
+          done
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be recorded in this file.
 
 ## [Unreleased]
+- Added `close-codex-issues.yml` workflow to automatically close Codex-created issues referenced by `Fixes #<issue>` after a pull request merges and documented it in `docs/README.md`.
 - Archived `languagetool_check.py` to `archive/` and removed its invocation from `scripts/check_docs.sh`.
 - Added `scripts/install_gh_cli.sh` for local GitHub CLI installation and referenced it in the docs.
 - Added `tests/README.md` describing how to install project requirements before running `pytest` so modules like `fastapi` are available.

--- a/docs/README.md
+++ b/docs/README.md
@@ -97,6 +97,8 @@ platforms. Please report any issues you encounter on your operating system.
   &ndash; quick fixes for setup problems and failing CI jobs.
 - [CI failure issue management](ci-failure-issues.md)
   &ndash; how automatic cleanup works and how to close old issues.
+- [Automatic Codex issue closing](codex-issue-autoclose.md)
+  &ndash; merged PRs with `Fixes #<issue>` close the linked Codex ticket.
 - [Offline setup](offline-setup.md) &ndash; download Python wheels and npm packages on another machine.
 - [Security audit](security-audit-2025-07-01.md) &ndash; latest dependency check results.
 - [Environment variables](env.md) &ndash; explanation of `.env` settings and the role-based permission system.

--- a/docs/codex-issue-autoclose.md
+++ b/docs/codex-issue-autoclose.md
@@ -1,0 +1,5 @@
+# Automatic Codex Issue Closing
+
+Pull requests can reference Codex-created issues using `Fixes #<number>`. When such a PR merges, the `close-codex-issues.yml` workflow checks each referenced issue. If the issue was opened by `codex[bot]`, the workflow comments that the fix landed and closes the issue.
+
+This automation keeps the board free of stale Codex tasks without manual cleanup.


### PR DESCRIPTION
## Summary
- add `close-codex-issues.yml` workflow
- document the automation in `README` and new `codex-issue-autoclose.md`
- log the change in the changelog

## Testing
- `bash scripts/run_tests.sh`
- `pre-commit run --files docs/CHANGELOG.md docs/README.md docs/codex-issue-autoclose.md .github/workflows/close-codex-issues.yml` *(fails: could not fetch hooks)*

------
https://chatgpt.com/codex/tasks/task_e_6864d1010ae083208b2207fb31f4ad51