### PR TITLE
Disable pytest pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,3 +53,4 @@ repos:
             name: Python tests
             entry: pytest --cov=src --cov-fail-under=95
             language: system
+            enabled: false

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be recorded in this file.
   `scripts/install_gh_cli.sh`.
 - Skips the `test` job when only docs or Markdown files change using
   `dorny/paths-filter`.
+- Disabled the `pytest` pre-commit hook by default and documented how to enable it.
 - Added `scripts/check_env_docs.py` to validate environment variable docs and
   referenced it in `docs/merge-checklist.md`.
 - CI workflow now runs `python scripts/check_env_docs.py` after the Black step

--- a/docs/git-guidelines.md
+++ b/docs/git-guidelines.md
@@ -81,7 +81,7 @@ pytest --cov=src --cov-fail-under=95
 - CI lints commit messages using `scripts/check_commit_messages.sh`.
   - Run `bash scripts/install_commit_msg_hook.sh` after cloning to install a local `commit-msg` hook so mistakes are caught before you push. See [CONTRIBUTING.md](../CONTRIBUTING.md).
   Past violations do not require rewriting history.
-- Enable the `pytest` pre-commit hook to run tests automatically and catch failures locally.
+  - Enable the `pytest` pre-commit hook to run tests automatically and catch failures locally. Run `pre-commit run pytest --all-files` once to enable it.
 - Update `docs/CHANGELOG.md` with a short summary of your change.
 - Update any other relevant documentation under `docs/`.
 - Follow the pull request template in `docs/pull_request_template.md`.


### PR DESCRIPTION
## Summary
- disable the pytest hook in `.pre-commit-config.yaml`
- note how to enable it in `docs/git-guidelines.md`
- update the changelog

## Testing
- `ruff check .`
- `pytest --cov=src --cov-fail-under=95`
- `bash scripts/check_docs.sh`


------
https://chatgpt.com/codex/tasks/task_e_686c31c4d7c4832096dea5bb939ebe00