### PR TITLE
Fix CI test annotation logic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
                   name: pytest-results
                   path: test-results/pytest-results.xml
             - name: Annotate pytest failures
-              if: failure()
+              if: failure() && hashFiles('test-results/pytest-results.xml') != ''
               run: |
                   line=$(grep -n -m 1 '<failure' test-results/pytest-results.xml | cut -d: -f1)
                   echo "::error file=test-results/pytest-results.xml,line=${line}::Test failures detected"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be recorded in this file.
 - Documented the 95% coverage requirement and how to run Python and JavaScript coverage tests in `tests/README.md`.
 - Documented manual cleanup of `ci-failure` issues in `docs/ci-failure-issues.md`.
 - CI workflow now closes every open `ci-failure` issue once the pipeline succeeds.
+- Pytest failure annotations run only when the results file exists to avoid grep errors.
 - Added a reusable `.github/actions/setup-gh-cli` action for installing the GitHub CLI.
 - Workflows log the install path with `which gh` and no longer modify `$GITHUB_PATH`.
 - Steps that invoke the GitHub CLI now call the path from `which gh` to ensure the latest version is used.


### PR DESCRIPTION
## Summary
- prevent grep errors when pytest results are missing
- document workflow change in changelog

## Testing
- `bash scripts/check_docs.sh`
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68662cbb5c6c832098af6a697070ba1f