### PR TITLE
Implement docs-only CI skip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,27 @@ permissions:
     issues: write
 
 jobs:
+    filter:
+        runs-on: ubuntu-latest
+        outputs:
+            docs: ${{ steps.filter.outputs.docs }}
+        steps:
+            - uses: actions/checkout@v3
+              with:
+                  fetch-depth: 0
+            - name: Filter paths
+              id: filter
+              uses: dorny/paths-filter@v2
+              with:
+                  filters: |
+                      docs:
+                          - 'docs/**'
+                          - '**/*.md'
     test:
+        needs: filter
         if: |
-            github.event_name != 'push' ||
-            !startsWith(github.event.head_commit.message, '[no-ci]')
+            (github.event_name != 'push' || !startsWith(github.event.head_commit.message, '[no-ci]')) &&
+            needs.filter.outputs.docs != 'true'
         runs-on: ubuntu-latest
         strategy:
             matrix:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be recorded in this file.
 - Skip Codex container setup when running in CI.
 - Install the GitHub CLI in CI using the preinstalled binary or
   `scripts/install_gh_cli.sh`.
+- Skips the `test` job when only docs or Markdown files change using
+  `dorny/paths-filter`.
 - Added `scripts/check_env_docs.py` to validate environment variable docs and
   referenced it in `docs/merge-checklist.md`.
 - CI workflow now runs `python scripts/check_env_docs.py` after the Black step

--- a/docs/ci-workflow.md
+++ b/docs/ci-workflow.md
@@ -6,6 +6,12 @@ The `ci.yml` workflow runs on every push and pull request. It sets up Python 3.1
 
 A concurrency group of `${{ github.workflow }}-${{ github.ref }}` cancels in-progress runs when a new commit pushes to the same branch. This prevents stale jobs from consuming minutes.
 
+## Documentation Filter
+
+The workflow runs `dorny/paths-filter` before other jobs. When the filter
+detects that only files under `docs/` or Markdown files were modified, the
+remaining jobs do not run. This keeps documentation-only pull requests fast.
+
 ## Caching
 
 The job caches several directories to speed up subsequent runs:


### PR DESCRIPTION
## Summary
- filter docs paths at the start of `ci.yml`
- skip the test job if only docs or Markdown files changed
- document the new filter behavior
- log the change in `CHANGELOG.md`

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686c2d41d7bc832080e7e70700c7d023