### PR TITLE
Rename cors origins util

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,8 @@ All notable changes to this project will be recorded in this file.
   and invoke `npm run coverage` for the bot and frontend packages.
 - Documented policy against rewriting commit history or force-pushing after commits are pushed.
 - Extracted CORS helper to `utils.cors` and reused in auth and XP services.
+- Renamed `_get_cors_origins` to `get_cors_origins` and exported it via
+  `utils.__all__`.
 
 - Updated `docker-compose.codex.yml` with the Codex runner image and documented manual invocation under "Codex Runs".
 

--- a/src/devonboarder/auth_service.py
+++ b/src/devonboarder/auth_service.py
@@ -10,7 +10,7 @@ from fastapi.responses import RedirectResponse
 
 from utils.discord import get_user_roles, get_user_profile
 from utils.roles import resolve_user_flags
-from utils.cors import _get_cors_origins
+from utils.cors import get_cors_origins
 from urllib.parse import urlencode
 import httpx
 from sqlalchemy import (
@@ -342,7 +342,7 @@ def create_app() -> FastAPI:
         init_db()
 
     app = FastAPI()
-    cors_origins = _get_cors_origins()
+    cors_origins = get_cors_origins()
 
     class _SecurityHeadersMiddleware(BaseHTTPMiddleware):
         """Add basic security headers to all responses."""

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,0 +1,5 @@
+"""Utility functions used across services."""
+
+from .cors import get_cors_origins
+
+__all__ = ["get_cors_origins"]

--- a/src/utils/cors.py
+++ b/src/utils/cors.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import os
 
 
-def _get_cors_origins() -> list[str]:
+def get_cors_origins() -> list[str]:
     """Return allowed CORS origins from the environment."""
     origins = os.getenv("CORS_ALLOW_ORIGINS")
     if origins:

--- a/src/xp/api/__init__.py
+++ b/src/xp/api/__init__.py
@@ -7,7 +7,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from starlette.middleware.base import BaseHTTPMiddleware
 from sqlalchemy.orm import Session
 
-from utils.cors import _get_cors_origins
+from utils.cors import get_cors_origins
 
 from devonboarder import auth_service
 router = APIRouter()
@@ -59,7 +59,7 @@ def contribute(
 def create_app() -> FastAPI:
     """Create a FastAPI application with the XP router."""
     app = FastAPI()
-    cors_origins = _get_cors_origins()
+    cors_origins = get_cors_origins()
 
     class _SecurityHeadersMiddleware(BaseHTTPMiddleware):
         async def dispatch(self, request, call_next):  # type: ignore[override]


### PR DESCRIPTION
## Summary
- rename `_get_cors_origins` to `get_cors_origins`
- export `get_cors_origins` from utils
- update auth and XP API to import new function
- note change in changelog

## Testing
- `bash scripts/run_tests.sh`
- `pytest --cov=src --cov-fail-under=95`
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_68660e2a93c48320b306402834ee98bc