### PR TITLE
Add weekly security audit workflow

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,0 +1,52 @@
+name: Security Audit
+
+on:
+  schedule:
+    - cron: "0 0 * * 0"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/setup-gh-cli
+      - name: Show gh version
+        run: |
+          which gh
+          gh --version
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.12"
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: "20"
+      - name: Install Python dependencies
+        run: |
+          pip install -r requirements-dev.txt
+          pip install -e .
+          pip install pip-audit
+      - name: Install frontend dependencies
+        run: npm ci
+        working-directory: frontend
+      - name: Install bot dependencies
+        run: npm ci
+        working-directory: bot
+      - name: Run security audit
+        id: audit
+        run: |
+          DATE=$(date -I)
+          bash scripts/security_audit.sh
+          echo "report=docs/security-audit-${DATE}.md" >> "$GITHUB_OUTPUT"
+      - name: Upload audit report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: security-audit
+          path: ${{ steps.audit.outputs.report }}
+          retention-days: 7

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -429,3 +429,4 @@ All notable changes to this project will be recorded in this file.
 
 - Updated bot and frontend lock files and added tests so `scripts/run_tests.sh` passes
 - Updated pytest artifact path in CI workflow to `artifacts/pytest-results.xml`
+- Added `security-audit.yml` workflow to run dependency audits weekly and upload the report as an artifact. Documented the job in `docs/README.md`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -165,3 +165,5 @@ See [doc-quality-onboarding.md](doc-quality-onboarding.md) for a step-by-step gu
 6. When CI fails, an issue titled `CI Failures for <sha>` is opened or updated with a summary of the failing tests and links to the artifacts.
 7. The CI workflow uses the built-in `GITHUB_TOKEN` with `issues: write` permission. When the pipeline succeeds, it closes every open `ci-failure` issue.
 8. A nightly job (`cleanup-ci-failure.yml`) closes any open `ci-failure` issues so the board stays tidy.
+
+9. A weekly job (`security-audit.yml`) runs dependency audits and uploads the report as an artifact.


### PR DESCRIPTION
## Summary
- run dependency audit on a weekly schedule
- document the new job in README
- note the workflow in the changelog

## Testing
- `ruff check .`
- `pytest --cov=src --cov-fail-under=95`
- `bash scripts/check_docs.sh`

------
https://chatgpt.com/codex/tasks/task_e_6867572192fc832086572443157e8b1d