### PR TITLE
Fix GitHub CLI action reference

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
                   ref: ${{ github.head_ref }}
             - name: Lint commit messages
               run: bash scripts/check_commit_messages.sh
-            - uses: actions/setup-gh@v4
+            - uses: cli/cli-action@v2
             - name: Show gh version
               run: |
                   which gh

--- a/.github/workflows/cleanup-ci-failure.yml
+++ b/.github/workflows/cleanup-ci-failure.yml
@@ -7,7 +7,7 @@ jobs:
         permissions:
             issues: write
         steps:
-            - uses: actions/setup-gh@v4
+            - uses: cli/cli-action@v2
             - name: Show gh version
               run: |
                   which gh

--- a/.github/workflows/close-codex-issues.yml
+++ b/.github/workflows/close-codex-issues.yml
@@ -12,7 +12,7 @@ jobs:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-gh@v4
+      - uses: cli/cli-action@v2
       - name: Show gh version
         run: |
           which gh

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-gh@v4
+      - uses: cli/cli-action@v2
       - name: Show gh version
         run: |
           which gh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ This repository follows the DevOnboarder protocol. Key points:
 3. **Development Environment**
 - Use the provided container setup and compose files for local development.
 - Ensure all tests pass before submitting a PR.
- - Workflows install the GitHub CLI with the official `actions/setup-gh` action.
+ - Workflows install the GitHub CLI with the official `cli/cli-action` action.
 
 4. **Contribution Guidelines**
 - Keep pull requests focused and small.

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ devonboarder-auth
 The auth service listens on `http://localhost:8002`.
 
 The CI pipeline uses `docker-compose.ci.yaml` to start the Postgres database during tests.
-All workflows install the GitHub CLI with the official `actions/setup-gh` action.
+All workflows install the GitHub CLI with the official `cli/cli-action` action.
 
 ## Codex Runs
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,12 +5,12 @@ All notable changes to this project will be recorded in this file.
 ## [Unreleased]
 - CI workflow caches Playwright browsers to reuse ~/.cache/ms-playwright.
 - Skip Codex container setup when running in CI.
-- Use official `actions/setup-gh` for installing the GitHub CLI in CI.
+- Use `cli/cli-action` for installing the GitHub CLI in CI.
 - Documented commit-msg hook setup in CONTRIBUTING.md and docs.
 - Offline install instructions now appear in CI logs when package installs fail.
 - CI now checks compose service status early and prints logs on failure.
 - `wait_for_service.sh` prints `docker compose ps` when a service fails.
-- Replaced deprecated `actions/setup-gh-cli` with `actions/setup-gh` in all workflows.
+- Replaced deprecated `actions/setup-gh-cli` with `cli/cli-action` in all workflows.
 - Updated README to document the new GitHub CLI installation method.
 - Added CODEOWNERS to automatically request maintainer reviews on pull requests.
 - CI workflow cancels in-progress runs when new commits push.


### PR DESCRIPTION
## Summary
- switch all workflows to `cli/cli-action`
- document the new action in AGENTS, README, and CHANGELOG

## Testing
- `pre-commit run --files .github/workflows/ci.yml .github/workflows/cleanup-ci-failure.yml .github/workflows/close-codex-issues.yml .github/workflows/security-audit.yml AGENTS.md README.md docs/CHANGELOG.md` *(fails: pathspec v3.6.2)*
- `bash scripts/run_tests.sh` *(fails: Cannot read properties of undefined in Login.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_6868c8b943b0832080971a2d19bc089d