### PR TITLE
Update docs on installing project before pytest

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to this project will be recorded in this file.
 - CI now checks compose service status early and prints logs on failure.
 - `wait_for_service.sh` prints `docker compose ps` when a service fails.
 - CI workflow uploads the full job log as the `ci-logs` artifact.
+- Documented running `pip install -e .` before `pytest` in docs/README.md and
+  docs/ONBOARDING.md to avoid `ModuleNotFoundError: No module named 'devonboarder'`.
 - Documented Teams and Llama2 environment variables in `docs/env.md`.
 - Added a Tests section to `bot/README.md` with `npm run coverage` instructions and noted the **95%** coverage requirement.
 - Linked `builder_ethics_dossier.md` from the README and docs overview.

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -43,6 +43,15 @@ If Codex does not respond, make sure:
 * Codex bot is installed and has permission to comment and create issues.
 * Workflow files (such as `.github/workflows/codex.ci.yml`) include `full-qa` as a supported command.
 
+If `pytest` exits with `ModuleNotFoundError: No module named 'devonboarder'`
+(referenced in `tests/test_app.py`), install the project in editable mode
+before running the tests:
+
+```bash
+pip install -e .
+pip install -r requirements-dev.txt
+```
+
 If Vale or LanguageTool cannot run due to network errors, Codex marks the documentation step as a "⚠️ Docs: Lint skipped" warning. You can still merge if all other required checks pass, but please run docs checks locally later to catch formatting errors.
 
 ### Optional Easter Egg (for fun!)

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,6 +44,10 @@ After cloning the repository, run `bash scripts/install_commit_msg_hook.sh` to i
     pip install -r requirements-dev.txt
     ```
 
+    If you skip these commands, `pytest` fails with
+    `ModuleNotFoundError: No module named 'devonboarder'` from
+    `tests/test_app.py`.
+
 14. Run `npm run coverage` in both the `bot/` and `frontend/` directories to collect test coverage.
     The CI workflow fails if coverage drops below **95%**.
 15. Install git hooks with `pre-commit install` so these checks run automatically.


### PR DESCRIPTION
## Summary
- warn about pytest failure if the project isn't installed in editable mode
- include installation troubleshooting instructions in ONBOARDING
- log the change in the changelog

## Testing
- `ruff check .`
- `pytest --cov=src --cov-fail-under=95`

------
https://chatgpt.com/codex/tasks/task_e_686bf4419ff4832093afd3199e78db3b