### PR TITLE
Add pre-commit install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,8 @@ docker compose -f docker-compose.prod.yaml --env-file .env.prod up -d
    npm run coverage --prefix bot
    npm run coverage --prefix frontend
    ```
-8. The CI workflow enforces a minimum of **95% code coverage** for all projects (frontend, bot, and backend). Pull requests will fail if any test suite drops below this threshold.
+8. Install git hooks with `pre-commit install` so lint checks run automatically.
+9. The CI workflow enforces a minimum of **95% code coverage** for all projects (frontend, bot, and backend). Pull requests will fail if any test suite drops below this threshold.
 
 Licensed under the MIT License. See `LICENSE.md` for details.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -459,6 +459,7 @@ All notable changes to this project will be recorded in this file.
 - Added `docs/builder_ethics_dossier.md` declaring the builder's ethics and reusable template.
 - Added environment variable summary to `agents/index.md`.
 - Added MS Teams integration variables (`TEAMS_APP_ID`, `TEAMS_APP_PASSWORD`, `TEAMS_TENANT_ID`, `TEAMS_CHANNEL_ID_ONBOARD`) to `.env.example` and documentation.
+- Documented running `pre-commit install` in README Quickstart.
 
 ## [0.1.0] - 2025-06-14
 


### PR DESCRIPTION
## Summary
- highlight running `pre-commit install` during setup
- document README update in changelog

## Testing
- `pre-commit run --files README.md docs/CHANGELOG.md` *(fails: CalledProcessError: command: ('/usr/bin/git', 'checkout', 'v3.6.2'))*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869acbe814883208c7d8a351b76f3ea