### PR TITLE
Add env audit script

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be recorded in this file.
   docs/ONBOARDING.md to avoid `ModuleNotFoundError: No module named 'devonboarder'`.
 - Documented Teams and Llama2 environment variables in `docs/env.md`.
 - Added a Tests section to `bot/README.md` with `npm run coverage` instructions and noted the **95%** coverage requirement.
+- Added `scripts/audit_env_vars.sh` to report missing or extra environment variables and documented usage in `docs/env.md`.
 - Added `pytest.ini` to load modules from `src` without installing the package.
 - Linked `builder_ethics_dossier.md` from the README and docs overview.
 - Added `scripts/ci_log_audit.py` and documented using it to summarize CI logs in `docs/ci-failure-issues.md`.

--- a/docs/env.md
+++ b/docs/env.md
@@ -109,3 +109,10 @@ starting `npm run dev`.
 The base `Dockerfile` installs Python packages with `pip install --root-user-action=ignore`
 to silence warnings when running as the root user. If you create your own image,
 you can activate a virtual environment instead of using this flag.
+
+## Auditing environment variables
+
+Run `scripts/audit_env_vars.sh` to compare your current environment to the
+variables listed in `.env.example`, `frontend/src/.env.example`,
+`bot/.env.example`, and `auth/.env.example`. The script prints any required
+variables that are missing and any extras found in the environment.

--- a/scripts/audit_env_vars.sh
+++ b/scripts/audit_env_vars.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Gather required variable names from example files
+FILES=(.env.example frontend/src/.env.example bot/.env.example auth/.env.example)
+required_vars=$(grep -h -oE '^[A-Za-z_][A-Za-z0-9_]*' "${FILES[@]}" | sort -u)
+
+# Current environment variable names
+current_vars=$(env | cut -d= -f1 | sort -u)
+
+# Print missing variables: required but not present in environment
+missing=$(comm -23 <(printf '%s\n' "$required_vars") <(printf '%s\n' "$current_vars"))
+# Print extra variables: present in environment but not required
+extra=$(comm -13 <(printf '%s\n' "$required_vars") <(printf '%s\n' "$current_vars"))
+
+echo "Missing variables:"; echo "$missing"
+echo
+echo "Extra variables:"; echo "$extra"


### PR DESCRIPTION
## Summary
- add `scripts/audit_env_vars.sh` to detect missing or extra environment variables
- document script usage in `docs/env.md`
- record change in `docs/CHANGELOG.md`

## Testing
- `bash scripts/run_tests.sh`
- `bash scripts/check_docs.sh`


------
https://chatgpt.com/codex/tasks/task_e_686c00eede90832095518b05ba9188fa