### PR TITLE
Add Llama2 Agile Helper expansion docs

### DIFF
--- a/agents/llama2-agile-helper.md
+++ b/agents/llama2-agile-helper.md
@@ -11,3 +11,42 @@
 
 - `LLAMA2_API_KEY` – API key for calling the Llama2 service.
 
+
+## Planned Workflows
+
+| Workflow | Description |
+| -------- | ----------- |
+| Sprint Planning | Break down epics into user stories, estimate story points, flag ambiguous tickets |
+| Daily Standups | Summarize team updates, detect blockers, highlight progress |
+| Retrospectives | Analyze retro notes, extract themes, suggest improvements |
+| Backlog Grooming | Classify stale tickets, suggest grouping or refactoring |
+| Agile Coaching | Provide tips or nudges when processes drift |
+
+## Prompt Templates
+
+Prompt files live in the `prompts/` folder.
+
+| Template | Input Data | Output |
+| -------- | ---------- | ------ |
+| `sprint_estimator.prompt` | Epics, stories, team history | Story point estimates |
+| `standup_summary.prompt`  | Team update logs | Bullet summary, blockers |
+| `retro_analysis.prompt`   | Raw retro notes | Summary, lessons learned |
+| `ticket_classifier.prompt` | Backlog items | Priority, labels |
+| `coaching_tips.prompt`    | Sprint metrics, WIP ratio | Process suggestions |
+
+## Integration Points
+
+| Integration Point | Description |
+| ----------------- | ----------- |
+| Codex Task Hook | Generate sprint summaries after each sprint |
+| Slack/Teams Trigger | Invoke `/retro-summary` or `/groom-backlog` in chat |
+| GitHub Action Hook | Run on PRs labeled `planning` or `retrospective` |
+| Frontend Button | Manual trigger in the dashboard |
+
+## Metrics
+
+Metrics are logged in `metrics/llama2-usage.md`.
+- Number of agent invocations
+- Time saved vs. manual planning (estimation)
+- Ticket classification accuracy
+- Team satisfaction via periodic polls

--- a/codex/tasks/llama2-agile-helper.yaml
+++ b/codex/tasks/llama2-agile-helper.yaml
@@ -1,0 +1,6 @@
+# Codex Task: Llama2 Agile Helper Integration
+steps:
+  - name: Generate sprint summary after each sprint
+    trigger: codex_post_sprint
+  - name: Suggest backlog grooming actions
+    trigger: manual

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -473,6 +473,7 @@ All notable changes to this project will be recorded in this file.
 - Documented planned status for Llama2 Agile Helper agent.
 - Documented running `npm run coverage` in `frontend/README.md` and noted the
   95% coverage requirement.
+- Added feature expansion plan for Llama2 Agile Helper agent with prompts and integration points.
 
 ## [0.1.0] - 2025-06-14
 

--- a/metrics/llama2-usage.md
+++ b/metrics/llama2-usage.md
@@ -1,0 +1,6 @@
+# Llama2 Agile Helper Metrics
+
+This log tracks agent usage and quality signals for research purposes.
+
+| Date | Invocations | Notes |
+| ---- | ----------- | ----- |

--- a/prompts/retro_analysis.prompt
+++ b/prompts/retro_analysis.prompt
@@ -1,0 +1,2 @@
+# Retrospective Analysis Prompt
+Summarize retrospective notes, extract recurring themes, and suggest action items for the next sprint.

--- a/prompts/sprint_estimator.prompt
+++ b/prompts/sprint_estimator.prompt
@@ -1,0 +1,2 @@
+# Sprint Estimator Prompt
+Provide story point estimates for each user story based on team history and complexity. Include a short rationale.


### PR DESCRIPTION
## Summary
- extend `llama2-agile-helper.md` with workflows, prompts, integration points, and metrics
- add placeholder prompt files
- add Codex task YAML and metrics log
- log the feature expansion in the changelog

## Testing
- `ruff check .`
- `pytest --maxfail=1 -q` *(fails: ModuleNotFoundError: No module named 'devonboarder')*
- `bash scripts/check_docs.sh` *(fails: Vale not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ad53ea39c8320b852e647cdbfd4b7