### PR TITLE
Update docs for Vale fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,10 @@ Workflow documentation lives under the [docs/](docs/) directory. New contributor
 9. See [docs/founders/README.md](docs/founders/README.md) for Founder's Circle guidelines.
 10. Follow our [emails/style-guide.md](emails/style-guide.md) when crafting invitations.
 11. Check [docs/sample-pr.md](docs/sample-pr.md) for a small example update.
-12. Run `./scripts/check_docs.sh` to lint documentation with **Vale** only.
+12. Run `./scripts/check_docs.sh` to lint documentation with **Vale**.
+    The script tries to download Vale automatically when it isn't
+    available in your `PATH`. If that download fails, it prints a
+    warning and exits without failing.
     LanguageTool checks are optional; start a local server and set
     `LANGUAGETOOL_URL` to enable them.
 13. Install the Vale CLI (version 3.12.0+) with `brew install vale` on macOS or

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -510,6 +510,8 @@ All notable changes to this project will be recorded in this file.
   LanguageTool checks requires a local server.
 - Updated README to note that `scripts/check_docs.sh` relies on Vale and that
   LanguageTool is optional.
+- Documented that `scripts/check_docs.sh` attempts to download Vale when it is
+  missing and prints a warning without failing if the download fails.
 
 ## [0.1.0] - 2025-06-14
 


### PR DESCRIPTION
## Summary
- document Vale download behavior in README
- note the new README detail in CHANGELOG

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686c3b7b2bf08320977db55bbf570a29