### PR TITLE
Fix trivy install method

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,8 @@ jobs:
             - name: Build containers
               run: docker compose -f docker-compose.ci.yaml --env-file .env.dev build
             - name: Scan images with Trivy
+              env:
+                  TRIVY_VERSION: 0.47.0
               run: bash scripts/trivy_scan.sh docker-compose.ci.yaml
             - name: Start docker compose
               run: docker compose -f docker-compose.ci.yaml --env-file .env.dev up -d

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to this project will be recorded in this file.
 - Skip Codex container setup when running in CI.
 - Install the GitHub CLI in CI using the preinstalled binary or
   `scripts/install_gh_cli.sh`.
+- `scripts/trivy_scan.sh` now downloads the pinned Trivy release tarball instead
+  of piping the install script. Offline instructions updated accordingly.
 - Detects documentation-only pushes and sets `steps.filter.outputs.code` to `false`.
 - Skips the `test` job when only docs or Markdown files change using
   `dorny/paths-filter`.

--- a/docs/offline-setup.md
+++ b/docs/offline-setup.md
@@ -64,10 +64,11 @@ After installing dependencies, run the usual setup commands such as `make deps` 
 1. On a machine with internet access, download the Trivy binary:
 
    ```bash
-   mkdir -p ~/devonboarder-offline/trivy
-   curl -L -o ~/devonboarder-offline/trivy/trivy.tar.gz \
-     https://github.com/aquasecurity/trivy/releases/download/v0.47.0/trivy_0.47.0_Linux-64bit.tar.gz
-   tar -xzf ~/devonboarder-offline/trivy/trivy.tar.gz -C ~/devonboarder-offline/trivy
+ mkdir -p ~/devonboarder-offline/trivy
+ curl -L -o ~/devonboarder-offline/trivy/trivy.tar.gz \
+   https://github.com/aquasecurity/trivy/releases/download/v0.47.0/trivy_0.47.0_Linux-64bit.tar.gz
+ tar -xzf ~/devonboarder-offline/trivy/trivy.tar.gz -C ~/devonboarder-offline/trivy
+  # `scripts/trivy_scan.sh` fetches this tarball automatically when network access is available
    ```
 
 2. Copy the `devonboarder-offline` folder to your offline machine.

--- a/scripts/trivy_scan.sh
+++ b/scripts/trivy_scan.sh
@@ -5,10 +5,17 @@ COMPOSE_FILE=${1:-docker-compose.ci.yaml}
 TRIVY_VERSION=${TRIVY_VERSION:-0.47.0}
 TRIVY_CMD=${TRIVY_CMD:-trivy}
 
+cleanup() { [ -n "${TMP_DIR:-}" ] && rm -rf "$TMP_DIR"; }
+trap cleanup EXIT
+
 if ! command -v "$TRIVY_CMD" >/dev/null 2>&1; then
-  echo "Trivy not found; installing version $TRIVY_VERSION..."
-  curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b . "$TRIVY_VERSION"
-  TRIVY_CMD=./trivy
+  echo "Trivy not found; downloading version $TRIVY_VERSION..."
+  TMP_DIR=$(mktemp -d)
+  tarball="trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"
+  url="https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/${tarball}"
+  curl -sSL "$url" -o "$TMP_DIR/$tarball"
+  tar -xzf "$TMP_DIR/$tarball" -C "$TMP_DIR"
+  TRIVY_CMD="$TMP_DIR/trivy"
 fi
 
 # Scan each built image referenced by the compose file


### PR DESCRIPTION
## Summary
- install Trivy by downloading the release tarball
- update CI to set `TRIVY_VERSION`
- document the new install approach and offline usage
- note the change in the changelog

## Testing
- `pre-commit run --files .github/workflows/ci.yml docs/CHANGELOG.md docs/offline-setup.md scripts/trivy_scan.sh` *(fails: called process error)*
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686cb9b86cd88320af3df41ae9b4478b