### PR TITLE
Add secrets alignment automation

### DIFF
--- a/.github/workflows/secrets-alignment.yml
+++ b/.github/workflows/secrets-alignment.yml
@@ -1,0 +1,55 @@
+name: Secrets Alignment
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
+  schedule:
+    - cron: "0 2 * * *"
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  audit:
+    if: github.event_name == 'schedule' || github.event.workflow_run.conclusion == 'failure'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+      - name: Install GitHub CLI
+        run: ./scripts/install_gh_cli.sh
+      - name: Show gh version
+        run: which gh && gh --version
+      - name: Generate secrets
+        run: ./scripts/generate-secrets.sh
+      - name: Run secret audit
+        run: |
+          env -i PATH="$PATH" bash -c 'set -a; source .env.dev; set +a; bash scripts/audit_env_vars.sh' > env_audit.log
+          cat env_audit.log
+      - name: Parse results
+        id: vars
+        run: |
+          missing=$(awk '/^Missing variables:/{flag=1;next}/^$/{flag=0}flag' env_audit.log | tr '\n' ',' | sed 's/,$//')
+          extras=$(awk '/^Extra variables:/{flag=1;next}flag' env_audit.log | grep -v -E '^(PATH|PWD|SHLVL|_)$' | tr '\n' ',' | sed 's/,$//')
+          echo "missing=$missing" >> "$GITHUB_OUTPUT"
+          echo "extras=$extras" >> "$GITHUB_OUTPUT"
+      - name: Create issue
+        if: steps.vars.outputs.missing != '' || steps.vars.outputs.extras != ''
+        run: |
+          cat > body.md <<'BODY'
+## Missing variables
+${{ steps.vars.outputs.missing }}
+
+## Extra variables
+${{ steps.vars.outputs.extras }}
+
+- [ ] I manually reviewed the variables against [agents/index.md](../../agents/index.md)
+BODY
+          gh issue create --title "Secrets misaligned in CI for ${{ github.event.workflow_run.head_sha || github.sha }}" --label ops --template "secret-alignment.md" --body-file body.md
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,8 @@ All notable changes to this project will be recorded in this file.
 - Added `scripts/audit_env_vars.sh` to report missing or extra environment variables and documented usage in `docs/env.md`.
 - CI now audits `.env.dev` in CI using `scripts/audit_env_vars.sh` and fails when variables are missing or extra.
 - Added `secret-alignment.md` issue template and referenced it from `docs/merge-checklist.md`.
+- Added `secrets-alignment.yml` workflow to open an issue when environment
+  variables are misaligned.
 - Added `pytest.ini` to load modules from `src` without installing the package.
 - Linked `builder_ethics_dossier.md` from the README and docs overview.
 - Added `scripts/ci_log_audit.py` and documented using it to summarize CI logs in `docs/ci-failure-issues.md`.

--- a/docs/ci-workflow.md
+++ b/docs/ci-workflow.md
@@ -34,3 +34,5 @@ After `.env.dev` is generated, the workflow runs `scripts/audit_env_vars.sh`.
 The script compares the generated environment file to the example files and
 fails if any variables are missing or extra. When the step fails, the CI failure
 issue automation records the details so maintainers can investigate.
+
+The `secrets-alignment.yml` workflow runs when the audit step fails or on a daily schedule. It reruns the environment audit and opens an issue using the Secret Alignment template if variables are missing or extra.


### PR DESCRIPTION
## Summary
- monitor env audit failures and nightly via new `secrets-alignment.yml`
- open an issue using the Secret Alignment template when variables differ
- document the automation in CI workflow docs
- note the workflow in the changelog

## Testing
- `bash scripts/run_tests.sh`
- `bash scripts/check_docs.sh`


------
https://chatgpt.com/codex/tasks/task_e_686c153457388320af5667c279f0ccb7