### PR TITLE
Add Codecov badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # DevOnboarder
 
+[![codecov](https://codecov.io/gh/theangrygamershowproductions/DevOnboarder/branch/main/graph/badge.svg)](https://codecov.io/gh/theangrygamershowproductions/DevOnboarder)
+
 DevOnboarder demonstrates a trunk‑based workflow with Docker‑based services for rapid onboarding.
 
 See [docs/README.md](docs/README.md) for full setup instructions and workflow guidelines.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be recorded in this file.
 
 ## [Unreleased]
 
+- Added a Codecov badge to the README.
+
 - CI workflow caches Playwright browsers to reuse ~/.cache/ms-playwright.
 - Skip Codex container setup when running in CI.
 - Install the GitHub CLI in CI using the preinstalled binary or


### PR DESCRIPTION
## Summary
- add a Codecov badge near the top of README
- document the badge addition in the changelog

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686c896afe18832082e321787c0632ce