### PR TITLE
Add CI log artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,11 +283,11 @@ jobs:
               id: ci_failure
               run: |
                   gh_bin=$(which gh)
-                  ISSUE=$($gh_bin issue list --state open --search "CI Failures for ${{ github.sha }} in:title" --json number --jq '.[0].number')
+                  ISSUE=$($gh_bin issue list --state open --search "CI Failures for ${{ github.sha }} in:title" --json number --jq '.[0].number' | tee -a gh_cli.log)
                   if [ -n "$ISSUE" ]; then
-                      "$gh_bin" issue comment "$ISSUE" --body-file summary.md
+                      "$gh_bin" issue comment "$ISSUE" --body-file summary.md 2>&1 | tee -a gh_cli.log
                   else
-                      ISSUE=$($gh_bin issue create --title "CI Failures for ${{ github.sha }}" --body-file summary.md --label ci-failure --json number --jq '.number')
+                      ISSUE=$($gh_bin issue create --title "CI Failures for ${{ github.sha }}" --body-file summary.md --label ci-failure --json number --jq '.number' | tee -a gh_cli.log)
                   fi
                   echo "issue-number=$ISSUE" >> "$GITHUB_OUTPUT"
               env:
@@ -306,10 +306,18 @@ jobs:
               if: success()
               run: |
                   gh_bin=$(which gh)
-                  ISSUES=$($gh_bin issue list --label ci-failure --state open --json number --jq '.[].number')
+                  ISSUES=$($gh_bin issue list --label ci-failure --state open --json number --jq '.[].number' | tee -a gh_cli.log)
                   for ISSUE in $ISSUES; do
-                    "$gh_bin" issue comment "$ISSUE" --body "CI run ${{ github.run_id }} passed. Closing."
-                    "$gh_bin" issue close "$ISSUE"
+                    "$gh_bin" issue comment "$ISSUE" --body "CI run ${{ github.run_id }} passed. Closing." 2>&1 | tee -a gh_cli.log
+                    "$gh_bin" issue close "$ISSUE" 2>&1 | tee -a gh_cli.log
                   done
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            - name: Upload CI logs
+              if: always()
+              uses: actions/upload-artifact@v4
+              with:
+                  name: ci-logs
+                  path: |
+                      ${{ runner.temp }}/_github_workflow/*/job.log
+                      gh_cli.log

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be recorded in this file.
 - Offline install instructions now appear in CI logs when package installs fail.
 - CI now checks compose service status early and prints logs on failure.
 - `wait_for_service.sh` prints `docker compose ps` when a service fails.
+- CI workflow uploads the full job log as the `ci-logs` artifact.
 - Replaced deprecated `actions/setup-gh-cli` with `cli/cli-action` in all workflows.
 - Updated README to document the new GitHub CLI installation method.
 - Added CODEOWNERS to automatically request maintainer reviews on pull requests.

--- a/docs/ci-failure-issues.md
+++ b/docs/ci-failure-issues.md
@@ -5,6 +5,7 @@ When the CI workflow fails, it opens or updates an issue titled `CI Failures for
 ## Automatic Cleanup
 
 - `ci.yml` closes every open `ci-failure` issue whenever the pipeline succeeds using the built-in `GITHUB_TOKEN`.
+- The workflow uploads a `ci-logs` artifact with the full job log for download after each run.
 
 ## Clearing Old Issues
 


### PR DESCRIPTION
## Summary
- capture `gh` CLI output and upload CI logs artifact
- document downloadable job logs for troubleshooting
- note CI log artifact in changelog

## Testing
- `pre-commit run --files .github/workflows/ci.yml docs/ci-failure-issues.md docs/CHANGELOG.md` *(fails: pathspec 'v3.6.2' did not match any files known to git)*
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6868cea5ff60832099ea1f5d966e5052