### PR TITLE
DOCS(agile-helper): expand Llama2 agent with prompts and tasks

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -474,6 +474,7 @@ All notable changes to this project will be recorded in this file.
 - Documented running `npm run coverage` in `frontend/README.md` and noted the
   95% coverage requirement.
 - Added feature expansion plan for Llama2 Agile Helper agent with prompts and integration points.
+- Added prompts, metrics log, and Codex tasks scaffolding for the Llama2 Agile Helper agent.
 
 ## [0.1.0] - 2025-06-14
 


### PR DESCRIPTION
## Summary
- summarize new Llama2 Agile Helper docs and scaffolding in CHANGELOG

## Testing
- `scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686bc69b70048320adc0fa9717c0d2f8