### PR TITLE
Skip Codex image setup in CI

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -176,6 +176,7 @@ All notable changes to this project will be recorded in this file.
 - Replaced `AUTH_SECRET_KEY` with `JWT_SECRET_KEY` and added `JWT_ALGORITHM` with dotenv support.
 - Documented database agent and synced environment variables with `.env.example`.
 - `setup-env.sh` now falls back to `npm install` when `pnpm` is unavailable.
+- `setup-env.sh` skips the Codex Docker image when `CI` is set and uses the local virtualenv.
 - Added documentation & QA checklist to `docs/pull_request_template.md` and `.github/pull_request_template.md`.
 - Added `doc-quality-onboarding.md` with a quickstart for running documentation checks.
 - Replaced marketing preview links with the frontend README and React demo.

--- a/scripts/setup-env.sh
+++ b/scripts/setup-env.sh
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 echo "Checking Docker availability..."
-if docker info >/dev/null 2>&1; then
+if docker info >/dev/null 2>&1 && [ -z "${CI:-}" ]; then
     echo "Docker is available ✅"
     echo "Pulling Codex image..."
     docker pull ghcr.io/openai/codex-universal
@@ -13,7 +13,11 @@ if docker info >/dev/null 2>&1; then
         ghcr.io/openai/codex-universal /opt/codex/setup_universal.sh
     echo "Docker-based setup complete ✅"
 else
-    echo "Docker not usable, falling back to local setup"
+    if [ -n "${CI:-}" ]; then
+        echo "CI environment detected, skipping Codex Docker setup"
+    else
+        echo "Docker not usable, falling back to local setup"
+    fi
     python3 -m venv venv
     source venv/bin/activate
     python -m pip install --upgrade pip

--- a/tests/test_setup_env.py
+++ b/tests/test_setup_env.py
@@ -31,3 +31,35 @@ def test_setup_env_without_docker(tmp_path):
 
     result = subprocess.check_output([venv_dir / "bin" / "pip", "list"], text=True)
     assert "PyYAML" in result
+
+
+def test_setup_env_ci_skips_docker(tmp_path):
+    """setup-env.sh should skip Docker when CI is set."""
+    repo_root = Path(__file__).resolve().parents[1]
+    shutil.copy(repo_root / "scripts" / "setup-env.sh", tmp_path / "setup-env.sh")
+    shutil.copy(repo_root / "requirements-dev.txt", tmp_path / "requirements-dev.txt")
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    docker_stub = bin_dir / "docker"
+    docker_stub.write_text(
+        "#!/bin/sh\nif [ \"$1\" = \"info\" ]; then exit 0; else exit 1; fi\n"
+    )
+    docker_stub.chmod(0o755)
+
+    env = os.environ.copy()
+    env["PATH"] = str(bin_dir) + os.pathsep + env.get("PATH", "")
+    env["CI"] = "true"
+
+    subprocess.run(
+        ["bash", str(tmp_path / "setup-env.sh")],
+        cwd=tmp_path,
+        env=env,
+        check=True,
+    )
+
+    venv_dir = tmp_path / "venv"
+    assert (venv_dir / "bin" / "python").exists()
+
+    result = subprocess.check_output([venv_dir / "bin" / "pip", "list"], text=True)
+    assert "PyYAML" in result


### PR DESCRIPTION
## Summary
- detect `CI` variable in `setup-env.sh`
- fall back to virtualenv when running in CI
- test that CI skips Docker usage
- document behaviour in CHANGELOG

## Testing
- `./scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6867682dc60c8320b45330d7b231a997