### PR TITLE
Add tests for ci_log_audit script

### DIFF
--- a/docs/Agents.md
+++ b/docs/Agents.md
@@ -299,6 +299,7 @@ When retiring an agent, mark the section as deprecated with the date and reason.
 
 | Date        | Version | Author    | Summary                                |
 | ----------- | ------- | --------- | -------------------------------------- |
+| 3 Jul 2025  | v0.3.3  | Codex     | Added tests for ci_log_audit script |
 | 22 Jun 2025 | v0.3.0  | Codex     | Added service map and healthcheck guide |
 | 23 Jun 2025 | v0.3.1  | Codex     | Documented `/health` endpoints |
 | 2 Jul 2025  | v0.3.2  | Codex     | Archived languagetool script and updated tasks |
@@ -306,5 +307,5 @@ When retiring an agent, mark the section as deprecated with the date and reason.
 | 21 Jun 2025 | v0.2.0  | C. Reesey | Master merged, health matrix, glossary |
 | 21 Jun 2025 | v0.1.0  | C. Reesey | Initial draft                          |
 
-*Last updated: 2 July 2025*
+*Last updated: 3 July 2025*
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be recorded in this file.
 - CI workflow uploads the full job log as the `ci-logs` artifact.
 - Added `scripts/ci_log_audit.py` and documented using it to summarize CI logs in `docs/ci-failure-issues.md`.
 - CI workflow now runs `ci_log_audit.py` on failures and appends the `audit.md` summary to CI failure issues.
+- Added tests for `ci_log_audit.py`.
 - Replaced deprecated `actions/setup-gh-cli` with a direct
   installation approach.
 - Verified GitHub CLI availability across all workflows.

--- a/tests/test_ci_log_audit.py
+++ b/tests/test_ci_log_audit.py
@@ -1,0 +1,52 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+
+# Load the ci_log_audit script as a module
+spec = importlib.util.spec_from_file_location(
+    "ci_log_audit", Path(__file__).resolve().parents[1] / "scripts" / "ci_log_audit.py"
+)
+ci_log_audit = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(ci_log_audit)
+
+
+SAMPLE_LINES = [
+    "All good",
+    "Traceback (most recent call last):",
+    "npm ERR! missing script: test",
+    "ERROR: something broke",
+    "FAIL MyTest",
+    "FAIL MyTest",
+]
+
+
+def test_extract_errors(tmp_path):
+    log = tmp_path / "ci.log"
+    log.write_text("\n".join(SAMPLE_LINES))
+
+    errors = ci_log_audit.extract_errors(log)
+    assert errors == [
+        "Traceback (most recent call last):",
+        "npm ERR! missing script: test",
+        "ERROR: something broke",
+        "FAIL MyTest",
+        "FAIL MyTest",
+    ]
+
+
+def test_main_summarizes_counts(tmp_path, monkeypatch, capsys):
+    log = tmp_path / "ci.log"
+    log.write_text("\n".join(SAMPLE_LINES))
+
+    monkeypatch.setattr(sys, "argv", ["ci_log_audit.py", str(log)])
+    ci_log_audit.main()
+    out_lines = [line for line in capsys.readouterr().out.splitlines() if line]
+
+    assert out_lines == [
+        "# CI Log Audit",
+        "2x FAIL MyTest",
+        "- Traceback (most recent call last):",
+        "- npm ERR! missing script: test",
+        "- ERROR: something broke",
+    ]


### PR DESCRIPTION
## Summary
- test `extract_errors` and `main` from `ci_log_audit.py`
- document test addition in CHANGELOG and Agents revision history

## Testing
- `pytest --cov=src --cov-fail-under=95 -vv`

------
https://chatgpt.com/codex/tasks/task_e_68696eea7fd08320857b25aeea86b599