### PR TITLE
Update Vale docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,10 @@ Workflow documentation lives under the [docs/](docs/) directory. New contributor
 12. Run `./scripts/check_docs.sh` to lint documentation with Vale and
     LanguageTool. Set `LANGUAGETOOL_URL` if you use a local LanguageTool
     server.
-13. Install Vale with `brew install vale` (or see the [Vale installation docs](https://vale.sh/docs/installation/))
+13. Install the Vale CLI (version 3.12.0+) with `brew install vale` on macOS or
+    `choco install vale` on Windows. You can also download it from the
+    [Vale releases page](https://github.com/errata-ai/vale/releases).
+    If the binary isn't in your `PATH`, set the `VALE_BINARY` environment variable
     and install Python dependencies from `requirements-dev.txt` so the
     documentation checks work locally.
 14. Browse the [agents overview](agents/index.md) for individual service specs.

--- a/docs/README.md
+++ b/docs/README.md
@@ -158,7 +158,8 @@ All Markdown files must pass Vale and LanguageTool checks.
 See [doc-quality-onboarding.md](doc-quality-onboarding.md) for a step-by-step guide.
 
 - Run `bash scripts/check_docs.sh` before pushing any changes.
-- Install Vale (version 3.12.0) with `brew install vale` or download it from the
+- Install Vale (version 3.12.0) with `brew install vale` on macOS or
+  `choco install vale` on Windows. You can also download it from the
   [Vale releases page](https://github.com/errata-ai/vale/releases).
 - If your network blocks direct downloads, fetch version 3.12.0 from
   `https://github.com/errata-ai/vale/releases` on another machine and copy the


### PR DESCRIPTION
## Summary
- mention Chocolatey installation in docs
- clarify Vale installation options in the main README

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `bash scripts/check_docs.sh` *(warns about Vale issues)*

------
https://chatgpt.com/codex/tasks/task_e_686c00e606888320946b30db1ba40814