### PR TITLE
Skip CI on [no-ci] pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ permissions:
 
 jobs:
     test:
+        if: |
+            github.event_name != 'push' ||
+            !startsWith(github.event.head_commit.message, '[no-ci]')
         runs-on: ubuntu-latest
         strategy:
             matrix:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,3 +85,9 @@ The `codex.ci.yml` workflow watches every CI job and step. When a failure
 occurs, Codex automatically opens a task describing the error so maintainers can
 investigate. The bot retries the build once and includes logs in the task if the
 second attempt fails.
+
+## Skipping CI Runs
+
+Prefix a commit message with `[no-ci]` to skip the CI workflow when pushing
+directly to a branch. Pull requests always run the workflow regardless of this
+marker.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -492,6 +492,7 @@ All notable changes to this project will be recorded in this file.
 - Verified builder ethics dossier links, journal log, and coverage doc alignment (`codex/tasks/confirm_doc_alignment.md`)
 - Documented Llama2 Agile Helper integration step in `codex.plan.md` and updated automation bundle.
 - Added `agile-001` task for Llama2 Agile Helper integration in `codex.tasks.json` and verified `codex.plan.md` reference.
+- CI workflow skips push runs when commit messages start with `[no-ci]`; documented the marker in `AGENTS.md`.
 
 ## [0.1.0] - 2025-06-14
 


### PR DESCRIPTION
## Summary
- skip CI workflow when a push commit starts with `[no-ci]`
- document `[no-ci]` marker
- log the change in the changelog

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686c19a24b00832099e62aa8ca404cbc