### PR TITLE
Cleanup legacy verification role ID mentions

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,7 +15,6 @@ All notable changes to this project will be recorded in this file.
 - CI workflow uploads the full job log as the `ci-logs` artifact.
 - Linked `builder_ethics_dossier.md` from the README and docs overview.
 - Added `scripts/ci_log_audit.py` and documented using it to summarize CI logs in `docs/ci-failure-issues.md`.
-- Removed `VERIFIED_GOVERNMENT_ROLE_ID`, `VERIFIED_MILITARY_ROLE_ID`, and `VERIFIED_EDUCATION_ROLE_ID` from `.env.example` and documentation.
 - Split `docs/Agents.md` into `agents/` pages and updated references.
 - CI workflow now runs `ci_log_audit.py` on failures and appends the `audit.md` summary to CI failure issues.
 - Added tests for `ci_log_audit.py`.
@@ -275,9 +274,6 @@ All notable changes to this project will be recorded in this file.
   conditions when checking expiry.
 - Bot API helpers now accept a `username` argument and bot commands send the
   caller's name in each request.
-- Clarified the purpose of `VERIFIED_GOVERNMENT_ROLE_ID`,
-  `VERIFIED_MILITARY_ROLE_ID`, and `VERIFIED_EDUCATION_ROLE_ID` in
-  `docs/env.md`.
 - XP API now reads `Contribution` and `XPEvent` data to return onboarding
   status and level for the requested user.
 - Moved role flag logic to `utils.roles` and added `resolve_verification_type`.
@@ -474,6 +470,7 @@ All notable changes to this project will be recorded in this file.
 - Documented running `npm run coverage` in `frontend/README.md` and noted the
   95% coverage requirement.
 - Added feature expansion plan for Llama2 Agile Helper agent with prompts and integration points.
+- Cleaned up outdated verification role ID references across the docs.
 
 ## [0.1.0] - 2025-06-14
 


### PR DESCRIPTION
## Summary
- scrub outdated role ID variables from the changelog
- document the cleanup

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `bash scripts/check_docs.sh` *(fails: unable to download Vale)*

------
https://chatgpt.com/codex/tasks/task_e_686bc6d8831c8320b0d54479d075a9d6