### PR TITLE
Use actions/setup-gh

### DIFF
--- a/.github/actions/setup-gh-cli/action.yml
+++ b/.github/actions/setup-gh-cli/action.yml
@@ -3,24 +3,9 @@ runs:
   using: composite
   steps:
     - name: Install GitHub CLI
+      uses: actions/setup-gh@v4
+    - name: Log gh version
       shell: bash
       run: |
-        set -e
-        if [ "$RUNNER_OS" = "Windows" ]; then
-            choco install gh --no-progress --yes
-        elif [ "$RUNNER_OS" = "macOS" ]; then
-            brew install gh
-        else
-            sudo rm -f /usr/bin/gh || true
-            sudo mkdir -p -m 0755 /etc/apt/keyrings
-            curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg |
-              sudo dd of=/etc/apt/keyrings/githubcli-archive-keyring.gpg
-            sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
-            echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" |
-              sudo tee /etc/apt/sources.list.d/github-cli.list >/dev/null
-            sudo apt-get update
-            sudo apt-get install -y gh
-        fi
-        echo "/usr/local/bin" >> "$GITHUB_PATH"
         which gh
         gh --version

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ devonboarder-auth
 The auth service listens on `http://localhost:8002`.
 
 The CI pipeline uses `docker-compose.ci.yaml` to start the Postgres database during tests.
-All workflows install the GitHub CLI via the reusable `.github/actions/setup-gh-cli` action.
+All workflows install the GitHub CLI via the reusable `.github/actions/setup-gh-cli` action, which wraps `actions/setup-gh`.
 
 ## Codex Runs
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be recorded in this file.
 - Steps that invoke the GitHub CLI now call the path from `which gh` to ensure the latest version is used.
 - Updated `setup-gh-cli` to remove the old `/usr/bin/gh` binary and export `/usr/local/bin` through `$GITHUB_PATH` so the new CLI is always found.
 - CI now lints commit messages with `scripts/check_commit_messages.sh`.
+- `setup-gh-cli` now installs the GitHub CLI with the `actions/setup-gh` action to avoid apt repository outages.
 - CI workflow fetches the full git history so commit message linting can compare against `origin/main`.
 - Added `mypy` type checking and a configuration file. CI now runs `mypy`.
 - Updated `scripts/run_tests.sh` to run `pytest --cov=src --cov-fail-under=95`


### PR DESCRIPTION
## Summary
- install GitHub CLI with the actions/setup-gh action
- document use of actions/setup-gh in the README
- note new install approach in the changelog

## Testing
- `ruff check .`
- `mypy src/devonboarder`
- `pytest --cov=src --cov-fail-under=95`
- `bash scripts/check_docs.sh`


------
https://chatgpt.com/codex/tasks/task_e_68676ba006a08320bf7774dcdcd571f3