### PR TITLE
Update env docs for Teams and Llama2 vars

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be recorded in this file.
 - CI now checks compose service status early and prints logs on failure.
 - `wait_for_service.sh` prints `docker compose ps` when a service fails.
 - CI workflow uploads the full job log as the `ci-logs` artifact.
+- Documented Teams and Llama2 environment variables in `docs/env.md`.
 - Linked `builder_ethics_dossier.md` from the README and docs overview.
 - Added `scripts/ci_log_audit.py` and documented using it to summarize CI logs in `docs/ci-failure-issues.md`.
 - Split `docs/Agents.md` into `agents/` pages and updated references.

--- a/docs/env.md
+++ b/docs/env.md
@@ -89,6 +89,14 @@ status and level.
 - `AUTH_URL` &ndash; base URL for the auth API used by Playwright tests. Defaults to `http://localhost:8002`.
 - `CHECK_HEADERS_URL` &ndash; endpoint queried by `scripts/check_headers.py` to verify headers (default `http://localhost:8002/api/user`).
 
+## Integrations
+
+- `TEAMS_APP_ID` &ndash; Azure app ID for the MS Teams integration.
+- `TEAMS_APP_PASSWORD` &ndash; secret used to authenticate the Teams app.
+- `TEAMS_TENANT_ID` &ndash; Azure tenant hosting the Teams app.
+- `TEAMS_CHANNEL_ID_ONBOARD` &ndash; Teams channel ID for onboarding updates.
+- `LLAMA2_API_KEY` &ndash; API key for accessing the Llama2 service.
+
 ## Docker development images
 
 `docker-compose.dev.yaml` builds the bot and frontend containers using


### PR DESCRIPTION
## Summary
- document Teams and Llama2 integration variables in `docs/env.md`
- note the documentation update in the changelog

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686bd62f1db883208aacf0a09bf1b739