### PR TITLE
Add recovery origin story

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ See [docs/README.md](docs/README.md) for full setup instructions and workflow gu
 
 ## Why This Project Exists
 
-The short version: everything broke, then got rebuilt. The longer lesson is documented in [docs/origin.md](docs/origin.md). It shows how journaling, automation, and relentless documentation turned failure into DevOnboarder.
+The short version: everything broke, then got rebuilt. The full recovery story lives in [docs/origin.md](docs/origin.md).
 
 ## Trunk-Based Workflow
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be recorded in this file.
 - Archived `languagetool_check.py` to `archive/` and removed its invocation from `scripts/check_docs.sh`.
 - Added `scripts/install_gh_cli.sh` for local GitHub CLI installation and referenced it in the docs.
 - Added `scripts/commit-msg` and `scripts/install_commit_msg_hook.sh` to help contributors set up a local `commit-msg` hook.
+- Replaced `docs/origin.md` with a full recovery story and updated README links.
 - Added `tests/README.md` describing how to install project requirements before running `pytest` so modules like `fastapi` are available.
 - `install_gh_cli.sh` now checks `GITHUB_PATH` before appending to prevent local failures.
 - Added `scripts/wait_for_service.sh` and updated the CI workflow to reuse it when waiting for the auth service to start.

--- a/docs/README.md
+++ b/docs/README.md
@@ -113,7 +113,7 @@ platforms. Please report any issues you encounter on your operating system.
 - [Network troubleshooting](network-troubleshooting.md#pre-commit-nodeenv-ssl-errors)
   &ndash; work around pre-commit `nodeenv` SSL errors and other network restrictions.
 - [Offline setup](offline-setup.md) &ndash; download Python wheels and npm packages on another machine.
-- [Origin story](origin.md) &ndash; how the project emerged from rebuilding efforts.
+- [Project origin & recovery story](origin.md) &ndash; why DevOnboarder exists.
 - [Pull request template](pull_request_template.md) &ndash; describe your changes and verify the checklist.
 - [Sample pull request](sample-pr.md) &ndash; walkthrough of a minimal docs update.
 - [Security audit](security-audit-2025-07-01.md) &ndash; latest dependency check results.

--- a/docs/origin.md
+++ b/docs/origin.md
@@ -1,16 +1,62 @@
-# Origin Story
+---
+title: Project Origin & Recovery Story
+version: v1.0.0
+created: 2025-07-05
+---
 
-Between 2017 and 2021 everything collapsed. Health problems and cascading
-infrastructure failures wiped away years of progress. Recovery started with
-the basics: doctors, rest, and a strict routine to regain strength.
+# 🛠️ Why This Project Exists
 
-With health on track, identity followed. The plan was simple—celebrate small
-wins, journal every obstacle, and script recurring fixes. Automation kept the
-process steady. Documentation turned each lesson into a reproducible step.
+DevOnboarder isn’t just code. It’s a journey—a rebuilding of purpose, systems, and self.
 
-Those habits shaped DevOnboarder’s modular design. Every component mirrors the
-recovery path: short, repeatable tasks that work together. The goal is to give
-others a stable base so they can avoid the turmoil that sparked this project.
+---
 
-*This story is shared only to explain DevOnboarder’s purpose—not to seek
-sympathy.*
+## ⚠️ From System Collapse to System Rebuild
+
+Between 2017–2021, the builder of this project lost nearly everything:
+- A 24TB NAS full of code, documentation, and projects.
+- Health events: concussions and spinal surgery (C4/C5 vertebral replacement).
+- A period of physical and emotional pain masked through self-medication.
+- A return to manual labor under unsafe conditions—and a principled walk-off.
+- A business partnership break where ethics and effort no longer aligned.
+
+This was not collapse. It was a reclamation moment.
+
+---
+
+## 🔄 Rebuilding from the Ashes
+
+After relocating and recovering in 2021, the builder:
+- Returned to software, re-learning languages and workflows.
+- Discovered AI tools like Codex and ChatGPT as avenues for resilience.
+- Began rebuilding systems: journaling, CLI interfaces (`sf drop`, `sf ask`, `sf show`), DevContainer setups, Discord workflows, and GitHub CI/CD pipelines.
+- Turned personal necessity into replicable tools for anyone who needs a fresh start.
+
+---
+
+## 🧭 Not Sympathy — Humility & Growth
+
+This story isn’t shared for sympathy. Sympathy offers momentary comfort—it doesn’t build futures.
+
+What does build futures is **humility in failure**, the hard-earned clarity that follows—and the willingness to teach what was learned.
+
+DevOnboarder is a system born from that humility. It’s modular. Tested. Functional. It’s designed to help others rebuild — not to elicit pity.
+
+---
+
+## 📘 Implications for Anyone Onboarding Here
+
+- *You’re joining a tool with history.* Every command, test, and commit comes from a place of hard-earned resilience.
+- *You’re working on more than code.* You’re using insights shaped by loss, recovery, and systems rebuilding.
+- *You’re standing on a foundation forged by clarity under fire.* Humility isn’t weakness here—it’s the blueprint.
+
+---
+
+## 🚀 What Comes Next
+
+- don’t just use this tool—help build it forward.
+- Add prompts, stories, features or test reflections.
+- If this story resonates with you, your contributions can make it more accessible to others seeking to rise again.
+
+---
+
+*“Your origin isn’t your obstacle — it’s your ignition.”*


### PR DESCRIPTION
## Summary
- rewrite origin story with full recovery narrative
- link to origin doc in README and docs/README
- mention change in changelog

## Testing
- `ruff check .`
- `pytest --cov=src --cov-fail-under=95` *(fails: unrecognized arguments)*
- `npm run coverage --prefix bot` *(fails: jest not found)*
- `npm run coverage --prefix frontend` *(fails: vitest not found)*
- `bash scripts/check_docs.sh` *(fails: Vale missing)*

------
https://chatgpt.com/codex/tasks/task_e_6868df2caf048320bc08cc4ccd91630e