### PR TITLE
Clarify auth_service test revisions

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -38,6 +38,7 @@ All notable changes to this project will be recorded in this file.
 - CI workflow cancels in-progress runs when new commits push.
 - Added a 60-minute timeout to the `test` job in `ci.yml`.
 - Added `close-codex-issues.yml` workflow to automatically close Codex-created issues referenced by `Fixes #<issue>` after a pull request merges and documented it in `docs/README.md`.
+- Clarified auth_service test revisions in commit e541dd5.
 - Removed obsolete `xp/.env.example`; the XP API now reads from the main `.env` file.
 - Archived `languagetool_check.py` to `archive/` and removed its invocation from `scripts/check_docs.sh`.
 - Added `scripts/install_gh_cli.sh` for local GitHub CLI installation and referenced it in the docs.


### PR DESCRIPTION
## Summary
- record auth_service test revisions in the changelog
- add an empty follow-up commit clarifying the change

This follow-up references commit `e541dd5` which originally updated `tests/test_auth_service.py` with the message "Missed file from previous commit".

## Testing
- `bash scripts/check_docs.sh`
- `bash scripts/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_686c096f8ec883209fcce0c3a4b530f8