### PR TITLE
Cache pre-commit hooks for offline setup

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -38,6 +38,8 @@ All notable changes to this project will be recorded in this file.
 - Workflows log the install path with `which gh` and no longer modify `$GITHUB_PATH`.
 - Steps that invoke the GitHub CLI now call the path from `which gh` to ensure the latest version is used.
 - Updated `setup-gh-cli` to remove the old `/usr/bin/gh` binary and export `/usr/local/bin` through `$GITHUB_PATH` so the new CLI is always found.
+- Added `scripts/cache_precommit_hooks.sh` and offline instructions for caching
+  pre-commit hooks.
 - CI now lints commit messages with `scripts/check_commit_messages.sh`.
 - `setup-gh-cli` now installs the GitHub CLI with the `actions/setup-gh` action to avoid apt repository outages.
 - CI workflow fetches the full git history so commit message linting can compare against `origin/main`.

--- a/docs/offline-setup.md
+++ b/docs/offline-setup.md
@@ -79,3 +79,24 @@ After installing dependencies, run the usual setup commands such as `make deps` 
    ```
 
 Use `scripts/trivy_scan.sh` to scan the images built with `docker-compose.ci.yaml`.
+
+## Pre-commit hooks
+
+1. On the online machine, generate an offline bundle of hook environments:
+
+   ```bash
+   ./scripts/cache_precommit_hooks.sh
+   ```
+
+   This writes all hook dependencies to `~/devonboarder-offline/precommit`.
+
+2. Copy the `devonboarder-offline` folder to your offline machine.
+
+3. Point `pre-commit` at the cached hooks before installing:
+
+   ```bash
+   export PRE_COMMIT_HOME=/path/to/devonboarder-offline/precommit
+   pre-commit install
+   ```
+
+The hooks will run without needing network access.

--- a/scripts/cache_precommit_hooks.sh
+++ b/scripts/cache_precommit_hooks.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Cache pre-commit hook environments for offline use
+set -euo pipefail
+
+cache_dir="${1:-$HOME/devonboarder-offline/precommit}"
+
+mkdir -p "$cache_dir"
+
+# Use the repository's config to install all hook environments
+PRE_COMMIT_HOME="$cache_dir" pre-commit install-hooks
+
+echo "Cached pre-commit hooks at $cache_dir"

--- a/scripts/install_gh_cli.sh
+++ b/scripts/install_gh_cli.sh
@@ -43,3 +43,12 @@ gh --version
 if [ -n "${GITHUB_PATH-}" ]; then
     echo "/usr/local/bin" >> "$GITHUB_PATH"
 fi
+
+# Import pre-cached pre-commit hooks when available
+cache_src="$(pwd)/devonboarder-offline/precommit"
+dest_dir="${PRE_COMMIT_HOME:-$HOME/.cache/pre-commit}"
+if [ -d "$cache_src" ]; then
+    echo "Copying pre-commit hooks from $cache_src"
+    mkdir -p "$dest_dir"
+    cp -r "$cache_src"/* "$dest_dir"/
+fi


### PR DESCRIPTION
## Summary
- cache pre-commit hooks locally with a new script
- copy cached hooks in `install_gh_cli.sh`
- document offline pre-commit bundle
- log the change in the changelog

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6868e12d717083209f067a906b443d57