### PR TITLE
Fix workflow CLI action mismatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
                   ref: ${{ github.head_ref }}
             - name: Lint commit messages
               run: bash scripts/check_commit_messages.sh
-            - uses: actions/setup-gh-cli@v4
+            - uses: actions/setup-gh@v4
             - name: Show gh version
               run: |
                   which gh

--- a/.github/workflows/cleanup-ci-failure.yml
+++ b/.github/workflows/cleanup-ci-failure.yml
@@ -7,7 +7,7 @@ jobs:
         permissions:
             issues: write
         steps:
-            - uses: actions/setup-gh-cli@v4
+            - uses: actions/setup-gh@v4
             - name: Show gh version
               run: |
                   which gh

--- a/.github/workflows/close-codex-issues.yml
+++ b/.github/workflows/close-codex-issues.yml
@@ -12,7 +12,7 @@ jobs:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-gh-cli@v4
+      - uses: actions/setup-gh@v4
       - name: Show gh version
         run: |
           which gh

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-gh-cli@v4
+      - uses: actions/setup-gh@v4
       - name: Show gh version
         run: |
           which gh

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ devonboarder-auth
 The auth service listens on `http://localhost:8002`.
 
 The CI pipeline uses `docker-compose.ci.yaml` to start the Postgres database during tests.
-All workflows install the GitHub CLI with the official `actions/setup-gh-cli` action.
+All workflows install the GitHub CLI with the official `actions/setup-gh` action.
 
 ## Codex Runs
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this project will be recorded in this file.
 - Offline install instructions now appear in CI logs when package installs fail.
 - CI now checks compose service status early and prints logs on failure.
 - `wait_for_service.sh` prints `docker compose ps` when a service fails.
+- Replaced deprecated `actions/setup-gh-cli` with `actions/setup-gh` in all workflows.
+- Updated README to document the new GitHub CLI installation method.
 - Added CODEOWNERS to automatically request maintainer reviews on pull requests.
 - CI workflow cancels in-progress runs when new commits push.
 - Added a 60-minute timeout to the `test` job in `ci.yml`.


### PR DESCRIPTION
## Summary
- switch CI workflows to `actions/setup-gh`
- update README to describe the new GitHub CLI install method

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6868c3b6cc88832097a2cd88aa9fca28