### PR TITLE
Add env docs check script

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be recorded in this file.
 - Skip Codex container setup when running in CI.
 - Install the GitHub CLI in CI using the preinstalled binary or
   `scripts/install_gh_cli.sh`.
+- Added `scripts/check_env_docs.py` to validate environment variable docs and
+  referenced it in `docs/merge-checklist.md`.
 - Documented commit-msg hook setup in CONTRIBUTING.md and docs.
 - Offline install instructions now appear in CI logs when package installs fail.
 - CI now checks compose service status early and prints logs on failure.

--- a/docs/merge-checklist.md
+++ b/docs/merge-checklist.md
@@ -6,6 +6,8 @@ Reviewers must verify the following before merging a pull request:
 - [ ] `docs/CHANGELOG.md` includes an entry for the change.
 - [ ] Documentation in `docs/` is updated as needed.
 - [ ] Documentation passes `bash scripts/check_docs.sh`.
+- [ ] Environment variable docs match `.env.example` files via
+      `python scripts/check_env_docs.py`.
 - [ ] The pull request contains a completed reviewer sign-off section.
 - [ ] Secret variable issues use the [Secret Alignment template](../.github/ISSUE_TEMPLATE/secret-alignment.md).
 

--- a/scripts/check_env_docs.py
+++ b/scripts/check_env_docs.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Validate environment variable docs against .env examples."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+DOC_PATH = Path("agents/index.md")
+ENV_FILES = [
+    Path(".env.example"),
+    Path("frontend/src/.env.example"),
+    Path("bot/.env.example"),
+    Path("auth/.env.example"),
+]
+
+
+def read_doc_vars(path: Path) -> set[str]:
+    """Return variable names listed in the docs table."""
+    pattern = re.compile(r"^\|\s*([A-Z0-9_]+)\b")
+    vars: set[str] = set()
+    with path.open("r", encoding="utf-8") as f:
+        for line in f:
+            m = pattern.match(line)
+            if m:
+                vars.add(m.group(1))
+    return vars
+
+
+def read_env_vars(paths: list[Path]) -> set[str]:
+    """Return variable names from example .env files."""
+    pattern = re.compile(r"^([A-Za-z_][A-Za-z0-9_]*)=")
+    vars: set[str] = set()
+    for p in paths:
+        with p.open("r", encoding="utf-8") as f:
+            for line in f:
+                m = pattern.match(line)
+                if m:
+                    vars.add(m.group(1))
+    return vars
+
+
+def main() -> int:
+    doc_vars = read_doc_vars(DOC_PATH)
+    env_vars = read_env_vars(ENV_FILES)
+
+    missing_in_docs = sorted(env_vars - doc_vars)
+    missing_in_files = sorted(doc_vars - env_vars)
+
+    if missing_in_docs:
+        print("Variables missing from agents/index.md:")
+        for name in missing_in_docs:
+            print(name)
+        print()
+
+    if missing_in_files:
+        print("Variables missing from .env examples:")
+        for name in missing_in_files:
+            print(name)
+        print()
+
+    if missing_in_docs or missing_in_files:
+        return 1
+
+    print("Environment variable docs match example files.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `scripts/check_env_docs.py` to compare env docs with example files
- reference the script in `docs/merge-checklist.md`
- note script in `docs/CHANGELOG.md`

## Testing
- `bash scripts/run_tests.sh`
- `bash scripts/check_docs.sh`
- `python scripts/check_env_docs.py`


------
https://chatgpt.com/codex/tasks/task_e_686c0f5053b48320ada704a625a77875