### PR TITLE
Remove obsolete XP environment file

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ The short version: everything broke, then got rebuilt. The full recovery story l
 - `bot/` – Discord bot written in TypeScript.
 - `frontend/` – Vite-based React application.
 - `auth/` – Environment files for the authentication service.
-- `xp/` – Environment files for the XP API.
 - `config/devonboarder.config.yml` – Config for the `devonboarder` tool.
 - `.env.example` – Sample variables shared across services.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to this project will be recorded in this file.
 - CI workflow cancels in-progress runs when new commits push.
 - Added a 60-minute timeout to the `test` job in `ci.yml`.
 - Added `close-codex-issues.yml` workflow to automatically close Codex-created issues referenced by `Fixes #<issue>` after a pull request merges and documented it in `docs/README.md`.
+- Removed obsolete `xp/.env.example`; the XP API now reads from the main `.env` file.
 - Archived `languagetool_check.py` to `archive/` and removed its invocation from `scripts/check_docs.sh`.
 - Added `scripts/install_gh_cli.sh` for local GitHub CLI installation and referenced it in the docs.
 - Added `scripts/commit-msg` and `scripts/install_commit_msg_hook.sh` to help contributors set up a local `commit-msg` hook.

--- a/xp/.env.example
+++ b/xp/.env.example
@@ -1,5 +1,0 @@
-# Environment variables for the XP API
-APP_ENV=development
-REDIS_URL=redis://localhost:6379/0
-DATABASE_URL=postgresql://devuser:devpass@localhost:5432/devdb
-LOG_LEVEL=INFO


### PR DESCRIPTION
## Summary
- drop unused `xp/.env.example`
- remove XP bullet from README
- document env file removal in CHANGELOG

## Testing
- `scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686be216b3708320a1f968a7683a894f