### PR TITLE
Enforce coverage in run_tests script

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,8 @@ docker compose -f docker-compose.prod.yaml --env-file .env.prod up -d
    pip install -e .  # or `pip install -r requirements.txt` if present
    pip install -r requirements-dev.txt
    ruff check .
-   pytest -q
-   npm test --prefix bot
+   pytest --cov=src --cov-fail-under=95
+   npm run coverage --prefix bot
    ```
 7. The CI workflow enforces a minimum of **95% code coverage** for all projects (frontend, bot, and backend). Pull requests will fail if any test suite drops below this threshold.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable changes to this project will be recorded in this file.
 - Workflows log the install path with `which gh` and no longer modify `$GITHUB_PATH`.
 - Steps that invoke the GitHub CLI now call the path from `which gh` to ensure the latest version is used.
 - CI now lints commit messages with `scripts/check_commit_messages.sh`.
+- Updated `scripts/run_tests.sh` to run `pytest --cov=src --cov-fail-under=95`
+  and invoke `npm run coverage` for the bot and frontend packages.
 - Documented policy against rewriting commit history or force-pushing after commits are pushed.
 
 - Updated `docker-compose.codex.yml` with the Codex runner image and documented manual invocation under "Codex Runs".

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,8 +32,8 @@ If you're setting up a fresh Ubuntu machine, follow [ubuntu-setup.md](ubuntu-set
     `curl http://localhost:8001/api/user/onboarding-status`
     and `curl http://localhost:8001/api/user/level`.
 12. Stop services with `docker compose -f docker-compose.dev.yaml --env-file .env.dev down`.
-13. Verify changes with `ruff check .`, `pytest -q`, and `npm test` from the `bot/` directory before committing.
-    After installing dependencies, run `npm test` in the `frontend/` directory as well
+13. Verify changes with `ruff check .`, `pytest --cov=src --cov-fail-under=95`, and `npm run coverage` from the `bot/` directory before committing.
+    After installing dependencies, run `npm run coverage` in the `frontend/` directory as well
     (see [../frontend/README.md](../frontend/README.md) for details).
     Install the project and dev requirements **before running the tests**:
 

--- a/docs/git-guidelines.md
+++ b/docs/git-guidelines.md
@@ -69,7 +69,7 @@ pip install -r requirements-dev.txt
 
 ```bash
 ruff check .
-pytest -q
+pytest --cov=src --cov-fail-under=95
 ```
 - Run documentation checks with `./scripts/check_docs.sh`.
   These use **Vale** and **LanguageTool** and require network access to

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -18,7 +18,7 @@
 pip install -e .  # or `pip install -r requirements.txt` if present
 pip install -r requirements-dev.txt
 ruff check .
-pytest -q
+pytest --cov=src --cov-fail-under=95
 bash scripts/check_docs.sh
 ```
 

--- a/docs/sample-pr.md
+++ b/docs/sample-pr.md
@@ -12,7 +12,7 @@ This guide demonstrates a minimal documentation update using the project workflo
    pip install -e .
    pip install -r requirements-dev.txt
    ruff check .
-   pytest -q
+   pytest --cov=src --cov-fail-under=95
    ```
 4. Commit your work and open a pull request using `docs/pull_request_template.md`.
 

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -11,16 +11,16 @@ if [ -f pyproject.toml ]; then
 fi
 
 ruff check .
-pytest -q
+pytest --cov=src --cov-fail-under=95
 if [ -d bot ] && [ -f bot/package.json ]; then
     npm ci --prefix bot
-    (cd bot && npm test)
+    (cd bot && npm run coverage)
 fi
 
 # Optionally run frontend tests when they exist
 if [ -d frontend ] && [ -f frontend/package.json ]; then
     if grep -q "\"test\"" frontend/package.json; then
         npm ci --prefix frontend
-        (cd frontend && npm test)
+        (cd frontend && npm run coverage)
     fi
 fi

--- a/tests/README.md
+++ b/tests/README.md
@@ -7,20 +7,15 @@ pip install -e .
 pip install -r requirements-dev.txt
 ```
 
-Then run `pytest` from the repository root:
-
-```bash
-pytest -q
-```
-
-Use `make test` to run the linter and all test suites at once.
-
-CI requires every suite to maintain **95%** code coverage. Run the Python tests
-with coverage enabled:
+Then run `pytest` from the repository root with coverage enabled:
 
 ```bash
 pytest --cov=src --cov-fail-under=95
 ```
+
+Use `make test` to run the linter and all test suites at once.
+
+CI requires every suite to maintain **95%** code coverage.
 
 Run JavaScript coverage from the `bot/` and `frontend/` directories:
 


### PR DESCRIPTION
# Summary
- run pytest with coverage enabled in scripts/run_tests.sh
- run `npm run coverage` for bot and frontend packages
- document coverage commands across docs and READMEs
- note run_tests.sh change in the changelog

# Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686561bf80448320b8b41e088b9ce85d