### PR TITLE
Add offline header check test

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be recorded in this file.
 - CI now checks compose service status early and prints logs on failure.
 - `wait_for_service.sh` prints `docker compose ps` when a service fails.
 - CI workflow uploads the full job log as the `ci-logs` artifact.
+- Documented offline header check in `tests/test_check_headers.py`.
 - Linked `builder_ethics_dossier.md` from the README and docs overview.
 - Added `scripts/ci_log_audit.py` and documented using it to summarize CI logs in `docs/ci-failure-issues.md`.
 - Split `docs/Agents.md` into `agents/` pages and updated references.

--- a/tests/test_check_headers.py
+++ b/tests/test_check_headers.py
@@ -29,4 +29,4 @@ def test_check_headers(monkeypatch):
     module = importlib.import_module("scripts.check_headers")
     importlib.reload(module)
 
-    module.main()
+    assert module.main() is None


### PR DESCRIPTION
## Summary
- assert that `scripts.check_headers.main()` returns None
- note the new offline header test in the changelog

## Testing
- `pytest --cov=src --cov-fail-under=95`

------
https://chatgpt.com/codex/tasks/task_e_686bc9f4b92483209181f96152d4f446