### PR TITLE
Ensure CI stops docker compose

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,6 +223,7 @@ jobs:
             - name: Run security audit
               run: bash scripts/security_audit.sh
             - name: Stop docker compose
+              if: always()
               run: docker compose -f docker-compose.ci.yaml --env-file .env.dev down
             - name: Label Codex PR
               if: github.actor == 'codex[bot]'

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -404,6 +404,7 @@ All notable changes to this project will be recorded in this file.
 - Ignored `.coverage` in `.gitignore` and `.dockerignore`.
 
 - Documented module descriptions for the auth service, XP API, roles, and CORS utilities.
+- CI now stops docker compose containers even when earlier steps fail.
 
 ## [0.1.0] - 2025-06-14
 


### PR DESCRIPTION
## Summary
- stop docker compose even when earlier steps fail
- document the change in the changelog

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68673e24a9a08320830d3eaadcab63b7