### PR TITLE
Add pytest.ini for src path

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be recorded in this file.
   docs/ONBOARDING.md to avoid `ModuleNotFoundError: No module named 'devonboarder'`.
 - Documented Teams and Llama2 environment variables in `docs/env.md`.
 - Added a Tests section to `bot/README.md` with `npm run coverage` instructions and noted the **95%** coverage requirement.
+- Added `pytest.ini` to load modules from `src` without installing the package.
 - Linked `builder_ethics_dossier.md` from the README and docs overview.
 - Added `scripts/ci_log_audit.py` and documented using it to summarize CI logs in `docs/ci-failure-issues.md`.
 - Split `docs/Agents.md` into `agents/` pages and updated references.

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -43,9 +43,9 @@ If Codex does not respond, make sure:
 * Codex bot is installed and has permission to comment and create issues.
 * Workflow files (such as `.github/workflows/codex.ci.yml`) include `full-qa` as a supported command.
 
-If `pytest` exits with `ModuleNotFoundError: No module named 'devonboarder'`
-(referenced in `tests/test_app.py`), install the project in editable mode
-before running the tests:
+`pytest.ini` sets `pythonpath=src` so tests can locate `devonboarder`.
+Install the project in editable mode before running the tests to ensure
+all dependencies are available:
 
 ```bash
 pip install -e .

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,9 +44,9 @@ After cloning the repository, run `bash scripts/install_commit_msg_hook.sh` to i
     pip install -r requirements-dev.txt
     ```
 
-    If you skip these commands, `pytest` fails with
-    `ModuleNotFoundError: No module named 'devonboarder'` from
-    `tests/test_app.py`.
+    `pytest.ini` sets `pythonpath=src` so tests can locate the
+    `devonboarder` package. Installing the project still ensures
+    dependencies like **FastAPI** are available.
 
 14. Run `npm run coverage` in both the `bot/` and `frontend/` directories to collect test coverage.
     The CI workflow fails if coverage drops below **95%**.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+pythonpath = src
+


### PR DESCRIPTION
## Summary
- configure pytest to add src to PYTHONPATH
- clarify test instructions in README and ONBOARDING
- log the new config in the changelog

## Testing
- `pytest -q`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_686bf8b1a804832081cadbb902999825