### PR TITLE
chore(ci): show auth logs on startup failure

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be recorded in this file.
 - Added `scripts/commit-msg` and `scripts/install_commit_msg_hook.sh` to help contributors set up a local `commit-msg` hook.
 - Added `tests/README.md` describing how to install project requirements before running `pytest` so modules like `fastapi` are available.
 - Added `scripts/wait_for_service.sh` and updated the CI workflow to reuse it when waiting for the auth service to start.
+- `scripts/wait_for_service.sh` now prints auth container logs when startup fails.
 - Documented the 95% coverage requirement and how to run Python and JavaScript coverage tests in `tests/README.md`.
 - Documented manual cleanup of `ci-failure` issues in `docs/ci-failure-issues.md`.
 - CI workflow now closes every open `ci-failure` issue once the pipeline succeeds.

--- a/scripts/wait_for_service.sh
+++ b/scripts/wait_for_service.sh
@@ -16,4 +16,5 @@ for ((i=1; i<=RETRIES; i++)); do
 done
 
 echo "Service failed to start: $URL" >&2
+docker compose logs auth >&2
 exit 1


### PR DESCRIPTION
## Summary
- print auth logs when service fails to start
- document the new behavior in the changelog

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68675dd8709083209e8a1414ae8055b9