### PR TITLE
Add test install reminder

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,9 @@ docker compose -f docker-compose.prod.yaml --env-file .env.prod up -d
    npm run coverage --prefix bot
    npm run coverage --prefix frontend
    ```
+   **Note:** `pip install -e .` and `pip install -r requirements-dev.txt` must
+   finish before running `pytest`. See
+   [tests/README.md](tests/README.md) for details.
 8. Install git hooks with `pre-commit install` so lint checks run automatically.
 9. The CI workflow enforces a minimum of **95% code coverage** for all projects (frontend, bot, and backend). Pull requests will fail if any test suite drops below this threshold.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,9 @@ All notable changes to this project will be recorded in this file.
   to fail when environment docs are out of sync.
 - Documented commit-msg hook setup in CONTRIBUTING.md and docs.
 - Offline install instructions now appear in CI logs when package installs fail.
+- Clarified README step 7 to run `pip install -e .` and
+  `pip install -r requirements-dev.txt` before `pytest` and linked to
+  `tests/README.md`.
 - CI now checks compose service status early and prints logs on failure.
 - Added `docs/fips-golang.md` summarizing FIPS compliance rules for Go projects.
 - `wait_for_service.sh` prints `docker compose ps` when a service fails.


### PR DESCRIPTION
## Summary
- clarify README step 7 on installing requirements before running tests
- note the change in the changelog

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686c77cdaca88320b4e5d39b61eef465