### PR TITLE
Update AGENTS docs on setup-gh action

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ This repository follows the DevOnboarder protocol. Key points:
 3. **Development Environment**
 - Use the provided container setup and compose files for local development.
 - Ensure all tests pass before submitting a PR.
-- Workflows install the GitHub CLI using the reusable `.github/actions/setup-gh-cli` action.
+ - Workflows install the GitHub CLI with the official `actions/setup-gh` action.
 
 4. **Contribution Guidelines**
 - Keep pull requests focused and small.


### PR DESCRIPTION
## Summary
- clarify that GitHub CLI installs via `actions/setup-gh`

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686879465070832086399c6908f8d406