### PR TITLE
Update JS test coverage enforcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
               run: npm run lint
               working-directory: frontend
             - name: Run frontend tests with coverage
-              run: npm run coverage --if-present 2>&1 | tee vitest.log
+              run: npm test 2>&1 | tee vitest.log
               working-directory: frontend
             - name: Upload vitest log
               if: always()
@@ -187,7 +187,7 @@ jobs:
               run: npm run lint
               working-directory: bot
             - name: Run bot tests with coverage
-              run: npm run coverage 2>&1 | tee jest.log
+              run: npm test 2>&1 | tee jest.log
               working-directory: bot
             - name: Upload jest log
               if: always()

--- a/bot/package.json
+++ b/bot/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "tsc",
     "start": "node dist/main.js",
-    "test": "jest",
+    "test": "jest --coverage",
     "coverage": "jest --coverage",
     "lint": "eslint \"src/**/*.{js,ts}\"",
     "format": "prettier --write \"src/**/*.{js,ts}\""

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -414,6 +414,9 @@ All notable changes to this project will be recorded in this file.
 - CI workflow caches pip downloads and Node dependencies for faster installs.
 - Cache keys include Python and Node versions to avoid mismatches.
 
+- JS test scripts now run coverage and fail if coverage drops below 95%.
+  CI uses `npm test` for the bot and frontend packages.
+
 ## [0.1.0] - 2025-06-14
 
 - Added `src/app.py` with `greet` function and updated smoke tests. [#21](https://github.com/theangrygamershowproductions/DevOnboarder/pull/21)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
         "build": "vite build",
         "preview": "vite preview",
         "start": "vite",
-        "test": "vitest run",
+        "test": "vitest run --coverage",
         "coverage": "vitest run --coverage",
         "test:e2e": "playwright test",
         "test:a11y": "playwright test e2e/accessibility.spec.ts",


### PR DESCRIPTION
## Summary
- run vitest coverage during `npm test`
- run jest coverage during `npm test`
- call these scripts without `--if-present` in CI
- document the new coverage enforcement

## Testing
- `npm test` in `bot`
- `npm test` in `frontend`
- `pre-commit run --files frontend/package.json bot/package.json .github/workflows/ci.yml docs/CHANGELOG.md` *(fails: pathspec 'v3.6.2' did not match any file)*

------
https://chatgpt.com/codex/tasks/task_e_6867520336948320a34998c669057c3f