### PR TITLE
Update GitHub CLI docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,8 @@ This repository follows the DevOnboarder protocol. Key points:
 3. **Development Environment**
 - Use the provided container setup and compose files for local development.
 - Ensure all tests pass before submitting a PR.
- - Workflows install the GitHub CLI with the official `cli/cli-action` action.
+ - Workflows rely on the preinstalled GitHub CLI or install it with
+   `scripts/install_gh_cli.sh`.
 
 4. **Contribution Guidelines**
 - Keep pull requests focused and small.

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ devonboarder-auth
 The auth service listens on `http://localhost:8002`.
 
 The CI pipeline uses `docker-compose.ci.yaml` to start the Postgres database during tests.
-All workflows install the GitHub CLI with `./scripts/install_gh_cli.sh`.
+Workflows rely on the preinstalled GitHub CLI or run `./scripts/install_gh_cli.sh`.
 
 ## Codex Runs
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,15 +5,16 @@ All notable changes to this project will be recorded in this file.
 ## [Unreleased]
 - CI workflow caches Playwright browsers to reuse ~/.cache/ms-playwright.
 - Skip Codex container setup when running in CI.
-- Use `cli/cli-action` for installing the GitHub CLI in CI.
+- Install the GitHub CLI in CI using the preinstalled binary or
+  `scripts/install_gh_cli.sh`.
 - Documented commit-msg hook setup in CONTRIBUTING.md and docs.
 - Offline install instructions now appear in CI logs when package installs fail.
 - CI now checks compose service status early and prints logs on failure.
 - `wait_for_service.sh` prints `docker compose ps` when a service fails.
 - CI workflow uploads the full job log as the `ci-logs` artifact.
-- Replaced deprecated `actions/setup-gh-cli` with `cli/cli-action` in all workflows.
-- Verified GitHub CLI installation via `cli/cli-action` across all workflows.
-- Workflows install the GitHub CLI via `install_gh_cli.sh` instead of `cli/cli-action`.
+- Replaced deprecated `actions/setup-gh-cli` with a direct
+  installation approach.
+- Verified GitHub CLI availability across all workflows.
 - Updated README to document the new GitHub CLI installation method.
 - Documented GitHub CLI installation and version output in `docs/ci-workflow.md`.
 - Added CODEOWNERS to automatically request maintainer reviews on pull requests.

--- a/docs/ci-workflow.md
+++ b/docs/ci-workflow.md
@@ -22,4 +22,4 @@ Both Python and JavaScript tests must maintain at least **95%** coverage. The wo
 
 ## GitHub CLI
 
-The workflows install the GitHub CLI with `./scripts/install_gh_cli.sh`. Each job then prints the install path and version with `which gh && gh --version` so the logs show exactly which binary is in use.
+Workflows rely on the GitHub CLI that comes preinstalled in the container image or install it with `./scripts/install_gh_cli.sh`. Each job prints the install path and version with `which gh && gh --version` so the logs show exactly which binary is in use.


### PR DESCRIPTION
## Summary
- fix AGENTS guidance about GH CLI installation
- clarify README details about GH CLI
- document new GH CLI policy in docs

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6868de026de8832084fe37f69f3c9a41