### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @theangrygamershowproductions/maintainers

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be recorded in this file.
 
 ## [Unreleased]
 - CI workflow caches Playwright browsers to reuse ~/.cache/ms-playwright.
+- Added CODEOWNERS to automatically request maintainer reviews on pull requests.
 - CI workflow cancels in-progress runs when new commits push.
 - Added a 60-minute timeout to the `test` job in `ci.yml`.
 - Added `close-codex-issues.yml` workflow to automatically close Codex-created issues referenced by `Fixes #<issue>` after a pull request merges and documented it in `docs/README.md`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -167,3 +167,4 @@ See [doc-quality-onboarding.md](doc-quality-onboarding.md) for a step-by-step gu
 8. A nightly job (`cleanup-ci-failure.yml`) closes any open `ci-failure` issues so the board stays tidy.
 
 9. A weekly job (`security-audit.yml`) runs dependency audits and uploads the report as an artifact.
+10. CODEOWNERS automatically requests reviews from the maintainer team.


### PR DESCRIPTION
## Summary
- auto-request reviews from maintainers via CODEOWNERS
- document CODEOWNERS behavior
- log CODEOWNERS addition in the changelog

## Testing
- `bash scripts/check_docs.sh` *(fails: Unable to download Vale)*
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6867595360ac8320adb3097d2811c65b