### PR TITLE
Update docs for optional LanguageTool

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -514,6 +514,8 @@ All notable changes to this project will be recorded in this file.
   LanguageTool is optional.
 - Documented that `scripts/check_docs.sh` attempts to download Vale when it is
   missing and prints a warning without failing if the download fails.
+- Updated ONBOARDING.md to display "Vale warnings" and noted that
+  LanguageTool runs only when `LANGUAGETOOL_URL` is set.
 
 ## [0.1.0] - 2025-06-14
 

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -25,8 +25,8 @@ After you comment `@codex run full-qa`, Codex replies directly to your comment w
 
 ```markdown
 - ❌ Lint: 3 Python files have PEP8 errors (see ruff logs)
- - ❌ Test: 1 backend test failed (see test-results/pytest-results.xml)
-- ⚠️ Docs: 12 Vale/LanguageTool warnings (docs/README.md)
+- ❌ Test: 1 backend test failed (see test-results/pytest-results.xml)
+- ⚠️ Docs: 12 Vale warnings (docs/README.md)
 - ⚠️ Security: 1 dependency flagged by pip-audit
 - ✅ All workflows run with correct tool versions
 ```
@@ -52,7 +52,7 @@ pip install -e .
 pip install -r requirements-dev.txt
 ```
 
-If Vale or LanguageTool cannot run due to network errors, Codex marks the documentation step as a "⚠️ Docs: Lint skipped" warning. You can still merge if all other required checks pass, but please run docs checks locally later to catch formatting errors.
+If Vale or the optional LanguageTool cannot run due to network errors, Codex marks the documentation step as a "⚠️ Docs: Lint skipped" warning. LanguageTool only runs when `LANGUAGETOOL_URL` is set. You can still merge if all other required checks pass, but please run docs checks locally later to catch formatting errors.
 
 ### Optional Easter Egg (for fun!)
 


### PR DESCRIPTION
## Summary
- clarify that LanguageTool only runs when `LANGUAGETOOL_URL` is set
- show "Vale warnings" in the sample Codex QA output
- record the change in the changelog

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686c3fa08f1c8320bc07659fdbd48c19