### PR TITLE
Add Llama2 integration step to Codex plan

### DIFF
--- a/codex.automation.bundle.json
+++ b/codex.automation.bundle.json
@@ -49,6 +49,14 @@
                 "Display XP, level, next milestone via API integration",
                 "Add loader and error states to calls"
             ]
+        },
+        {
+            "name": "llama2_agile_helper",
+            "description": "Provide sprint summaries and backlog grooming tips via the Llama2 Agile Helper agent.",
+            "actions": [
+                "Generate sprint summary after each sprint",
+                "Suggest backlog grooming actions"
+            ]
         }
     ],
     "workflow": "main"

--- a/codex.plan.md
+++ b/codex.plan.md
@@ -59,6 +59,12 @@ This document defines the roadmap and execution logic for Codex tasks during the
 
 ---
 
+### 🚧 Phase 5: Llama2 Agile Helper Integration
+
+- [agile-001] Connect Llama2 Agile Helper agent for sprint summaries and backlog suggestions. See [codex/tasks/llama2-agile-helper.yaml](codex/tasks/llama2-agile-helper.yaml).
+
+---
+
 ## 📆 Upcoming Milestones
 
 | Date       | Task ID         | Target Version |
@@ -66,6 +72,7 @@ This document defines the roadmap and execution logic for Codex tasks during the
 | 2025-07-05 | integration-001 | v0.4.0 |
 | 2025-07-12 | feedback-001    | v0.5.0 |
 | 2025-07-19 | feedback-002    | v0.5.0 |
+| 2025-07-26 | agile-001       | v0.5.0 |
 
 ---
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -474,6 +474,7 @@ All notable changes to this project will be recorded in this file.
 - Added prompts, metrics log, and Codex tasks scaffolding for the Llama2 Agile Helper agent.
 - Documented configuring `VALE_BINARY` when the Vale binary is not in `PATH`.
 - Verified builder ethics dossier links, journal log, and coverage doc alignment (`codex/tasks/confirm_doc_alignment.md`)
+- Documented Llama2 Agile Helper integration step in `codex.plan.md` and updated automation bundle.
 
 ## [0.1.0] - 2025-06-14
 


### PR DESCRIPTION
## Summary
- document Phase 5 for the Llama2 Agile Helper in `codex.plan.md`
- list Agile Helper module in `codex.automation.bundle.json`
- log the change in `docs/CHANGELOG.md`

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686bd34863388320bbb5ca140ab0d2ad