### PR TITLE
Remove Codecov integration and document coverage policy

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,7 +21,7 @@ Refer to [doc-quality-onboarding.md](../docs/doc-quality-onboarding.md) for setu
 - [ ] No secrets or sensitive data are present in commits
 - [ ] Did Codex introduce any direct commits to `main`?
 - [ ] Are all Codex changes covered by tests and docs?
-- [ ] Coverage does not decrease (see Codecov status)
+- [ ] Coverage does not decrease (see CI summary)
 
 _Reviewer Sign-Off_
 - [ ] I confirm all checklist items are complete.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,8 +248,6 @@ jobs:
                   name: lighthouse-report
                   path: frontend/lhci-report
                   retention-days: 7
-            - name: Upload coverage to Codecov
-              uses: codecov/codecov-action@v3
             - name: Install bot dependencies
               run: |
                   npm ci || {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,3 +95,9 @@ marker.
 The workflow also skips its test job when a push only modifies documentation or
 Markdown files. It uses `dorny/paths-filter` to set `steps.filter.outputs.code`
 to `false` in that case.
+
+## \U0001F512 Security Note
+
+CI/CD scripts must not fetch and execute remote code via `curl | sh`. Tools like
+Codecov are prohibited due to past security breaches. Use local coverage
+reporting instead and vet all third-party integrations carefully.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # DevOnboarder
 
-[![codecov](https://codecov.io/gh/theangrygamershowproductions/DevOnboarder/branch/main/graph/badge.svg)](https://codecov.io/gh/theangrygamershowproductions/DevOnboarder)
 
 DevOnboarder demonstrates a trunk‑based workflow with Docker‑based services for rapid onboarding.
 

--- a/docs/Agents.md
+++ b/docs/Agents.md
@@ -263,6 +263,15 @@ Use a small loop in your workflow to wait for the auth service before running te
 CI health and failure events are monitored by Codex. Future outages will trigger
 an automated notification and suggested fix via Codex's reporting channel.
 
+## \U0001F512 Security Policy for Tooling and Dependencies
+
+To reduce the attack surface in CI/CD workflows:
+
+- **Do not use Codecov** or any third-party coverage uploaders that execute
+  remote scripts in CI.
+- Avoid integrations that rely on `bash <curl | sh>` style commands.
+- Vet all external tools for prior security incidents before adoption.
+
 ---
 
 ## How to Extend/Contribute

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be recorded in this file.
 
 ## [Unreleased]
 
-- Added a Codecov badge to the README.
+- Removed the Codecov badge from the README and deleted the upload step.
 - Updated README star and issue links to point to the repository.
 
 - CI workflow caches Playwright browsers to reuse ~/.cache/ms-playwright.

--- a/docs/README.md
+++ b/docs/README.md
@@ -190,3 +190,9 @@ See [doc-quality-onboarding.md](doc-quality-onboarding.md) for a step-by-step gu
 
 9. A weekly job (`security-audit.yml`) runs dependency audits and uploads the report as an artifact.
 10. CODEOWNERS automatically requests reviews from the maintainer team.
+
+## \U0001F6E1\uFE0F Coverage and Security
+
+We track coverage locally using `pytest --cov=src` and `npm run coverage`. This
+project does **not** use external uploaders like Codecov because remote scripts
+pose a supply chain risk. Only local, inspectable tools are permitted.

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -47,7 +47,7 @@ bash scripts/check_docs.sh
 - [ ] Codex did **not** introduce any direct commits to `main`
 - [ ] Documentation passes `bash scripts/check_docs.sh`
 - [ ] Are all Codex changes covered by tests and docs?
-- [ ] Coverage does not decrease (see Codecov status)
+- [ ] Coverage does not decrease (see CI summary)
 
 # Reviewer Sign-Off
 


### PR DESCRIPTION
## Summary
- drop Codecov badge and remove CI upload step
- discourage remote script tooling in AGENTS policy docs
- document local coverage policy in docs
- adjust PR templates to reference CI summary instead of Codecov

## Testing
- `bash scripts/run_tests.sh`
- `bash scripts/check_docs.sh`
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_686cad1482c8832080cea2cd0040e2e8