### PR TITLE
Add commit-msg hook and install script

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be recorded in this file.
 - Added `close-codex-issues.yml` workflow to automatically close Codex-created issues referenced by `Fixes #<issue>` after a pull request merges and documented it in `docs/README.md`.
 - Archived `languagetool_check.py` to `archive/` and removed its invocation from `scripts/check_docs.sh`.
 - Added `scripts/install_gh_cli.sh` for local GitHub CLI installation and referenced it in the docs.
+- Added `scripts/commit-msg` and `scripts/install_commit_msg_hook.sh` to help contributors set up a local `commit-msg` hook.
 - Added `tests/README.md` describing how to install project requirements before running `pytest` so modules like `fastapi` are available.
 - Documented the 95% coverage requirement and how to run Python and JavaScript coverage tests in `tests/README.md`.
 - Documented manual cleanup of `ci-failure` issues in `docs/ci-failure-issues.md`.

--- a/docs/git-guidelines.md
+++ b/docs/git-guidelines.md
@@ -79,6 +79,7 @@ pytest --cov=src --cov-fail-under=95
   `pre-commit autoupdate --repo https://github.com/pre-commit/mirrors-prettier`
   to confirm the hook installs correctly.
 - CI lints commit messages using `scripts/check_commit_messages.sh`.
+  - Run `bash scripts/install_commit_msg_hook.sh` to install a local `commit-msg` hook so mistakes are caught before you push.
   Past violations do not require rewriting history.
 - Update `docs/CHANGELOG.md` with a short summary of your change.
 - Update any other relevant documentation under `docs/`.

--- a/scripts/commit-msg
+++ b/scripts/commit-msg
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Prevent commits if the message does not match <TYPE>(<scope>): <subject>
+regex='^(FEAT|FIX|DOCS|STYLE|REFACTOR|TEST|CHORE)(\([^)]+\))?: .+'
+message=$(cat "$1")
+
+if ! printf '%s' "$message" | grep -Eq "$regex"; then
+  echo "Invalid commit message format."
+  echo "Use: <TYPE>(<scope>): <subject>"
+  echo "Example: FIX(ci): ensure latest GitHub CLI binary is used"
+  exit 1
+fi

--- a/scripts/install_commit_msg_hook.sh
+++ b/scripts/install_commit_msg_hook.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_hook="$(dirname "$0")/commit-msg"
+hook_dest=".git/hooks/commit-msg"
+
+if [ ! -d "$(git rev-parse --git-dir)" ]; then
+  echo "Error: not inside a git repository" >&2
+  exit 1
+fi
+
+cp "$repo_hook" "$hook_dest"
+chmod +x "$hook_dest"
+echo "Installed commit-msg hook to $hook_dest"


### PR DESCRIPTION
## Summary
- add `commit-msg` script to enforce commit message style locally
- include `install_commit_msg_hook.sh` for easy hook installation
- document local commit message hook in git guidelines
- log hook scripts in changelog

## Testing
- `ruff check .`
- `pytest --cov=src --cov-fail-under=95`
- `npm run coverage` in `bot`
- `npm run coverage` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_686619524b988320b9cba89b0ac4dfdf