### PR TITLE
Split Agents docs into dedicated directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ Workflow documentation lives under the [docs/](docs/) directory. New contributor
 13. Install Vale with `brew install vale` (or see the [Vale installation docs](https://vale.sh/docs/installation/))
     and install Python dependencies from `requirements-dev.txt` so the
     documentation checks work locally.
-14. Keep the sentinel word `Potato` and the file `Potato.md` listed in `.gitignore`, `.dockerignore`, and `.codespell-ignore`.
+14. Browse the [agents overview](agents/index.md) for individual service specs.
+15. Keep the sentinel word `Potato` and the file `Potato.md` listed in `.gitignore`, `.dockerignore`, and `.codespell-ignore`.
     See [AGENTS.md](AGENTS.md) for the full policy. Both pre-commit and CI run `scripts/check_potato_ignore.sh`
     to confirm the entries exist. Do not remove them without approval.
 

--- a/agents/discord-integration.md
+++ b/agents/discord-integration.md
@@ -1,0 +1,7 @@
+# Discord Integration Agent
+
+**Status:** Deferred – planned endpoints `/oauth` and `/roles` are not yet implemented.
+
+**Purpose:** Handles Discord OAuth flows and role lookups once the service is built.
+
+**Key Files:** To be determined when development resumes.

--- a/agents/index.md
+++ b/agents/index.md
@@ -1,0 +1,10 @@
+# Agents Overview
+
+This directory documents the services and integrations that make up the DevOnboarder platform. Each agent has its own page describing the purpose and how it fits into the workflow.
+
+## Available Agents
+
+- [Discord Integration](discord-integration.md)
+- [MS Teams Integration](ms-teams-integration.md)
+
+Use the [template](templates/agent-spec-template.md) when documenting a new agent.

--- a/agents/ms-teams-integration.md
+++ b/agents/ms-teams-integration.md
@@ -1,0 +1,7 @@
+# MS Teams Integration Agent
+
+**Status:** Planned.
+
+**Purpose:** Provides Microsoft Teams notifications and channel integrations for project updates.
+
+**Key Files:** To be determined when work begins.

--- a/agents/templates/agent-spec-template.md
+++ b/agents/templates/agent-spec-template.md
@@ -1,0 +1,11 @@
+# <Agent Name>
+
+**Purpose:** <Describe what the agent does.>
+
+**Inputs:** <List required inputs or triggers.>
+
+**Outputs:** <Describe results or side effects.>
+
+**Environment:** <Relevant variables or configuration.>
+
+**Workflow:** <Step-by-step outline of how the agent operates.>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be recorded in this file.
 - `wait_for_service.sh` prints `docker compose ps` when a service fails.
 - CI workflow uploads the full job log as the `ci-logs` artifact.
 - Added `scripts/ci_log_audit.py` and documented using it to summarize CI logs in `docs/ci-failure-issues.md`.
+- Split `docs/Agents.md` into `agents/` pages and updated references.
 - CI workflow now runs `ci_log_audit.py` on failures and appends the `audit.md` summary to CI failure issues.
 - Added tests for `ci_log_audit.py`.
 - Expanded `docs/ci-failure-issues.md` with an explanation of the automated audit step and how to interpret `audit.md`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -103,6 +103,7 @@ platforms. Please report any issues you encounter on your operating system.
 - [E2E test guide](e2e-tests.md) &ndash; run the Playwright suite.
 - [Endpoint reference](endpoint-reference.md) &ndash; list of API routes and Discord command mappings.
 - [Environment variables](env.md) &ndash; explanation of `.env` settings and the role-based permission system.
+- [Agents overview](../agents/index.md) &ndash; service and integration specs.
 - [Feedback dashboard PRD](prd/feedback-dashboard.md) &ndash; objectives and features for the feedback tool.
 - [Founder's Circle onboarding](founders/README.md) &ndash; roles and perks for core supporters.
 - [Founders log](../FOUNDERS.md) &ndash; record core contributors and how they help.

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -38,8 +38,8 @@ bash scripts/check_docs.sh
 # Checklist
 
 - [ ] All code passes lint, type, and security checks
-- [ ] All new ENV variables are documented in `docs/Agents.md`
-- [ ] `.env.example` matches the table in `docs/Agents.md`
+- [ ] All new ENV variables are documented in `agents/index.md`
+- [ ] `.env.example` matches the table in `agents/index.md`
 - [ ] OpenAPI/contract and migration checks pass
 - [ ] All API endpoints have docstrings and documentation
 - [ ] CORS and security headers validated


### PR DESCRIPTION
## Summary
- add agents index and integration docs
- provide template for agent specs
- link new docs from README and docs README
- update PR template references
- note restructure in changelog

## Testing
- `bash scripts/check_docs.sh`
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68697ca0bce4832086a2462e05ae268d