### PR TITLE
Improve docs for installing dev requirements

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,9 @@ All notable changes to this project will be recorded in this file.
 - `wait_for_service.sh` prints `docker compose ps` when a service fails.
 - CI workflow uploads the full job log as the `ci-logs` artifact.
 - Documented offline header check in `tests/test_check_headers.py`.
+- Reminded contributors to run `pip install -r requirements-dev.txt` and
+  `pip install -e .` before running `pytest`. `scripts/check_dependencies.sh`
+  now verifies these packages are installed.
 - Documented running `pip install -e .` before `pytest` in docs/README.md and
   docs/ONBOARDING.md to avoid `ModuleNotFoundError: No module named 'devonboarder'`.
 - Documented Teams and Llama2 environment variables in `docs/env.md`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,7 +37,8 @@ After cloning the repository, run `bash scripts/install_commit_msg_hook.sh` to i
 13. Verify changes with `ruff check .`, `pytest --cov=src --cov-fail-under=95`, and `npm run coverage` from the `bot/` directory before committing.
     After installing dependencies, run `npm run coverage` in the `frontend/` directory as well
     (see [../frontend/README.md](../frontend/README.md) for details).
-    Install the project and dev requirements **before running the tests**:
+    Install the project and dev requirements **before running the tests**. Running
+    `pytest` without these installs may fail with `ModuleNotFoundError`:
 
     ```bash
     pip install -e .  # or `pip install -r requirements.txt` if you have one

--- a/docs/git-guidelines.md
+++ b/docs/git-guidelines.md
@@ -64,6 +64,7 @@ Once commits are pushed to a shared branch, avoid rewriting history. Do not run 
 pip install -e .
 pip install -r requirements-dev.txt
 ```
+Run these commands **before** invoking `pytest` so all dev dependencies are available.
 
 - Run the linter and tests to confirm they pass:
 

--- a/scripts/check_dependencies.sh
+++ b/scripts/check_dependencies.sh
@@ -26,6 +26,18 @@ if ! command -v vale >/dev/null 2>&1; then
     missing=1
 fi
 
+check_python_module() {
+    local module=$1
+    local hint=$2
+    if ! python -c "import $module" >/dev/null 2>&1; then
+        echo "$module not found. $hint"
+        missing=1
+    fi
+}
+
+check_python_module devonboarder "Run 'pip install -e .' before running the tests."
+check_python_module pytest "Run 'pip install -r requirements-dev.txt'."
+
 if [ "$missing" -eq 0 ]; then
     echo "All optional dependencies installed ✅"
 fi


### PR DESCRIPTION
## Summary
- clarify the need to install dev requirements before running tests
- remind the same in git guidelines
- verify `devonboarder` and `pytest` are installed
- note docs update in changelog

## Testing
- `ruff check .`
- `pytest`
- `bash scripts/check_dependencies.sh` *(fails: jest and vitest missing)*

------
https://chatgpt.com/codex/tasks/task_e_686c3579902483209a740a8a0a6166b5