### PR TITLE
Update docs bullet on Vale auto-download

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,12 @@ Workflow documentation lives under the [docs/](docs/) directory. New contributor
 10. Follow our [emails/style-guide.md](emails/style-guide.md) when crafting invitations.
 11. Check [docs/sample-pr.md](docs/sample-pr.md) for a small example update.
 12. Run `./scripts/check_docs.sh` to lint documentation with **Vale**.
-    The script downloads Vale automatically when it isn't available
-    and prints a warning if that download fails. See
-    [docs/README.md#documentation-quality-checks](docs/README.md#documentation-quality-checks)
-    for full instructions. LanguageTool checks are optional; start a
-    local server and set `LANGUAGETOOL_URL` to enable them.
+    - The script automatically downloads Vale if it isn’t installed and
+      prints a warning if the download fails. See
+      [docs/README.md#documentation-quality-checks](docs/README.md#documentation-quality-checks)
+      for more details.
+    - LanguageTool checks are optional; start a local server and set
+      `LANGUAGETOOL_URL` to enable them.
 13. Install the Vale CLI (version 3.12.0+) with `brew install vale` on macOS or
     `choco install vale` on Windows. You can also download it from the
     [Vale releases page](https://github.com/errata-ai/vale/releases).


### PR DESCRIPTION
## Summary
- clarify `check_docs.sh` auto-download note in README

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686ca5dd70b4832093911dc5f7677826