### PR TITLE
Add builder ethics dossier

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -444,6 +444,8 @@ All notable changes to this project will be recorded in this file.
 - Added `docs/origin.md` with the project's backstory and linked it from the README.
 - Expanded `docs/origin.md` with more detail on the 2017–2021 collapse,
   recovery steps, and disclaimers.
+- Added `docs/builder-ethics-dossier.md` documenting project values and
+  ethical commitments.
 
 ## [0.1.0] - 2025-06-14
 

--- a/docs/builder-ethics-dossier.md
+++ b/docs/builder-ethics-dossier.md
@@ -1,0 +1,88 @@
+---
+
+title: Builder Ethics Dossier
+author: DevOnboarder Project
+date_created: 2025-07-05
+version: v1.0.0
+---------------
+
+# 🧭 Builder Ethics Dossier
+
+This document outlines the foundational ethics, principles, and behavioral record
+of the primary builder of the DevOnboarder project. It is intended to serve as
+a model for transparency, personal accountability, and values-based development
+in open source and internal software ecosystems.
+
+---
+
+## 📌 Section 1: Builder Profile & Integrity Snapshot
+
+**Name (alias):** reesey275
+**Role:** Systems Realignment Architect / Principal Engineer
+**Project:** DevOnboarder (GitHub, Discord, VSCode, WSL2 toolchain)
+
+### Guiding Ethos:
+
+* **Transparency:** Everything documented, everything explainable.
+* **Resilience:** Built systems after loss of data, health, and stability.
+* **Service through Systems:** Builds tools that help others move forward.
+* **Humility in Failure:** Failure is not shame—it is curriculum.
+
+### Boundary Ethics:
+
+* Will not manipulate, misrepresent, or hide technical behavior.
+* Will not use nonprofit or open source resources for personal gain.
+* Will not conceal mistakes—prefers journaling and correction.
+* Will not gatekeep knowledge that could benefit others.
+
+---
+
+## 📂 Section 2: Values in Action – Real Decisions
+
+### 🔒 Integrity Checkpoints
+
+* **Refused to push unrecoverable changes without documentation.**
+* **Created journal systems to capture decision rationale.**
+* **Openly discusses burnout and mental load to model transparency.**
+* **Rejected partnerships where ethical alignment could not be ensured.**
+* **Built systems that make unethical behavior *difficult to hide*.**
+
+### 🧠 Self-Reflection Moments
+
+* Publicly acknowledged recovery period from 2017–2021.
+* Shared experiences of rebuilding after spinal injury, data loss,
+  and professional dissolution—*not for sympathy, but for clarity*.
+
+---
+
+## 📝 Section 3: Template for Other Builders
+
+> Copy and fill this section into your own documentation if desired.
+
+**Builder Alias or Name:**
+**Primary Projects:**
+**Role:**
+
+### Core Values
+
+* [ ] Transparency
+* [ ] Reproducibility
+* [ ] Resilience
+* [ ] Accountability
+* [ ] Knowledge-sharing
+
+### Behavioral Commitments
+
+* [ ] I will not misuse project resources for personal gain
+* [ ] I will maintain clear, auditable commit trails
+* [ ] I will not obscure errors or shortcomings
+* [ ] I will treat team members, users, and contributors with respect
+
+### Signature Statement
+
+*“I recognize that every decision I log becomes part of my ethical legacy.
+I choose to build in a way that makes me proud—and that others can trust.”*
+
+---
+
+> *For more tools and templates, see the DevOnboarder documentation suite.*


### PR DESCRIPTION
## Summary
- add builder ethics dossier with core values
- note addition in changelog

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6868e16450b8832099a192b085dcb752