### PR TITLE
Add Go FIPS compliance guidelines

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be recorded in this file.
 - Documented commit-msg hook setup in CONTRIBUTING.md and docs.
 - Offline install instructions now appear in CI logs when package installs fail.
 - CI now checks compose service status early and prints logs on failure.
+- Added `docs/fips-golang.md` summarizing FIPS compliance rules for Go projects.
 - `wait_for_service.sh` prints `docker compose ps` when a service fails.
 - CI workflow uploads the full job log as the `ci-logs` artifact.
 - Documented offline header check in `tests/test_check_headers.py`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -124,6 +124,7 @@ platforms. Please report any issues you encounter on your operating system.
 - [Pull request template](pull_request_template.md) &ndash; describe your changes and verify the checklist.
 - [Sample pull request](sample-pr.md) &ndash; walkthrough of a minimal docs update.
 - [Security audit](security-audit-2025-07-01.md) &ndash; latest dependency check results.
+- [FIPS compliance for Go services](fips-golang.md) &ndash; guidelines for running a Go project in FIPS mode.
 - [Builder ethics dossier](builder_ethics_dossier.md) &ndash; outlines contributor ethics and provides a template.
 - [Task management](task-management.md) &ndash; archive completed items in `codex.tasks.json`.
 - [Troubleshooting guide](troubleshooting.md)

--- a/docs/fips-golang.md
+++ b/docs/fips-golang.md
@@ -1,0 +1,15 @@
+# FIPS Compliance for Golang Projects
+
+Federal Information Processing Standards (FIPS) define security requirements for cryptographic modules used in U.S. government systems. A Go service must use FIPS-validated components and restrict algorithms that are not approved.
+
+## Key Guidelines
+
+- Use a FIPS 140 validated cryptographic library such as BoringCrypto or a FIPS build of OpenSSL.
+- Enable FIPS mode on the operating system and verify only FIPS-approved algorithms are available.
+- Document the module's FIPS boundary and maintain certificates proving validation.
+- Disable or remove non-FIPS algorithms like MD5 or RC4.
+- Ensure random number generation comes from a FIPS validated source.
+- Run regular self-tests to confirm the crypto module operates in FIPS mode.
+- Provide instructions for building the Go binaries with the FIPS-compliant toolchain.
+
+Consult NIST publications for complete requirements and keep all dependencies up to date with validated versions.


### PR DESCRIPTION
## Summary
- document FIPS compliance requirements for Golang services
- link the new docs from the main README
- note the addition in the changelog

Follow-up to commit `e541dd5` which missed files for auth tests and required clarification in `d304e94`.


------
https://chatgpt.com/codex/tasks/task_e_686c37cc28888320a049f13558c4634d