### PR TITLE
Run CI log audit on failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,10 +277,15 @@ jobs:
             - name: Summarize CI failures
               if: failure()
               run: python scripts/summarize_ci_failures.py
+            - name: Run CI log audit
+              if: failure()
+              run: python scripts/ci_log_audit.py ${{ runner.temp }}/_github_workflow/*/job.log > audit.md
             - name: Create or update CI failure issue
               if: failure()
               id: ci_failure
               run: |
+                  printf '\n' >> summary.md
+                  cat audit.md >> summary.md
                   gh_bin=$(which gh)
                   ISSUE=$($gh_bin issue list --state open --search "CI Failures for ${{ github.sha }} in:title" --json number --jq '.[0].number' | tee -a gh_cli.log)
                   if [ -n "$ISSUE" ]; then
@@ -320,3 +325,4 @@ jobs:
                   path: |
                       ${{ runner.temp }}/_github_workflow/*/job.log
                       gh_cli.log
+                      audit.md

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be recorded in this file.
 - `wait_for_service.sh` prints `docker compose ps` when a service fails.
 - CI workflow uploads the full job log as the `ci-logs` artifact.
 - Added `scripts/ci_log_audit.py` and documented using it to summarize CI logs in `docs/ci-failure-issues.md`.
+- CI workflow now runs `ci_log_audit.py` on failures and appends the `audit.md` summary to CI failure issues.
 - Replaced deprecated `actions/setup-gh-cli` with a direct
   installation approach.
 - Verified GitHub CLI availability across all workflows.

--- a/docs/ci-failure-issues.md
+++ b/docs/ci-failure-issues.md
@@ -9,7 +9,9 @@ When the CI workflow fails, it opens or updates an issue titled `CI Failures for
 
 ## Root Cause Summaries
 
-Run `scripts/ci_log_audit.py` on a downloaded log to highlight common errors.
+The workflow automatically runs `scripts/ci_log_audit.py` on the CI job log when a step fails and appends the resulting `audit.md` to the failure issue comment.
+
+Run the script manually on a downloaded log if you need to dig deeper:
 
 ```bash
 python scripts/ci_log_audit.py ci.log > audit.md


### PR DESCRIPTION
## Summary
- run `ci_log_audit.py` when CI fails
- append the audit output to the CI failure issue comment
- upload the audit file with other logs
- document the new behavior

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68696932adc08320be558f6d87e589a6