### PR TITLE
Add pip and node module caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,27 @@ jobs:
               uses: actions/setup-node@v3
               with:
                   node-version: "20"
+            - name: Cache pip downloads
+              uses: actions/cache@v3
+              with:
+                  path: ~/.cache/pip
+                  key: ${{ runner.os }}-pip-${{ hashFiles('requirements-dev.txt') }}
+                  restore-keys: |
+                      ${{ runner.os }}-pip-
+            - name: Cache frontend node modules
+              uses: actions/cache@v3
+              with:
+                  path: frontend/node_modules
+                  key: ${{ runner.os }}-frontend-${{ hashFiles('frontend/package-lock.json') }}
+                  restore-keys: |
+                      ${{ runner.os }}-frontend-
+            - name: Cache bot node modules
+              uses: actions/cache@v3
+              with:
+                  path: bot/node_modules
+                  key: ${{ runner.os }}-bot-${{ hashFiles('bot/package-lock.json') }}
+                  restore-keys: |
+                      ${{ runner.os }}-bot-
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@v3
             - name: Install dev dependencies

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -407,6 +407,7 @@ All notable changes to this project will be recorded in this file.
 - CI now stops docker compose containers even when earlier steps fail.
 - Added `openapi-spec-validator` and `requests` to `requirements-dev.txt` and
   removed their manual installation from the CI workflow.
+- CI workflow caches pip downloads and Node dependencies for faster installs.
 
 ## [0.1.0] - 2025-06-14
 


### PR DESCRIPTION
# Summary
- cache pip downloads
- cache frontend and bot `node_modules`
- document caches in changelog

# Linked Issues

# Screenshots

# Testing Steps
- `pip install -e .`
- `pip install -r requirements-dev.txt`
- `ruff check .`
- `pytest --cov=src --cov-fail-under=95`
- `bash scripts/check_docs.sh`


------
https://chatgpt.com/codex/tasks/task_e_686742c1491c8320a75b7f491d29dd1f