### PR TITLE
Update docs for automatic Vale download

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -158,6 +158,9 @@ All Markdown files must pass Vale and LanguageTool checks.
 See [doc-quality-onboarding.md](doc-quality-onboarding.md) for a step-by-step guide.
 
 - Run `bash scripts/check_docs.sh` before pushing any changes.
+- The script automatically downloads Vale when it is missing. CI issues a
+  warning (not a failure) if the download fails. Set `VALE_BINARY` to
+  use a custom path.
 - Install Vale (version 3.12.0) with `brew install vale` on macOS or
   `choco install vale` on Windows. You can also download it from the
   [Vale releases page](https://github.com/errata-ai/vale/releases).


### PR DESCRIPTION
## Summary
- document automatic Vale download in docs

## Testing
- `bash scripts/run_tests.sh`
- `bash scripts/check_docs.sh`

------
https://chatgpt.com/codex/tasks/task_e_686c1c26a2048320b6d7d3f0c6bd1761