### PR TITLE
Fix README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ docker compose -f docker-compose.prod.yaml --env-file .env.prod up -d
 Licensed under the MIT License. See `LICENSE.md` for details.
 
 ## Found DevOnboarder useful?
-If this project helped speed up onboarding, save time, or avoid headaches, please [⭐ star the repo](#) or [open an issue](#) with your feedback. Your input directly shapes future improvements.
+If this project helped speed up onboarding, save time, or avoid headaches, please [⭐ star the repo](https://github.com/theangrygamershowproductions/DevOnboarder) or [open an issue](https://github.com/theangrygamershowproductions/DevOnboarder/issues) with your feedback. Your input directly shapes future improvements.
 
 ## License
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be recorded in this file.
 ## [Unreleased]
 
 - Added a Codecov badge to the README.
+- Updated README star and issue links to point to the repository.
 
 - CI workflow caches Playwright browsers to reuse ~/.cache/ms-playwright.
 - Skip Codex container setup when running in CI.


### PR DESCRIPTION
## Summary
- update README star and issue links with repository URL
- note change in docs/CHANGELOG

## Testing
- `bash scripts/run_tests.sh`
- `pre-commit run --files README.md docs/CHANGELOG.md` *(fails: pathspec 'v3.6.2' did not match any file(s) known to git)*

------
https://chatgpt.com/codex/tasks/task_e_686c8c1ede808320a599f462bb443933