### PR TITLE
docs: clarify check_docs script

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ Workflow documentation lives under the [docs/](docs/) directory. New contributor
 9. See [docs/founders/README.md](docs/founders/README.md) for Founder's Circle guidelines.
 10. Follow our [emails/style-guide.md](emails/style-guide.md) when crafting invitations.
 11. Check [docs/sample-pr.md](docs/sample-pr.md) for a small example update.
-12. Run `./scripts/check_docs.sh` to lint documentation with Vale and
-    LanguageTool. Set `LANGUAGETOOL_URL` if you use a local LanguageTool
-    server.
+12. Run `./scripts/check_docs.sh` to lint documentation with **Vale** only.
+    LanguageTool checks are optional; start a local server and set
+    `LANGUAGETOOL_URL` to enable them.
 13. Install the Vale CLI (version 3.12.0+) with `brew install vale` on macOS or
     `choco install vale` on Windows. You can also download it from the
     [Vale releases page](https://github.com/errata-ai/vale/releases).

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -508,6 +508,8 @@ All notable changes to this project will be recorded in this file.
 - Documented running `env -i PATH="$PATH" bash scripts/audit_env_vars.sh` in `docs/env.md` and explained the `JSON_OUTPUT` option for machine-readable results.
 - Clarified that `scripts/check_docs.sh` uses Vale only and that running
   LanguageTool checks requires a local server.
+- Updated README to note that `scripts/check_docs.sh` relies on Vale and that
+  LanguageTool is optional.
 
 ## [0.1.0] - 2025-06-14
 


### PR DESCRIPTION
## Summary
- clarify `scripts/check_docs.sh` instructions in README
- note the README change in the changelog

## Testing
- `ruff check .`
- `pytest --cov=src --cov-fail-under=95`
- `./scripts/check_docs.sh`

------
https://chatgpt.com/codex/tasks/task_e_686c384bae588320a809dbfe77028c6b