### PR TITLE
Add env doc alignment workflow

### DIFF
--- a/.github/workflows/env-doc-alignment.yml
+++ b/.github/workflows/env-doc-alignment.yml
@@ -1,0 +1,48 @@
+name: Env Doc Alignment
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  audit:
+    if: github.event.workflow_run.conclusion == 'failure'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+      - name: Install GitHub CLI
+        run: ./scripts/install_gh_cli.sh
+      - name: Show gh version
+        run: which gh && gh --version
+      - name: Validate env docs
+        id: check
+        run: |
+          python scripts/check_env_docs.py > env_docs.log && echo "success=true" >> "$GITHUB_OUTPUT" || echo "success=false" >> "$GITHUB_OUTPUT"
+          cat env_docs.log
+      - name: Parse missing variables
+        if: steps.check.outputs.success == 'false'
+        id: vars
+        run: |
+          missing=$(awk '/^Variables missing from agents\/index.md:/{flag=1;next}/^$/{flag=0}flag' env_docs.log | tr '\n' ',' | sed 's/,$//')
+          echo "missing=$missing" >> "$GITHUB_OUTPUT"
+      - name: Create issue
+        if: steps.check.outputs.success == 'false'
+        run: |
+          cat > body.md <<'BODY'
+## Missing variables
+${{ steps.vars.outputs.missing }}
+
+- [ ] I manually reviewed the variables against [agents/index.md](../../agents/index.md)
+BODY
+          gh issue create --title "Secrets misaligned in docs for ${{ github.event.workflow_run.head_sha || github.sha }}" --label ops --template "secret-alignment.md" --body-file body.md
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -38,6 +38,8 @@ All notable changes to this project will be recorded in this file.
 - Added `secret-alignment.md` issue template and referenced it from `docs/merge-checklist.md`.
 - Added `secrets-alignment.yml` workflow to open an issue when environment
   variables are misaligned.
+- Added `env-doc-alignment.yml` workflow that opens a Secret Alignment issue
+  when `check_env_docs.py` reports missing variables.
 - Added `pytest.ini` to load modules from `src` without installing the package.
 - Linked `builder_ethics_dossier.md` from the README and docs overview.
 - Added `scripts/ci_log_audit.py` and documented using it to summarize CI logs in `docs/ci-failure-issues.md`.

--- a/docs/ci-workflow.md
+++ b/docs/ci-workflow.md
@@ -49,3 +49,8 @@ After the Black formatting check, CI runs `python scripts/check_env_docs.py`.
 This script compares the environment variable table in `agents/index.md` with
 the example `.env` files. Any differences cause the job to fail so the
 documentation stays in sync with the environment configuration.
+
+The `env-doc-alignment.yml` workflow runs when this step fails. It reruns
+`check_env_docs.py`, parses the missing variables from the output, and opens a
+Secret Alignment issue with the commit SHA. The issue lists the missing
+variables so maintainers know which entries to add to `agents/index.md`.


### PR DESCRIPTION
## Summary
- automate env docs alignment issue creation
- document the new workflow
- note automation in the changelog

## Testing
- `pre-commit run --files docs/ci-workflow.md docs/CHANGELOG.md .github/workflows/env-doc-alignment.yml` *(fails: CalledProcessError: git checkout v3.6.2)*
- `pytest -k 'nonexistentpattern'` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686c843b188c8320ac0a70040500687f