### PR TITLE
Clarify docs check script

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -503,6 +503,8 @@ All notable changes to this project will be recorded in this file.
 - CI workflow skips push runs when commit messages start with `[no-ci]`; documented the marker in `AGENTS.md`.
 - Added optional `pytest` pre-commit hook so tests can run locally before each commit.
 - Documented running `env -i PATH="$PATH" bash scripts/audit_env_vars.sh` in `docs/env.md` and explained the `JSON_OUTPUT` option for machine-readable results.
+- Clarified that `scripts/check_docs.sh` uses Vale only and that running
+  LanguageTool checks requires a local server.
 
 ## [0.1.0] - 2025-06-14
 

--- a/docs/git-guidelines.md
+++ b/docs/git-guidelines.md
@@ -72,9 +72,9 @@ ruff check .
 pytest --cov=src --cov-fail-under=95
 ```
 - Run documentation checks with `./scripts/check_docs.sh`.
-  These use **Vale** and **LanguageTool** and require network access to
--  `api.languagetool.org` or a locally hosted server specified via
-  `LANGUAGETOOL_URL`.
+  The script runs **Vale** only.
+  LanguageTool checks are optional. If desired, run a local server and
+  set `LANGUAGETOOL_URL` to its address.
 - Keep Prettier pinned to `v3.6.2`. Run
   `pre-commit autoupdate --repo https://github.com/pre-commit/mirrors-prettier`
   to confirm the hook installs correctly.


### PR DESCRIPTION
## Summary
- clarify that `scripts/check_docs.sh` uses Vale only
- explain optional LanguageTool checks
- note the change in the changelog

## Testing
- `bash scripts/check_docs.sh`
- `bash scripts/run_tests.sh` *(fails: Cannot read properties of undefined (reading 'then'))*

------
https://chatgpt.com/codex/tasks/task_e_686c342cbf9083208b1a26b70a5efee2