### PR TITLE
Add builder ethics dossier links

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Workflow documentation lives under the [docs/](docs/) directory. New contributor
 15. Keep the sentinel word `Potato` and the file `Potato.md` listed in `.gitignore`, `.dockerignore`, and `.codespell-ignore`.
     See [AGENTS.md](AGENTS.md) for the full policy. Both pre-commit and CI run `scripts/check_potato_ignore.sh`
     to confirm the entries exist. Do not remove them without approval.
+16. Review the [builder ethics dossier](docs/builder_ethics_dossier.md) outlining contributor ethics and a simple template.
 
 These files expand on the steps listed in the Quickstart section.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be recorded in this file.
 - CI now checks compose service status early and prints logs on failure.
 - `wait_for_service.sh` prints `docker compose ps` when a service fails.
 - CI workflow uploads the full job log as the `ci-logs` artifact.
+- Linked `builder_ethics_dossier.md` from the README and docs overview.
 - Added `scripts/ci_log_audit.py` and documented using it to summarize CI logs in `docs/ci-failure-issues.md`.
 - Removed `VERIFIED_GOVERNMENT_ROLE_ID`, `VERIFIED_MILITARY_ROLE_ID`, and `VERIFIED_EDUCATION_ROLE_ID` from `.env.example` and documentation.
 - Split `docs/Agents.md` into `agents/` pages and updated references.

--- a/docs/README.md
+++ b/docs/README.md
@@ -118,6 +118,7 @@ platforms. Please report any issues you encounter on your operating system.
 - [Pull request template](pull_request_template.md) &ndash; describe your changes and verify the checklist.
 - [Sample pull request](sample-pr.md) &ndash; walkthrough of a minimal docs update.
 - [Security audit](security-audit-2025-07-01.md) &ndash; latest dependency check results.
+- [Builder ethics dossier](builder_ethics_dossier.md) &ndash; outlines contributor ethics and provides a template.
 - [Task management](task-management.md) &ndash; archive completed items in `codex.tasks.json`.
 - [Troubleshooting guide](troubleshooting.md)
   &ndash; quick fixes for setup problems and failing CI jobs.


### PR DESCRIPTION
## Summary
- link to the builder ethics dossier from the project README
- highlight the builder ethics dossier under Key Documentation
- note the new links in the changelog

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686ac7903fec8320a79086fafa097c26