### PR TITLE
Extract shared CORS origin helper

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be recorded in this file.
 - Updated `scripts/run_tests.sh` to run `pytest --cov=src --cov-fail-under=95`
   and invoke `npm run coverage` for the bot and frontend packages.
 - Documented policy against rewriting commit history or force-pushing after commits are pushed.
+- Extracted CORS helper to `utils.cors` and reused in auth and XP services.
 
 - Updated `docker-compose.codex.yml` with the Codex runner image and documented manual invocation under "Codex Runs".
 

--- a/src/devonboarder/auth_service.py
+++ b/src/devonboarder/auth_service.py
@@ -8,6 +8,7 @@ from fastapi.responses import RedirectResponse
 
 from utils.discord import get_user_roles, get_user_profile
 from utils.roles import resolve_user_flags
+from utils.cors import _get_cors_origins
 from urllib.parse import urlencode
 import httpx
 from sqlalchemy import (
@@ -37,15 +38,6 @@ ALGORITHM = os.getenv("JWT_ALGORITHM", "HS256")
 TOKEN_EXPIRE_SECONDS = int(os.getenv("TOKEN_EXPIRE_SECONDS", "3600"))
 API_TIMEOUT = int(os.getenv("DISCORD_API_TIMEOUT", "10"))
 
-
-def _get_cors_origins() -> list[str]:
-    """Return allowed CORS origins from the environment."""
-    origins = os.getenv("CORS_ALLOW_ORIGINS")
-    if origins:
-        return [o.strip() for o in origins.split(",") if o.strip()]
-    if os.getenv("APP_ENV") == "development":
-        return ["*"]
-    return []
 
 CONTRIBUTION_XP = 50
 

--- a/src/utils/cors.py
+++ b/src/utils/cors.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+import os
+
+
+def _get_cors_origins() -> list[str]:
+    """Return allowed CORS origins from the environment."""
+    origins = os.getenv("CORS_ALLOW_ORIGINS")
+    if origins:
+        return [o.strip() for o in origins.split(",") if o.strip()]
+    if os.getenv("APP_ENV") == "development":
+        return ["*"]
+    return []

--- a/src/xp/api/__init__.py
+++ b/src/xp/api/__init__.py
@@ -4,20 +4,10 @@ from fastapi import APIRouter, FastAPI, Depends, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from starlette.middleware.base import BaseHTTPMiddleware
 from sqlalchemy.orm import Session
-import os
+
+from utils.cors import _get_cors_origins
 
 from devonboarder import auth_service
-
-
-def _get_cors_origins() -> list[str]:
-    """Return allowed CORS origins from the environment."""
-    origins = os.getenv("CORS_ALLOW_ORIGINS")
-    if origins:
-        return [o.strip() for o in origins.split(",") if o.strip()]
-    if os.getenv("APP_ENV") == "development":
-        return ["*"]
-    return []
-
 router = APIRouter()
 
 


### PR DESCRIPTION
## Summary
- move `_get_cors_origins()` to `utils.cors`
- use helper in auth and XP API services
- document change in the changelog

## Testing
- `bash scripts/run_tests.sh`
- `bash scripts/check_docs.sh`


------
https://chatgpt.com/codex/tasks/task_e_6865633709108320a709c30df755bd0a