### PR TITLE
Document AUTH_URL and header check URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,6 +44,7 @@ BOT_JWT=
 INIT_DB_ON_STARTUP=
 CORS_ALLOW_ORIGINS=*
 AUTH_URL=
+CHECK_HEADERS_URL=http://localhost:8002/api/user
 
 # Frontend configuration
 VITE_AUTH_URL=

--- a/docs/Agents.md
+++ b/docs/Agents.md
@@ -248,6 +248,7 @@ Use a small loop in your workflow to wait for the auth service before running te
 | BOT_JWT                      | JWT used by the bot for API calls          |
 | API_BASE_URL                 | XP API URL for the bot                     |
 | AUTH_URL                     | Auth service URL for Playwright tests      |
+| CHECK_HEADERS_URL            | Endpoint used by header checks (default `http://localhost:8002/api/user`) |
 | VITE_AUTH_URL                | Auth service URL for the frontend          |
 | VITE_API_URL                 | XP API URL for the frontend                |
 | VITE_DISCORD_CLIENT_ID       | Discord client ID for the frontend         |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -421,6 +421,7 @@ All notable changes to this project will be recorded in this file.
   CI uses `npm test` for the bot and frontend packages.
 - Documented the CI job's caching, concurrency, and coverage requirements in
   `docs/ci-workflow.md`.
+- Documented `AUTH_URL`, `DISCORD_API_TIMEOUT`, and `CHECK_HEADERS_URL` environment variables.
 
 ## [0.1.0] - 2025-06-14
 

--- a/docs/env.md
+++ b/docs/env.md
@@ -33,6 +33,7 @@ the repository. Provide them through your build or deployment secret store:
 - `DISCORD_GUILD_IDS` &ndash; comma-separated guilds where the bot operates.
 - `DISCORD_REDIRECT_URI` &ndash; callback URL for Discord OAuth. Defaults to
   `http://localhost:8002/login/discord/callback`.
+- `DISCORD_API_TIMEOUT` &ndash; HTTP timeout in seconds when contacting Discord APIs (default `10`).
 - `BOT_JWT` &ndash; fallback token used by the bot when calling the API. Bot
   API helpers send this JWT when no other token is provided.
 
@@ -90,6 +91,11 @@ status and level.
 - `VITE_API_URL` &ndash; base URL for the XP API.
 - `VITE_DISCORD_CLIENT_ID` &ndash; OAuth client ID for Discord.
 - `VITE_SESSION_REFRESH_INTERVAL` &ndash; interval (seconds) between session refreshes.
+
+## Testing utilities
+
+- `AUTH_URL` &ndash; base URL for the auth API used by Playwright tests. Defaults to `http://localhost:8002`.
+- `CHECK_HEADERS_URL` &ndash; endpoint queried by `scripts/check_headers.py` to verify headers (default `http://localhost:8002/api/user`).
 
 ## Docker development images
 


### PR DESCRIPTION
## Summary
- document `AUTH_URL`, `DISCORD_API_TIMEOUT`, and `CHECK_HEADERS_URL`
- list `CHECK_HEADERS_URL` in Agents environment table
- add `CHECK_HEADERS_URL` to `.env.example`
- record changelog entry

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6867648dfac48320ab23f59c9cacf713