### PR TITLE
Update Quickstart coverage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ docker compose -f docker-compose.prod.yaml --env-file .env.prod up -d
    ruff check .
    pytest --cov=src --cov-fail-under=95
    npm run coverage --prefix bot
+   npm run coverage --prefix frontend
    ```
 7. The CI workflow enforces a minimum of **95% code coverage** for all projects (frontend, bot, and backend). Pull requests will fail if any test suite drops below this threshold.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -58,6 +58,7 @@ All notable changes to this project will be recorded in this file.
 - Updated `docker-compose.codex.yml` with the Codex runner image and documented manual invocation under "Codex Runs".
 
 - Clarified README instructions to stop the server with Ctrl+C.
+- Updated README quickstart to run `npm run coverage --prefix frontend`.
 - Removed unused `REDIS_URL`, `LOG_LEVEL`, and `API_KEY` from `.env.example` and
   documented `CORS_ALLOW_ORIGINS` and `DISCORD_REDIRECT_URI` in `docs/Agents.md`
   and `docs/env.md`.


### PR DESCRIPTION
## Summary
- mention running frontend coverage in the Quickstart instructions
- log the documentation update in the changelog

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68697d6cbae483209eb36042b40fbec9