### PR TITLE
docs(journal): Log frontend coverage quickstart update

### DIFF
--- a/codex/journal/2025-07-05.md
+++ b/codex/journal/2025-07-05.md
@@ -4,3 +4,7 @@ Created `docs/builder_ethics_dossier.md` to formally document builder intent, bo
 
 Removed the outdated duplicate `docs/builder-ethics-dossier.md`.
 
+
+## ✅ Task Complete: Frontend Coverage in Quickstart
+Added `npm run coverage --prefix frontend` to README and updated `docs/CHANGELOG.md`.
+


### PR DESCRIPTION
## Summary
- update the codex journal with quickstart coverage documentation reference

## Testing
- `ruff check .`
- `pytest --cov=src --cov-fail-under=95` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `bash scripts/check_docs.sh`

------
https://chatgpt.com/codex/tasks/task_e_6869f9e03f7c8320988150f9d83fd87e