### PR TITLE
Add origin story documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ See [docs/README.md](docs/README.md) for full setup instructions and workflow gu
 
 *Designed to automate onboarding, reduce friction, and support developers building from the ground up.*
 
+## Why This Project Exists
+
+The short version: everything broke, then got rebuilt. The longer lesson is documented in [docs/origin.md](docs/origin.md). It shows how journaling, automation, and relentless documentation turned failure into DevOnboarder.
+
 ## Trunk-Based Workflow
 
 - All stable code lives in the `main` branch.

--- a/codex/journal/devonboarder_feedback_log.md
+++ b/codex/journal/devonboarder_feedback_log.md
@@ -18,3 +18,4 @@
 ## Testimonials
 
 > "We got three remote interns up to speed in a day, instead of a week. Huge win." — @remoteteamops
+- 2025-07-07 — Added origin story documentation focusing on humility and learning from failure

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -437,6 +437,7 @@ All notable changes to this project will be recorded in this file.
   `docs/ci-workflow.md`.
 - Documented `AUTH_URL`, `DISCORD_API_TIMEOUT`, and `CHECK_HEADERS_URL` environment variables.
 - Documented running `scripts/install_commit_msg_hook.sh` after cloning so commit messages pass CI linting.
+- Added `docs/origin.md` with the project's backstory and linked it from the README.
 
 ## [0.1.0] - 2025-06-14
 

--- a/docs/origin.md
+++ b/docs/origin.md
@@ -1,0 +1,13 @@
+# Origin Story
+
+Between 2017 and 2021, the system that held everything together fell apart. Health issues and cascading outages forced a hard reset. The setback was severe, but recovery came through steady work: fixing the body first, then rebuilding an identity around smaller, repeatable wins.
+
+The process produced three lessons:
+
+1. **Journaling is fuel.** Recording each failure and improvement turned confusion into a map forward.
+2. **Automation prevents drift.** Replacing guesswork with scripts kept the recovery steps consistent.
+3. **Documentation keeps momentum.** Writing down each fix and procedure meant no step was lost when focus slipped.
+
+Those practices evolved into DevOnboarder. The project exists so others can skip the chaos and build on a clear, repeatable base.
+
+*This origin is shared to explain the project’s purpose—not to seek pity.*


### PR DESCRIPTION
## Summary
- document the project's origin story
- reference the story from the README
- note the new doc in the changelog and feedback log

## Testing
- `ruff check .`
- `pytest --cov=src --cov-fail-under=95`
- `npm run coverage --prefix bot`
- `npm run coverage --prefix frontend`
- `bash scripts/check_docs.sh`


------
https://chatgpt.com/codex/tasks/task_e_6868d8a716dc83208a1991512567a28e