### PR TITLE
docs: note new agent docs location

### DIFF
--- a/docs/Agents.md
+++ b/docs/Agents.md
@@ -1,5 +1,9 @@
 # Agents — Service and Integration Roles (Codex-Driven Reference)
 
+> **Note**: The up-to-date agent documentation now lives at
+> [agents/index.md](../agents/index.md). The remainder of this file is kept for
+> legacy reference only.
+
 This document defines all agents (services, bots, integrations, and guards) in the TAGS ecosystem. Each entry describes the agent's purpose, configuration, and typical workflow so contributors and Codex automation can keep the platform healthy.
 
 <!-- This file is derived from the master merged draft provided during onboarding. -->

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -457,6 +457,7 @@ All notable changes to this project will be recorded in this file.
 - Added `docs/builder_ethics_dossier.md` declaring the builder's ethics and reusable template.
 - Added environment variable summary to `agents/index.md`.
 - Added MS Teams integration variables (`TEAMS_APP_ID`, `TEAMS_APP_PASSWORD`, `TEAMS_TENANT_ID`, `TEAMS_CHANNEL_ID_ONBOARD`) to `.env.example` and documentation.
+- Added a legacy note in `docs/Agents.md` directing readers to `agents/index.md`.
 
 ## [0.1.0] - 2025-06-14
 


### PR DESCRIPTION
## Summary
- point old Agents page to new agents/index.md
- log the change in the changelog

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6869ac826bfc8320a53e1b249a91c742