### PR TITLE
chore(ci): version-aware cache keys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,10 @@ permissions:
 jobs:
     test:
         runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                python-version: ["3.12"]
+                node-version: ["20"]
         env:
             VALE_VERSION: 3.12.0
 
@@ -32,32 +36,32 @@ jobs:
             - name: Set up Python
               uses: actions/setup-python@v4
               with:
-                  python-version: "3.12"
+                  python-version: ${{ matrix.python-version }}
             - name: Set up Node
               uses: actions/setup-node@v3
               with:
-                  node-version: "20"
+                  node-version: ${{ matrix.node-version }}
             - name: Cache pip downloads
               uses: actions/cache@v3
               with:
                   path: ~/.cache/pip
-                  key: ${{ runner.os }}-pip-${{ hashFiles('requirements-dev.txt') }}
+                  key: ${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('requirements-dev.txt') }}
                   restore-keys: |
-                      ${{ runner.os }}-pip-
+                      ${{ runner.os }}-py${{ matrix.python-version }}-
             - name: Cache frontend node modules
               uses: actions/cache@v3
               with:
                   path: frontend/node_modules
-                  key: ${{ runner.os }}-frontend-${{ hashFiles('frontend/package-lock.json') }}
+                  key: ${{ runner.os }}-node${{ matrix.node-version }}-frontend-${{ hashFiles('frontend/package-lock.json') }}
                   restore-keys: |
-                      ${{ runner.os }}-frontend-
+                      ${{ runner.os }}-node${{ matrix.node-version }}-frontend-
             - name: Cache bot node modules
               uses: actions/cache@v3
               with:
                   path: bot/node_modules
-                  key: ${{ runner.os }}-bot-${{ hashFiles('bot/package-lock.json') }}
+                  key: ${{ runner.os }}-node${{ matrix.node-version }}-bot-${{ hashFiles('bot/package-lock.json') }}
                   restore-keys: |
-                      ${{ runner.os }}-bot-
+                      ${{ runner.os }}-node${{ matrix.node-version }}-bot-
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@v3
             - name: Install dev dependencies
@@ -132,9 +136,9 @@ jobs:
               uses: actions/cache@v3
               with:
                   path: ~/.cache/ms-playwright
-                  key: ${{ runner.os }}-playwright-${{ hashFiles('frontend/package-lock.json') }}
+                  key: ${{ runner.os }}-node${{ matrix.node-version }}-playwright-${{ hashFiles('frontend/package-lock.json') }}
                   restore-keys: |
-                      ${{ runner.os }}-playwright-
+                      ${{ runner.os }}-node${{ matrix.node-version }}-playwright-
             - name: Install Playwright browsers
               run: npx playwright install --with-deps
               working-directory: frontend

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -411,6 +411,7 @@ All notable changes to this project will be recorded in this file.
 - Added `openapi-spec-validator` and `requests` to `requirements-dev.txt` and
   removed their manual installation from the CI workflow.
 - CI workflow caches pip downloads and Node dependencies for faster installs.
+- Cache keys include Python and Node versions to avoid mismatches.
 
 ## [0.1.0] - 2025-06-14
 


### PR DESCRIPTION
## Summary
- make CI cache keys depend on Python and Node versions
- note cache key update in the changelog

## Testing
- `bash scripts/run_tests.sh`
- `bash scripts/check_docs.sh`


------
https://chatgpt.com/codex/tasks/task_e_68674f569efc83208634f8c5b8133c73