### PR TITLE
Add builder ethics journal entry

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -462,6 +462,8 @@ All notable changes to this project will be recorded in this file.
 - Expanded `docs/origin.md` with more detail on the 2017–2021 collapse,
   recovery steps, and disclaimers.
 - Added `docs/builder_ethics_dossier.md` documenting project values and a reusable template. Removed the outdated `docs/builder-ethics-dossier.md`.
+- Added a journal log section in `docs/builder_ethics_dossier.md` summarizing the removal of
+  `docs/builder-ethics-dossier.md` and noting the Quickstart coverage command.
 - Added environment variable summary to `agents/index.md`.
 - Added MS Teams integration variables (`TEAMS_APP_ID`, `TEAMS_APP_PASSWORD`, `TEAMS_TENANT_ID`, `TEAMS_CHANNEL_ID_ONBOARD`) to `.env.example` and documentation.
 - Documented running `pre-commit install` in README Quickstart.

--- a/docs/builder_ethics_dossier.md
+++ b/docs/builder_ethics_dossier.md
@@ -45,4 +45,10 @@ Behavioral promises:
 
 "I recognize that every decision I log becomes part of my ethical legacy. I choose to build in a way that makes me proud—and that others can trust."
 
+## 📘 Journal Log: 2025-07-05
+
+Removed the outdated `docs/builder-ethics-dossier.md` in favor of this
+`docs/builder_ethics_dossier.md`. The Quickstart now instructs running
+`npm run coverage --prefix frontend` so React tests meet the coverage
+policy.
 


### PR DESCRIPTION
## Summary
- add a "📘 Journal Log" section to `builder_ethics_dossier.md`
- document the new journal log in the changelog

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686ac9b9cab083209c55d545a9bf2857