### PR TITLE
Update env audit docs

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -501,6 +501,7 @@ All notable changes to this project will be recorded in this file.
 - Added `agile-001` task for Llama2 Agile Helper integration in `codex.tasks.json` and verified `codex.plan.md` reference.
 - CI workflow skips push runs when commit messages start with `[no-ci]`; documented the marker in `AGENTS.md`.
 - Added optional `pytest` pre-commit hook so tests can run locally before each commit.
+- Documented running `env -i PATH="$PATH" bash scripts/audit_env_vars.sh` in `docs/env.md` and explained the `JSON_OUTPUT` option for machine-readable results.
 
 ## [0.1.0] - 2025-06-14
 

--- a/docs/env.md
+++ b/docs/env.md
@@ -112,8 +112,8 @@ you can activate a virtual environment instead of using this flag.
 
 ## Auditing environment variables
 
-Run `scripts/audit_env_vars.sh` to compare your current environment to the
-variables listed in `.env.example`, `frontend/src/.env.example`,
-`bot/.env.example`, and `auth/.env.example`. The script prints any required
-variables that are missing and any extras found in the environment. Set
-`JSON_OUTPUT` to a file path to also write a JSON summary for automation.
+Run `env -i PATH="$PATH" bash scripts/audit_env_vars.sh` to compare only the
+variables loaded from `.env.dev` with those listed in `.env.example`,
+`frontend/src/.env.example`, `bot/.env.example`, and `auth/.env.example`. The
+script prints any required variables that are missing and any extras found in
+the environment. Set `JSON_OUTPUT` to a file path for machine-readable results.


### PR DESCRIPTION
## Summary
- document how to run the environment audit with a clean env
- note JSON_OUTPUT for machine-readable summaries

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686c308907588320bdb13e851ad83d34