### PR TITLE
Expand ci-failure docs

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be recorded in this file.
 - Added `scripts/ci_log_audit.py` and documented using it to summarize CI logs in `docs/ci-failure-issues.md`.
 - CI workflow now runs `ci_log_audit.py` on failures and appends the `audit.md` summary to CI failure issues.
 - Added tests for `ci_log_audit.py`.
+- Expanded `docs/ci-failure-issues.md` with an explanation of the automated audit step and how to interpret `audit.md`.
 - Replaced deprecated `actions/setup-gh-cli` with a direct
   installation approach.
 - Verified GitHub CLI availability across all workflows.

--- a/docs/ci-failure-issues.md
+++ b/docs/ci-failure-issues.md
@@ -19,6 +19,19 @@ python scripts/ci_log_audit.py ci.log > audit.md
 
 Attach the `audit.md` output to CI failure issues so maintainers can quickly spot the failing step.
 
+## Automated Audit Step
+
+CI runs `scripts/ci_log_audit.py` whenever a job fails. The script searches the
+log for common error patterns such as `Traceback`, `npm ERR`, `ERROR`, and
+`FAIL`. It counts how many times each line appears and writes the results to
+`audit.md`.
+
+The workflow uploads `audit.md` with the job logs and appends its contents to
+the failure issue. The file begins with `# CI Log Audit` followed by lines
+prefixed with `Nx` when a message appears multiple times or `-` if it occurs
+once. Use these counts to find the most frequent errors before opening the full
+log artifact.
+
 ## Clearing Old Issues
 
 Past failures may leave old `ci-failure` issues open. You can close them in bulk with the GitHub CLI:


### PR DESCRIPTION
## Summary
- describe the automated log audit step and interpreting `audit.md`
- note the new section in the changelog

## Testing
- `ruff check .`
- `pytest --cov=src --cov-fail-under=95`
- `npm run coverage` in `bot/`
- `npm run coverage` in `frontend/`


------
https://chatgpt.com/codex/tasks/task_e_686972bc6c2c83209d79ac38a40e12c7