### PR TITLE
Add ID.me verification and AI mentor stubs

### DIFF
--- a/agents/ai-mentor.md
+++ b/agents/ai-mentor.md
@@ -1,0 +1,11 @@
+# AI Mentor Agent
+
+**Purpose:** Provides automated mentorship and guidance to new contributors.
+
+**Inputs:** TBD
+
+**Outputs:** TBD
+
+**Environment:** TBD
+
+**Workflow:** TBD

--- a/agents/idme-verification.md
+++ b/agents/idme-verification.md
@@ -1,0 +1,11 @@
+# ID.me Verification Agent
+
+**Purpose:** Handles user verification via ID.me.
+
+**Inputs:** TBD
+
+**Outputs:** TBD
+
+**Environment:** TBD
+
+**Workflow:** TBD

--- a/agents/index.md
+++ b/agents/index.md
@@ -6,6 +6,8 @@ This directory documents the services and integrations that make up the DevOnboa
 
 - [Discord Integration](discord-integration.md)
 - [MS Teams Integration](ms-teams-integration.md)
+- [ID.me Verification](idme-verification.md)
+- [AI Mentor](ai-mentor.md)
 
 Use the [template](templates/agent-spec-template.md) when documenting a new agent.
 ## Required Environment Variables

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be recorded in this file.
 - Updated README to document the new GitHub CLI installation method.
 - Documented GitHub CLI installation and version output in `docs/ci-workflow.md`.
 - Added CODEOWNERS to automatically request maintainer reviews on pull requests.
+- Added stub agent specs for ID.me verification and AI mentor.
 - CI workflow cancels in-progress runs when new commits push.
 - Added a 60-minute timeout to the `test` job in `ci.yml`.
 - Added `close-codex-issues.yml` workflow to automatically close Codex-created issues referenced by `Fixes #<issue>` after a pull request merges and documented it in `docs/README.md`.


### PR DESCRIPTION
## Summary
- stub out agents for ID.me verification and AI mentor
- list new stubs in the agents index
- document the new pages in the changelog

## Testing
- `bash scripts/run_tests.sh` *(fails: KeyboardInterrupt after tests complete)*
- `bash scripts/check_docs.sh`

------
https://chatgpt.com/codex/tasks/task_e_6869d48bdafc8320a9e0cf7b7029fe37