### PR TITLE
Add bot install step to setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ docker compose -f docker-compose.prod.yaml --env-file .env.prod up -d
 
 1. Install Docker, Docker Compose, Node.js 20, and Python 3.12.
 2. Run `bash scripts/bootstrap.sh` to create `.env.dev` and install dependencies.
+   The script installs the frontend and bot packages so `npm ci --prefix bot` is
+   only needed if you skip this step.
 3. Run `bash scripts/generate-secrets.sh` so `.env.dev` matches the secrets CI uses.
 4. Copy each `*.env.example` to `.env` inside its service directory.
 5. Build the containers with `make deps` and start them with `make up`.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -206,6 +206,8 @@ All notable changes to this project will be recorded in this file.
 - Documented database agent and synced environment variables with `.env.example`.
 - `setup-env.sh` now falls back to `npm install` when `pnpm` is unavailable.
 - `setup-env.sh` skips the Codex Docker image when `CI` is set and uses the local virtualenv.
+- `setup-env.sh` installs bot packages when `bot/` exists and the README quickstart mentions
+  running `npm ci --prefix bot`.
 - Added documentation & QA checklist to `docs/pull_request_template.md` and `.github/pull_request_template.md`.
 - Added `doc-quality-onboarding.md` with a quickstart for running documentation checks.
 - Replaced marketing preview links with the frontend README and React demo.

--- a/scripts/setup-env.sh
+++ b/scripts/setup-env.sh
@@ -43,6 +43,17 @@ else
         fi
         cd ..
     fi
+
+    if [ -d bot ]; then
+        cd bot
+        if command -v pnpm >/dev/null 2>&1; then
+            pnpm install
+        else
+            echo "pnpm not found, using npm"
+            npm install
+        fi
+        cd ..
+    fi
     export PYTHONPATH="$(pwd)"
     echo "Local environment ready ✅"
 fi


### PR DESCRIPTION
## Summary
- install bot packages in `setup-env.sh`
- mention bot install in README quickstart
- note the change in `CHANGELOG`

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6869fcf987e0832095d8c973d3a240b5