### PR TITLE
Add builder ethics dossier

### DIFF
--- a/codex/journal/2025-07-05.md
+++ b/codex/journal/2025-07-05.md
@@ -1,0 +1,4 @@
+## ✅ Ethics Dossier Added
+
+Created `docs/builder_ethics_dossier.md` to formally document builder intent, boundaries, and reproducible ethical guidelines for future contributors.
+

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -452,6 +452,7 @@ All notable changes to this project will be recorded in this file.
   recovery steps, and disclaimers.
 - Added `docs/builder-ethics-dossier.md` documenting project values and
   ethical commitments.
+- Added `docs/builder_ethics_dossier.md` declaring the builder's ethics and reusable template.
 
 ## [0.1.0] - 2025-06-14
 

--- a/docs/builder_ethics_dossier.md
+++ b/docs/builder_ethics_dossier.md
@@ -1,0 +1,48 @@
+---
+title: Builder Ethics Dossier
+author: DevOnboarder Project
+date_created: 2025-07-05
+version: v1.0.0
+---
+
+# Builder Ethics Dossier
+
+## Builder Profile & Integrity Snapshot
+
+- **Name (alias):** `reesey275`
+- **Role:** `Systems Realignment Architect`
+- **Core values:** transparency, resilience, service-through-systems, humility in failure
+
+### Boundary statements
+- Will not misuse nonprofit or OSS resources for personal gain
+- Will not obscure or hide bugs/errors
+- Will maintain full audit trails through journaling and commits
+
+## Values in Action – Real Decisions
+
+- Rebuilding DevOnboarder after data and health loss (2017–2021)
+- Public logs, Codex journaling, and GitHub transparency
+- Refusal to compromise on documentation or clarity
+- Designed systems that make unethical behavior *technically difficult*
+
+## Template for Other Builders
+
+Checklist and commitment form:
+
+- [ ] Transparency
+- [ ] Accountability
+- [ ] Resilience
+- [ ] Service-through-systems
+- [ ] Humility in failure
+
+Behavioral promises:
+
+- [ ] I will not misuse project resources for personal gain
+- [ ] I will not obscure or hide bugs/errors
+- [ ] I will maintain clear audit trails in commits
+
+**Signature statement:**
+
+"I recognize that every decision I log becomes part of my ethical legacy. I choose to build in a way that makes me proud—and that others can trust."
+
+


### PR DESCRIPTION
## Summary
- add `docs/builder_ethics_dossier.md` with builder profile, real decision examples, and a template
- record the change in the changelog
- log the addition in `codex/journal/2025-07-05.md`

## Testing
- `bash scripts/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_686978d2a54883209a8b988d2590a621