### PR TITLE
Add env docs check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,8 @@ jobs:
                   }
             - name: Run Black
               run: black --check .
+            - name: Validate env docs
+              run: python scripts/check_env_docs.py
             - name: Setup environment
               run: ./scripts/setup-env.sh
             - name: Install package

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this project will be recorded in this file.
   `scripts/install_gh_cli.sh`.
 - Added `scripts/check_env_docs.py` to validate environment variable docs and
   referenced it in `docs/merge-checklist.md`.
+- CI workflow now runs `python scripts/check_env_docs.py` after the Black step
+  to fail when environment docs are out of sync.
 - Documented commit-msg hook setup in CONTRIBUTING.md and docs.
 - Offline install instructions now appear in CI logs when package installs fail.
 - CI now checks compose service status early and prints logs on failure.

--- a/docs/ci-workflow.md
+++ b/docs/ci-workflow.md
@@ -38,3 +38,8 @@ fails, the CI failure issue automation records the details so maintainers can
 investigate.
 
 The `secrets-alignment.yml` workflow runs when the audit step fails or on a daily schedule. It reruns the environment audit and opens an issue using the Secret Alignment template if variables are missing or extra.
+
+After the Black formatting check, CI runs `python scripts/check_env_docs.py`.
+This script compares the environment variable table in `agents/index.md` with
+the example `.env` files. Any differences cause the job to fail so the
+documentation stays in sync with the environment configuration.


### PR DESCRIPTION
## Summary
- run `python scripts/check_env_docs.py` in CI after the Black step
- document the env docs check in CI workflow docs
- note the new CI step in the changelog

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686c2265b8f88320943b25af4a34b31e