### PR TITLE
Update frontend README with coverage instructions

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -471,6 +471,8 @@ All notable changes to this project will be recorded in this file.
 - Documented `API_BASE_URL` in `.env.example` and environment docs.
 - Added Llama2 Agile Helper agent doc and `LLAMA2_API_KEY` variable.
 - Documented planned status for Llama2 Agile Helper agent.
+- Documented running `npm run coverage` in `frontend/README.md` and noted the
+  95% coverage requirement.
 
 ## [0.1.0] - 2025-06-14
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -14,3 +14,13 @@ After approving the OAuth prompt, Discord redirects back to
 `/login/discord/callback` on the frontend. The `Login` component exchanges the
 provided `code` for a JWT via the auth service, stores it in `localStorage`, and
 then displays your onboarding status and level.
+
+## Tests
+
+Generate a coverage report with:
+
+```bash
+npm run coverage
+```
+
+The CI workflow requires every suite to maintain **95%** coverage.


### PR DESCRIPTION
## Summary
- document npm coverage script in `frontend/README.md`
- note the CI coverage requirement
- record the README change in `docs/CHANGELOG.md`

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686acdb7c16c8320b6d3026be6532a3e