### PR TITLE
Add module docstrings

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -396,6 +396,8 @@ All notable changes to this project will be recorded in this file.
 - Updated `.nvmrc` and CI workflow to use Node 20.
 - Ignored `.coverage` in `.gitignore` and `.dockerignore`.
 
+- Documented module descriptions for the auth service, XP API, roles, and CORS utilities.
+
 ## [0.1.0] - 2025-06-14
 
 - Added `src/app.py` with `greet` function and updated smoke tests. [#21](https://github.com/theangrygamershowproductions/DevOnboarder/pull/21)

--- a/src/devonboarder/auth_service.py
+++ b/src/devonboarder/auth_service.py
@@ -1,3 +1,5 @@
+"""Authentication service with Discord integration and JWT utilities."""
+
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, FastAPI, HTTPException, status

--- a/src/utils/cors.py
+++ b/src/utils/cors.py
@@ -1,3 +1,5 @@
+"""Utility for loading allowed CORS origins from environment variables."""
+
 from __future__ import annotations
 
 import os

--- a/src/utils/roles.py
+++ b/src/utils/roles.py
@@ -1,3 +1,5 @@
+"""Helpers for resolving Discord role flags and verification status."""
+
 from __future__ import annotations
 
 import os

--- a/src/xp/api/__init__.py
+++ b/src/xp/api/__init__.py
@@ -1,3 +1,5 @@
+"""XP API exposing onboarding status and level endpoints."""
+
 from __future__ import annotations
 
 from fastapi import APIRouter, FastAPI, Depends, HTTPException


### PR DESCRIPTION
## Summary
- add documentation strings to auth service, XP API, CORS, and roles modules
- update changelog with doc addition

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686569d319f083209629ff077fdf33ae