### PR TITLE
Add JSON env audit summary for secrets alignment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,14 +105,24 @@ jobs:
               run: ./scripts/generate-secrets.sh
             - name: Audit environment variables
               run: |
-                  env -i PATH="$PATH" bash -c 'set -a; source .env.dev; set +a; bash scripts/audit_env_vars.sh' > env_audit.log
+                  env -i PATH="$PATH" bash -c 'set -a; source .env.dev; set +a; JSON_OUTPUT=env_audit.json bash scripts/audit_env_vars.sh' > env_audit.log
                   cat env_audit.log
-                  missing=$(awk '/^Missing variables:/{flag=1;next}/^$/{flag=0}flag' env_audit.log | tr -d "\n ")
-                  extras=$(awk '/^Extra variables:/{flag=1;next}flag' env_audit.log | grep -v -E "^(PATH|PWD|SHLVL|_)$" | tr -d "\n ")
+                  cat env_audit.json
+                  missing=$(python -c 'import json,sys;print("".join(json.load(open("env_audit.json")).get("missing", [])))')
+                  extras=$(python -c 'import json,sys;d=json.load(open("env_audit.json"));print("".join(e for e in d.get("extra", []) if e not in ("PATH","PWD","SHLVL","_")))')
                   if [ -n "$missing" ] || [ -n "$extras" ]; then
                       echo "::error::Environment variable mismatch detected"
                       exit 1
                   fi
+            - name: Upload env audit
+              if: always()
+              uses: actions/upload-artifact@v4
+              with:
+                  name: env-audit
+                  path: |
+                      env_audit.log
+                      env_audit.json
+                  retention-days: 7
             - name: Build containers
               run: docker compose -f docker-compose.ci.yaml --env-file .env.dev build
             - name: Scan images with Trivy

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -38,6 +38,8 @@ All notable changes to this project will be recorded in this file.
 - Verified GitHub CLI availability across all workflows.
 - Updated README to document the new GitHub CLI installation method.
 - Documented GitHub CLI installation and version output in `docs/ci-workflow.md`.
+- `audit_env_vars.sh` now writes a JSON summary when `JSON_OUTPUT` is set and CI
+  uploads the file for the secrets-alignment workflow.
 - Added CODEOWNERS to automatically request maintainer reviews on pull requests.
 - Added stub agent specs for ID.me verification and AI mentor.
 - CI workflow cancels in-progress runs when new commits push.

--- a/docs/ci-workflow.md
+++ b/docs/ci-workflow.md
@@ -32,7 +32,9 @@ The job runs `black --check .` after installing development requirements. Format
 
 After `.env.dev` is generated, the workflow runs `scripts/audit_env_vars.sh`.
 The script compares the generated environment file to the example files and
-fails if any variables are missing or extra. When the step fails, the CI failure
-issue automation records the details so maintainers can investigate.
+fails if any variables are missing or extra. The step writes `env_audit.json`
+so the `secrets-alignment.yml` workflow can reuse the results. When the audit
+fails, the CI failure issue automation records the details so maintainers can
+investigate.
 
 The `secrets-alignment.yml` workflow runs when the audit step fails or on a daily schedule. It reruns the environment audit and opens an issue using the Secret Alignment template if variables are missing or extra.

--- a/docs/env.md
+++ b/docs/env.md
@@ -115,4 +115,5 @@ you can activate a virtual environment instead of using this flag.
 Run `scripts/audit_env_vars.sh` to compare your current environment to the
 variables listed in `.env.example`, `frontend/src/.env.example`,
 `bot/.env.example`, and `auth/.env.example`. The script prints any required
-variables that are missing and any extras found in the environment.
+variables that are missing and any extras found in the environment. Set
+`JSON_OUTPUT` to a file path to also write a JSON summary for automation.

--- a/scripts/audit_env_vars.sh
+++ b/scripts/audit_env_vars.sh
@@ -16,3 +16,33 @@ extra=$(comm -13 <(printf '%s\n' "$required_vars") <(printf '%s\n' "$current_var
 echo "Missing variables:"; echo "$missing"
 echo
 echo "Extra variables:"; echo "$extra"
+
+# Output machine-readable summary
+to_json_array() {
+  local input="$1"
+  if [ -z "$input" ]; then
+    echo "[]"
+    return
+  fi
+  local json="["
+  local first=true
+  while IFS= read -r var; do
+    [ -n "$var" ] || continue
+    if [ "$first" = true ]; then
+      json+="\"$var\""
+      first=false
+    else
+      json+=" ,\"$var\""
+    fi
+  done <<< "$input"
+  json+="]"
+  echo "$json"
+}
+
+json_missing=$(to_json_array "$missing")
+json_extra=$(to_json_array "$extra")
+summary="{\"missing\":${json_missing},\"extra\":${json_extra}}"
+echo "$summary"
+if [ -n "${JSON_OUTPUT:-}" ]; then
+  echo "$summary" > "$JSON_OUTPUT"
+fi


### PR DESCRIPTION
## Summary
- output JSON summary from `audit_env_vars.sh`
- store JSON summary in CI and upload as artifact
- document new JSON output
- record change in CHANGELOG

## Testing
- `ruff check .`
- `pytest --cov=src --cov-fail-under=95`
- `bash scripts/check_docs.sh`


------
https://chatgpt.com/codex/tasks/task_e_686c17c694388320a23c4df9fcc4465b