### PR TITLE
chore(ci): reuse helper script for auth startup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,18 +97,7 @@ jobs:
             - name: Start docker compose
               run: docker compose -f docker-compose.ci.yaml --env-file .env.dev up -d
             - name: Wait for auth service
-              run: |
-                  for i in {1..30}; do
-                    if curl -fs http://localhost:8002/health; then
-                      echo "Auth service is up!"
-                      exit 0
-                    fi
-                    echo "Waiting for auth service..."
-                    sleep 2
-                  done
-                  echo "Auth service failed to start"
-                  docker compose -f docker-compose.ci.yaml logs auth --tail=50
-                  exit 1
+              run: bash scripts/wait_for_service.sh http://localhost:8002/health
             - name: Prepare test-results directory
               run: mkdir -p test-results
             - name: Run tests with coverage
@@ -231,19 +220,8 @@ jobs:
                   "$gh_bin" pr comment ${{ github.event.pull_request.number }} --body-file coverage-summary.md
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-            - name: Wait for auth service before header check
-              run: |
-                  for i in {1..30}; do
-                    if curl -fs http://localhost:8002/health; then
-                      echo "Auth service is up!"
-                      exit 0
-                    fi
-                    echo "Waiting for auth service..."
-                    sleep 2
-                  done
-                  echo "Auth service failed to start"
-                  docker compose -f docker-compose.ci.yaml logs auth --tail=50
-                  exit 1
+            - name: Wait for auth service
+              run: bash scripts/wait_for_service.sh http://localhost:8002/health
             - name: Check CORS & security headers
               run: python scripts/check_headers.py
               env:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be recorded in this file.
 - Added `scripts/install_gh_cli.sh` for local GitHub CLI installation and referenced it in the docs.
 - Added `scripts/commit-msg` and `scripts/install_commit_msg_hook.sh` to help contributors set up a local `commit-msg` hook.
 - Added `tests/README.md` describing how to install project requirements before running `pytest` so modules like `fastapi` are available.
+- Added `scripts/wait_for_service.sh` and updated the CI workflow to reuse it when waiting for the auth service to start.
 - Documented the 95% coverage requirement and how to run Python and JavaScript coverage tests in `tests/README.md`.
 - Documented manual cleanup of `ci-failure` issues in `docs/ci-failure-issues.md`.
 - CI workflow now closes every open `ci-failure` issue once the pipeline succeeds.

--- a/scripts/wait_for_service.sh
+++ b/scripts/wait_for_service.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Poll a URL until it returns success or retry limit is reached
+set -euo pipefail
+
+URL=${1:?"usage: $0 URL [retries] [sleep]"}
+RETRIES=${2:-30}
+SLEEP=${3:-2}
+
+for ((i=1; i<=RETRIES; i++)); do
+  if curl -fs "$URL" >/dev/null; then
+    echo "Service is up!"
+    exit 0
+  fi
+  echo "Waiting for service... ($i/$RETRIES)"
+  sleep "$SLEEP"
+done
+
+echo "Service failed to start: $URL" >&2
+exit 1


### PR DESCRIPTION
## Summary
- add wait_for_service helper script
- reuse the script in CI when starting the auth service

## Testing
- `ruff check .`
- `pytest --cov=src --cov-fail-under=95`
- `bash scripts/check_docs.sh`
- `pre-commit run --files .github/workflows/ci.yml docs/CHANGELOG.md scripts/wait_for_service.sh` *(fails: CalledProcessError: command: ('/usr/bin/git', 'checkout', 'v3.6.2'))*

------
https://chatgpt.com/codex/tasks/task_e_68674a2425688320b280a7a4553be774