### PR TITLE
Extend wait_for_service logging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
                       exit 1
                   fi
             - name: Wait for auth service
-              run: bash scripts/wait_for_service.sh http://localhost:8002/health
+              run: bash scripts/wait_for_service.sh http://localhost:8002/health 30 2 auth
             - name: Prepare test-results directory
               run: mkdir -p test-results
             - name: Run tests with coverage
@@ -258,7 +258,7 @@ jobs:
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             - name: Wait for auth service
-              run: bash scripts/wait_for_service.sh http://localhost:8002/health
+              run: bash scripts/wait_for_service.sh http://localhost:8002/health 30 2 auth
             - name: Check CORS & security headers
               run: python scripts/check_headers.py
               env:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be recorded in this file.
 - `install_gh_cli.sh` now checks `GITHUB_PATH` before appending to prevent local failures.
 - Added `scripts/wait_for_service.sh` and updated the CI workflow to reuse it when waiting for the auth service to start.
 - `scripts/wait_for_service.sh` now prints auth container logs when startup fails.
+- `wait_for_service.sh` accepts an optional service name and prints that container's logs when provided.
 - Documented the 95% coverage requirement and how to run Python and JavaScript coverage tests in `tests/README.md`.
 - Documented manual cleanup of `ci-failure` issues in `docs/ci-failure-issues.md`.
 - CI workflow now closes every open `ci-failure` issue once the pipeline succeeds.

--- a/scripts/wait_for_service.sh
+++ b/scripts/wait_for_service.sh
@@ -2,9 +2,10 @@
 # Poll a URL until it returns success or retry limit is reached
 set -euo pipefail
 
-URL=${1:?"usage: $0 URL [retries] [sleep]"}
+URL=${1:?"usage: $0 URL [retries] [sleep] [service]"}
 RETRIES=${2:-30}
 SLEEP=${3:-2}
+SERVICE=${4:-auth}
 
 for ((i=1; i<=RETRIES; i++)); do
   if curl -fs "$URL" >/dev/null; then
@@ -17,5 +18,5 @@ done
 
 echo "Service failed to start: $URL" >&2
 docker compose ps >&2
-docker compose logs auth >&2
+docker compose logs "$SERVICE" >&2
 exit 1


### PR DESCRIPTION
## Summary
- extend `wait_for_service.sh` to accept a container name
- pass auth service name in CI workflow
- document new option in CHANGELOG

## Testing
- `bash scripts/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68689578853c83208986c91ab5feed10