### PR TITLE
Implement docs-only CI detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     filter:
         runs-on: ubuntu-latest
         outputs:
-            docs: ${{ steps.filter.outputs.docs }}
+            code: ${{ steps.filter.outputs.code }}
         steps:
             - uses: actions/checkout@v3
               with:
@@ -25,14 +25,16 @@ jobs:
               uses: dorny/paths-filter@v2
               with:
                   filters: |
-                      docs:
-                          - 'docs/**'
-                          - '**/*.md'
+                      code:
+                          - '!docs/**'
+                          - '!**/*.md'
+                          - '**'
     test:
         needs: filter
         if: |
-            (github.event_name != 'push' || !startsWith(github.event.head_commit.message, '[no-ci]')) &&
-            needs.filter.outputs.docs != 'true'
+            github.event_name != 'push' ||
+            !contains(join(github.event.head_commit.message), '[no-ci]') &&
+            needs.filter.outputs.code == 'true'
         runs-on: ubuntu-latest
         strategy:
             matrix:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,3 +91,7 @@ second attempt fails.
 Prefix a commit message with `[no-ci]` to skip the CI workflow when pushing
 directly to a branch. Pull requests always run the workflow regardless of this
 marker.
+
+The workflow also skips its test job when a push only modifies documentation or
+Markdown files. It uses `dorny/paths-filter` to set `steps.filter.outputs.code`
+to `false` in that case.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be recorded in this file.
 - Skip Codex container setup when running in CI.
 - Install the GitHub CLI in CI using the preinstalled binary or
   `scripts/install_gh_cli.sh`.
+- Detects documentation-only pushes and sets `steps.filter.outputs.code` to `false`.
 - Skips the `test` job when only docs or Markdown files change using
   `dorny/paths-filter`.
 - Disabled the `pytest` pre-commit hook by default and documented how to enable it.


### PR DESCRIPTION
## Summary
- detect docs-only pushes in `ci.yml`
- document test skipping logic in `AGENTS.md`
- note docs-only CI skip in the changelog

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686c3bc5587c8320bd7ea1e116a0404b