### PR TITLE
Add empty commit clarifying e541dd5

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -42,6 +42,7 @@ All notable changes to this project will be recorded in this file.
 - Added a 60-minute timeout to the `test` job in `ci.yml`.
 - Added `close-codex-issues.yml` workflow to automatically close Codex-created issues referenced by `Fixes #<issue>` after a pull request merges and documented it in `docs/README.md`.
 - Clarified auth_service test revisions in commit e541dd5.
+- Added empty commit referencing e541dd5 for additional context.
 - Removed obsolete `xp/.env.example`; the XP API now reads from the main `.env` file.
 - Archived `languagetool_check.py` to `archive/` and removed its invocation from `scripts/check_docs.sh`.
 - Added `scripts/install_gh_cli.sh` for local GitHub CLI installation and referenced it in the docs.


### PR DESCRIPTION
## Summary
- note the empty commit in `docs/CHANGELOG.md`
- add an empty commit clarifying `e541dd5`

Commit `e541dd5` missed some test updates, so this PR clarifies that change without modifying code.


------
https://chatgpt.com/codex/tasks/task_e_686c16e6298c8320a90bc4ecc305e9da