### PR TITLE
Add bot coverage instructions

### DIFF
--- a/bot/README.md
+++ b/bot/README.md
@@ -44,6 +44,16 @@ bot:
   command: ["npm", "start"]
 ```
 
+## Tests
+
+Generate a coverage report with:
+
+```bash
+npm run coverage
+```
+
+The CI workflow requires every suite to maintain **95%** coverage.
+
 ## Adding Commands
 
 Place new command modules in `src/commands`. Each module exports

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be recorded in this file.
 - CI now checks compose service status early and prints logs on failure.
 - `wait_for_service.sh` prints `docker compose ps` when a service fails.
 - CI workflow uploads the full job log as the `ci-logs` artifact.
+- Added a Tests section to `bot/README.md` with `npm run coverage` instructions and noted the **95%** coverage requirement.
 - Linked `builder_ethics_dossier.md` from the README and docs overview.
 - Added `scripts/ci_log_audit.py` and documented using it to summarize CI logs in `docs/ci-failure-issues.md`.
 - Split `docs/Agents.md` into `agents/` pages and updated references.


### PR DESCRIPTION
## Summary
- document how to run `npm run coverage` for the Discord bot
- mention 95% coverage threshold in bot docs
- log the README update in the changelog

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686bea3c4a308320afdba3e2a6734101