### PR TITLE
Add CI log audit helper

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be recorded in this file.
 - CI now checks compose service status early and prints logs on failure.
 - `wait_for_service.sh` prints `docker compose ps` when a service fails.
 - CI workflow uploads the full job log as the `ci-logs` artifact.
+- Added `scripts/ci_log_audit.py` and documented using it to summarize CI logs in `docs/ci-failure-issues.md`.
 - Replaced deprecated `actions/setup-gh-cli` with a direct
   installation approach.
 - Verified GitHub CLI availability across all workflows.

--- a/docs/ci-failure-issues.md
+++ b/docs/ci-failure-issues.md
@@ -7,6 +7,16 @@ When the CI workflow fails, it opens or updates an issue titled `CI Failures for
 - `ci.yml` closes every open `ci-failure` issue whenever the pipeline succeeds using the built-in `GITHUB_TOKEN`.
 - The workflow uploads a `ci-logs` artifact with the full job log for download after each run.
 
+## Root Cause Summaries
+
+Run `scripts/ci_log_audit.py` on a downloaded log to highlight common errors.
+
+```bash
+python scripts/ci_log_audit.py ci.log > audit.md
+```
+
+Attach the `audit.md` output to CI failure issues so maintainers can quickly spot the failing step.
+
 ## Clearing Old Issues
 
 Past failures may leave old `ci-failure` issues open. You can close them in bulk with the GitHub CLI:

--- a/scripts/ci_log_audit.py
+++ b/scripts/ci_log_audit.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+"""Summarize common errors from CI logs."""
+from __future__ import annotations
+
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+
+PATTERNS = [
+    re.compile(r"Traceback"),
+    re.compile(r"npm ERR", re.IGNORECASE),
+    re.compile(r"ERROR"),
+    re.compile(r"FAIL"),
+]
+
+
+def extract_errors(path: Path) -> list[str]:
+    """Return lines matching error patterns from ``path``."""
+    if not path.exists():
+        return []
+    matches: list[str] = []
+    with path.open() as handle:
+        for line in handle:
+            if any(p.search(line) for p in PATTERNS):
+                matches.append(line.strip())
+    return matches
+
+
+def main() -> None:
+    files = [Path(p) for p in sys.argv[1:]]
+    if not files:
+        files = [Path("ci.log")]
+
+    counts: Counter[str] = Counter()
+    for file in files:
+        counts.update(extract_errors(file))
+
+    if not counts:
+        print("No error patterns found.")
+        return
+
+    print("# CI Log Audit\n")
+    for line, count in counts.most_common(20):
+        prefix = f"{count}x" if count > 1 else "-"
+        print(f"{prefix} {line}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `ci_log_audit.py` for extracting errors from CI logs
- document how to run the new log-audit script
- note log audit script in changelog

## Testing
- `bash scripts/check_docs.sh`
- `bash scripts/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_6868e58d79948320aecde2d8c867ecf5