### PR TITLE
Add check_headers test

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be recorded in this file.
 - Split `docs/Agents.md` into `agents/` pages and updated references.
 - CI workflow now runs `ci_log_audit.py` on failures and appends the `audit.md` summary to CI failure issues.
 - Added tests for `ci_log_audit.py`.
+- Added a test for `scripts/check_headers.py` using FastAPI's TestClient.
 - Expanded `docs/ci-failure-issues.md` with an explanation of the automated audit step and how to interpret `audit.md`.
 - Replaced deprecated `actions/setup-gh-cli` with a direct
   installation approach.

--- a/tests/test_check_headers.py
+++ b/tests/test_check_headers.py
@@ -1,0 +1,32 @@
+import importlib
+import os
+import sys
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+import requests
+
+# Ensure the repository root is on the import path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+# Ensure required environment variables exist before importing the service
+os.environ.setdefault("APP_ENV", "development")
+os.environ.setdefault("JWT_SECRET_KEY", "devsecret")
+
+from devonboarder.auth_service import create_app
+
+
+def test_check_headers(monkeypatch):
+    """Verify check_headers.main succeeds against the auth service."""
+    app = create_app()
+    client = TestClient(app)
+
+    # Patch requests.get to route through the TestClient
+    monkeypatch.setattr(requests, "get", lambda url, timeout=5: client.get(url))
+
+    # Point the script to the TestClient's URL
+    monkeypatch.setenv("CHECK_HEADERS_URL", f"{client.base_url}/api/user")
+    module = importlib.import_module("scripts.check_headers")
+    importlib.reload(module)
+
+    module.main()


### PR DESCRIPTION
## Summary
- add regression test for scripts/check_headers.py
- document the new test in the changelog

## Testing
- `pytest --cov=src --cov-fail-under=95 -q`

------
https://chatgpt.com/codex/tasks/task_e_686abd841fa08320928319c42046c576