### PR TITLE
Update README Vale note

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,11 @@ Workflow documentation lives under the [docs/](docs/) directory. New contributor
 10. Follow our [emails/style-guide.md](emails/style-guide.md) when crafting invitations.
 11. Check [docs/sample-pr.md](docs/sample-pr.md) for a small example update.
 12. Run `./scripts/check_docs.sh` to lint documentation with **Vale**.
-    The script tries to download Vale automatically when it isn't
-    available in your `PATH`. If that download fails, it prints a
-    warning and exits without failing.
-    LanguageTool checks are optional; start a local server and set
-    `LANGUAGETOOL_URL` to enable them.
+    The script downloads Vale automatically when it isn't available
+    and prints a warning if that download fails. See
+    [docs/README.md#documentation-quality-checks](docs/README.md#documentation-quality-checks)
+    for full instructions. LanguageTool checks are optional; start a
+    local server and set `LANGUAGETOOL_URL` to enable them.
 13. Install the Vale CLI (version 3.12.0+) with `brew install vale` on macOS or
     `choco install vale` on Windows. You can also download it from the
     [Vale releases page](https://github.com/errata-ai/vale/releases).

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -514,6 +514,8 @@ All notable changes to this project will be recorded in this file.
   LanguageTool is optional.
 - Documented that `scripts/check_docs.sh` attempts to download Vale when it is
   missing and prints a warning without failing if the download fails.
+- Summarized the download fallback in `README.md` and linked to
+  `docs/README.md#documentation-quality-checks` for full details.
 
 ## [0.1.0] - 2025-06-14
 


### PR DESCRIPTION
## Summary
- describe check_docs.sh fallback in README
- point to docs README for details
- record change in changelog

## Testing
- `bash scripts/check_docs.sh`
- `bash scripts/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_686c3f3466b08320aab774c9bcc9aa84