### PR TITLE
Ignore coverage db

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,6 +11,7 @@ venv/
 node_modules/
 dist/
 coverage/
+.coverage
 .nyc_output/
 pnpm-lock.yaml
 

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ venv/
 node_modules/
 dist/
 coverage/
+.coverage
 .nyc_output/
 pnpm-lock.yaml
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -391,6 +391,7 @@ All notable changes to this project will be recorded in this file.
   `scripts/bootstrap.sh` when variables are missing. Marked the env var audit
   task complete in `docs/Agents.md`.
 - Updated `.nvmrc` and CI workflow to use Node 20.
+- Ignored `.coverage` in `.gitignore` and `.dockerignore`.
 
 ## [0.1.0] - 2025-06-14
 


### PR DESCRIPTION
## Summary
- keep `.coverage` files out of Git and Docker build context
- document the new ignore entry in the changelog

## Testing
- `bash scripts/check_potato_ignore.sh`
- `bash scripts/run_tests.sh` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68655f0931d083208d51c8945bce5603