### PR TITLE
Cache Playwright browsers in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,13 @@ jobs:
               with:
                   name: vitest-log
                   path: frontend/vitest.log
+            - name: Cache Playwright browsers
+              uses: actions/cache@v3
+              with:
+                  path: ~/.cache/ms-playwright
+                  key: ${{ runner.os }}-playwright-${{ hashFiles('frontend/package-lock.json') }}
+                  restore-keys: |
+                      ${{ runner.os }}-playwright-
             - name: Install Playwright browsers
               run: npx playwright install --with-deps
               working-directory: frontend

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be recorded in this file.
 
 ## [Unreleased]
+- CI workflow caches Playwright browsers to reuse ~/.cache/ms-playwright.
 - Added `close-codex-issues.yml` workflow to automatically close Codex-created issues referenced by `Fixes #<issue>` after a pull request merges and documented it in `docs/README.md`.
 - Archived `languagetool_check.py` to `archive/` and removed its invocation from `scripts/check_docs.sh`.
 - Added `scripts/install_gh_cli.sh` for local GitHub CLI installation and referenced it in the docs.


### PR DESCRIPTION
## Summary
- cache the Playwright browser directory using `actions/cache`
- document the new cache in the changelog

## Testing
- `bash scripts/run_tests.sh`
- `pre-commit run --files .github/workflows/ci.yml docs/CHANGELOG.md` *(fails: pathspec 'v3.6.2' did not match any file)*

------
https://chatgpt.com/codex/tasks/task_e_6867452c290083209d2124767e3d7c82