### PR TITLE
Change artifact upload condition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
             - name: Run tests with coverage
               run: pytest --cov=src --cov-fail-under=95 --junitxml=test-results/pytest-results.xml
             - name: Upload pytest results
-              if: success() && hashFiles('test-results/pytest-results.xml') != ''
+              if: always() && hashFiles('test-results/pytest-results.xml') != ''
               uses: actions/upload-artifact@v4
               with:
                   name: pytest-results


### PR DESCRIPTION
## Summary
- upload pytest results even when tests fail

## Testing Steps
- `ruff check .`
- `pytest --cov=src --cov-fail-under=95`
- `bash scripts/check_docs.sh`


------
https://chatgpt.com/codex/tasks/task_e_68662aaab4f48320b8268465417c024f