### PR TITLE
Fix gh CLI install script for local envs

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be recorded in this file.
 - Added `scripts/install_gh_cli.sh` for local GitHub CLI installation and referenced it in the docs.
 - Added `scripts/commit-msg` and `scripts/install_commit_msg_hook.sh` to help contributors set up a local `commit-msg` hook.
 - Added `tests/README.md` describing how to install project requirements before running `pytest` so modules like `fastapi` are available.
+- `install_gh_cli.sh` now checks `GITHUB_PATH` before appending to prevent local failures.
 - Added `scripts/wait_for_service.sh` and updated the CI workflow to reuse it when waiting for the auth service to start.
 - `scripts/wait_for_service.sh` now prints auth container logs when startup fails.
 - Documented the 95% coverage requirement and how to run Python and JavaScript coverage tests in `tests/README.md`.

--- a/scripts/install_gh_cli.sh
+++ b/scripts/install_gh_cli.sh
@@ -40,4 +40,6 @@ esac
 
 which gh
 gh --version
-echo "/usr/local/bin" >> "$GITHUB_PATH"
+if [ -n "${GITHUB_PATH-}" ]; then
+    echo "/usr/local/bin" >> "$GITHUB_PATH"
+fi


### PR DESCRIPTION
# Summary
- check `GITHUB_PATH` before appending in `install_gh_cli.sh`
- note change in changelog

# Linked Issues

# Screenshots

# Testing Steps
```bash
pip install -e .
pip install -r requirements-dev.txt
ruff check .
pytest --cov=src --cov-fail-under=95
bash scripts/check_docs.sh
```


------
https://chatgpt.com/codex/tasks/task_e_6868874ae9d48320b544fd07ba9df70d