### PR TITLE
Update doc-quality instructions

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -53,6 +53,7 @@ All notable changes to this project will be recorded in this file.
 - Added empty commit referencing e541dd5 for additional context.
 - Removed obsolete `xp/.env.example`; the XP API now reads from the main `.env` file.
 - Archived `languagetool_check.py` to `archive/` and removed its invocation from `scripts/check_docs.sh`.
+- `scripts/check_docs.sh` now downloads Vale automatically and prints a notice when a LanguageTool server is required. Updated docs to make LanguageTool optional.
 - Added `scripts/install_gh_cli.sh` for local GitHub CLI installation and referenced it in the docs.
 - Added `scripts/commit-msg` and `scripts/install_commit_msg_hook.sh` to help contributors set up a local `commit-msg` hook.
 - Replaced `docs/origin.md` with a full recovery story and updated README links.

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,10 +54,9 @@ After cloning the repository, run `bash scripts/install_commit_msg_hook.sh` to i
 16. `pre-commit` also verifies environment variable docs with
     `python scripts/check_env_docs.py`.
 17. Lint all Markdown docs with `./scripts/check_docs.sh` before pushing.
-    This script uses **Vale** for style and **LanguageTool** for grammar.
-    LanguageTool requires network access to `api.languagetool.org` unless you
-    provide a custom server URL in the `LANGUAGETOOL_URL` environment variable.
-    If your environment blocks outbound requests, run your own instance with:
+    The script downloads **Vale** automatically when it is missing and prints a
+    notice if grammar checks require **LanguageTool**.
+    To run LanguageTool locally, start your own instance with:
 
     ```bash
     docker run -d --name languagetool -p 8010:8010 silviof/docker-languagetool
@@ -156,7 +155,8 @@ who has contributed and when.
 
 ## Documentation Quality Checks
 
-All Markdown files must pass Vale and LanguageTool checks.
+All Markdown files are checked with **Vale** for style. The docs script prints a
+notice if grammar checks need **LanguageTool**.
 See [doc-quality-onboarding.md](doc-quality-onboarding.md) for a step-by-step guide.
 
 - Run `bash scripts/check_docs.sh` before pushing any changes.
@@ -172,7 +172,8 @@ See [doc-quality-onboarding.md](doc-quality-onboarding.md) for a step-by-step gu
 - If the binary lives outside `PATH`, set the `VALE_BINARY` environment variable
   to its location so `scripts/check_docs.sh` can find it.
 - Install Python dev dependencies with `pip install -r requirements-dev.txt`.
-- Set `LANGUAGETOOL_URL` if you use a self-hosted LanguageTool server. See the [LanguageTool HTTP server guide](https://dev.languagetool.org/http-server).
+- Set `LANGUAGETOOL_URL` when running your own LanguageTool server if you want
+  local grammar checks. See the [LanguageTool HTTP server guide](https://dev.languagetool.org/http-server).
 
 ## Issues and Pull Requests
 

--- a/docs/doc-quality-onboarding.md
+++ b/docs/doc-quality-onboarding.md
@@ -2,12 +2,8 @@
 
 ## 🚀 Quickstart for Contributors
 
-Welcome to the project! To keep our docs clear and professional, we run two tools:
-
-* **Vale** – style and terminology checks
-* **LanguageTool** – grammar and spelling
-
-**You must pass both checks before pushing or opening a PR.**
+Welcome to the project! Documentation style is checked with **Vale**. Grammar
+checks with **LanguageTool** are optional.
 
 ---
 
@@ -37,7 +33,7 @@ Run `bash scripts/check_dependencies.sh` to confirm Vale and the Node test tools
 
 ### Step 3: (Optional) Set Up Local LanguageTool Server
 
-By default the project uses the public LanguageTool API, but CI or firewalls may block it. For local use or when offline:
+By default the project uses the public LanguageTool API, but CI or firewalls may block it. Start a local server if you want to run grammar checks:
 
 ```bash
 docker run -d -p 8010:8010 --name languagetool \
@@ -52,7 +48,7 @@ java -jar languagetool-server.jar --port 8010 &
 export LANGUAGETOOL_URL="http://localhost:8010"
 ```
 
-Set this environment variable in your shell or profile for all checks.
+Set this environment variable in your shell or profile when you want LanguageTool checks.
 
 ---
 
@@ -70,7 +66,7 @@ CI also saves `test-results/pytest-results.xml` when running the test suite. You
 both artifacts from the **Artifacts** section of each GitHub Actions run to
 review Vale output and debug failing tests.
 
-This will fail if Vale is missing, run both Vale and LanguageTool, and print issues by file, line, and column.
+The script downloads Vale if it's missing and prints a notice when a LanguageTool server is required for grammar checks.
 
 CI also uploads `test-results/pytest-results.xml` when the test suite runs in GitHub Actions. Visit a workflow run, open the **Artifacts** drop-down, and download the file to review which tests failed and why.
 
@@ -132,7 +128,7 @@ and commit the change with your documentation update.
 
 * **Vale not found:** install it as shown above or download the binary manually and set `VALE_BINARY` to its path.
 * **Python errors:** ensure `pip install -e .` (or `pip install -r requirements.txt`) and `pip install -r requirements-dev.txt` succeeded.
-* **LanguageTool API issues:** run a local server and set `LANGUAGETOOL_URL` to its address.
+* **LanguageTool API issues:** run a local server and set `LANGUAGETOOL_URL` to its address if you want to run grammar checks.
 * **pytest fails:** double-check that all dev dependencies and the project itself are installed.
 
 ### Known Limitations
@@ -151,8 +147,8 @@ and commit the change with your documentation update.
 ### CI Policy
 
 - **Spelling errors block merging.** Codespell runs in pre-commit and CI. Fix typos or add valid project terms to `.codespell-ignore`.
-- **Formatting and grammar warnings do not block CI.** Vale and LanguageTool emit GitHub warnings instead of failing. Address them when touching the affected files.
-- Large files skipped by LanguageTool are documented above; run it manually on sections if you need a full grammar review.
+- **Formatting warnings do not block CI.** Vale emits GitHub warnings and LanguageTool runs only when configured. Address issues when touching the affected files.
+- Large files skipped by LanguageTool are documented above; run it manually on sections if you want a full grammar review.
 
 ---
 


### PR DESCRIPTION
## Summary
- adjust docs to make LanguageTool optional and describe check_docs.sh behavior
- mention automatic Vale download & notice output
- record doc update in changelog

## Testing
- `pre-commit run --files docs/README.md docs/doc-quality-onboarding.md docs/CHANGELOG.md` *(fails: pathspec 'v3.6.2' did not match)*
- `bash scripts/check_docs.sh` *(fails to download Vale)*
- `pytest -k ''` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686c2e9c74488320b238348f097d0f87