### PR TITLE
Add optional pytest pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,3 +45,7 @@ repos:
             language: system
             pass_filenames: false
             working_directory: bot
+          - id: pytest
+            name: Python tests
+            entry: pytest --cov=src --cov-fail-under=95
+            language: system

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -497,6 +497,7 @@ All notable changes to this project will be recorded in this file.
 - Documented Llama2 Agile Helper integration step in `codex.plan.md` and updated automation bundle.
 - Added `agile-001` task for Llama2 Agile Helper integration in `codex.tasks.json` and verified `codex.plan.md` reference.
 - CI workflow skips push runs when commit messages start with `[no-ci]`; documented the marker in `AGENTS.md`.
+- Added optional `pytest` pre-commit hook so tests can run locally before each commit.
 
 ## [0.1.0] - 2025-06-14
 

--- a/docs/git-guidelines.md
+++ b/docs/git-guidelines.md
@@ -81,6 +81,7 @@ pytest --cov=src --cov-fail-under=95
 - CI lints commit messages using `scripts/check_commit_messages.sh`.
   - Run `bash scripts/install_commit_msg_hook.sh` after cloning to install a local `commit-msg` hook so mistakes are caught before you push. See [CONTRIBUTING.md](../CONTRIBUTING.md).
   Past violations do not require rewriting history.
+- Enable the `pytest` pre-commit hook to run tests automatically and catch failures locally.
 - Update `docs/CHANGELOG.md` with a short summary of your change.
 - Update any other relevant documentation under `docs/`.
 - Follow the pull request template in `docs/pull_request_template.md`.


### PR DESCRIPTION
## Summary
- add pytest test hook to `.pre-commit-config.yaml`
- document optional test hook in git guidelines
- note the new hook in the changelog

## Testing
- `pytest -q`
- `pre-commit run --files .pre-commit-config.yaml docs/git-guidelines.md docs/CHANGELOG.md` *(fails: CalledProcessError: command: ('/usr/bin/git', 'checkout', 'v3.6.2'))*

------
https://chatgpt.com/codex/tasks/task_e_686c251e70b08320b18dda2f1b1a61b5