### PR TITLE
Add CI verification note to changelog

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be recorded in this file.
 - `wait_for_service.sh` prints `docker compose ps` when a service fails.
 - CI workflow uploads the full job log as the `ci-logs` artifact.
 - Replaced deprecated `actions/setup-gh-cli` with `cli/cli-action` in all workflows.
+- Verified GitHub CLI installation via `cli/cli-action` across all workflows.
 - Updated README to document the new GitHub CLI installation method.
 - Documented GitHub CLI installation and version output in `docs/ci-workflow.md`.
 - Added CODEOWNERS to automatically request maintainer reviews on pull requests.


### PR DESCRIPTION
## Summary
- mention that CI verified the cli/cli-action migration

## Testing
- `bash scripts/check_docs.sh` *(fails: Unable to download Vale)*
- `bash scripts/check_potato_ignore.sh`
- `ruff check .`
- `mypy src`
- `bash scripts/run_tests.sh`
- `bash scripts/check_dependencies.sh` *(fails: jest not found, vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868d7a07f2883209c42a20a975d1ad4