### PR TITLE
Document token requirement for forked PRs

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -531,6 +531,7 @@ All notable changes to this project will be recorded in this file.
   LanguageTool runs only when `LANGUAGETOOL_URL` is set.
 
 - Added governance checklist for bot permissions in `docs/governance/bot_access_governance.md`.
+- Documented token requirements for forked pull requests in `docs/ci-failure-issues.md` and referenced it from the documentation README.
 ## [0.1.0] - 2025-06-14
 
 - Added `src/app.py` with `greet` function and updated smoke tests. [#21](https://github.com/theangrygamershowproductions/DevOnboarder/pull/21)

--- a/docs/README.md
+++ b/docs/README.md
@@ -186,10 +186,11 @@ See [doc-quality-onboarding.md](doc-quality-onboarding.md) for a step-by-step gu
 5. See the Codex CI Monitoring Policy in [../AGENTS.md](../AGENTS.md) for how failed CI jobs automatically create tasks.
 6. When CI fails, an issue titled `CI Failures for <sha>` is opened or updated with a summary of the failing tests and links to the artifacts.
 7. The CI workflow uses the built-in `GITHUB_TOKEN` with `issues: write` permission. When the pipeline succeeds, it closes every open `ci-failure` issue.
-8. A nightly job (`cleanup-ci-failure.yml`) closes any open `ci-failure` issues so the board stays tidy.
+8. `${{ secrets.GITHUB_TOKEN }}` is read-only on pull requests from forks. Use a token with `issues: write` permission or a `pull_request_target` workflow as explained in [ci-failure-issues.md](ci-failure-issues.md#forked-pull-requests).
+9. A nightly job (`cleanup-ci-failure.yml`) closes any open `ci-failure` issues so the board stays tidy.
 
-9. A weekly job (`security-audit.yml`) runs dependency audits and uploads the report as an artifact.
-10. CODEOWNERS automatically requests reviews from the maintainer team.
+10. A weekly job (`security-audit.yml`) runs dependency audits and uploads the report as an artifact.
+11. CODEOWNERS automatically requests reviews from the maintainer team.
 
 ## \U0001F6E1\uFE0F Coverage and Security
 

--- a/docs/ci-failure-issues.md
+++ b/docs/ci-failure-issues.md
@@ -7,6 +7,13 @@ When the CI workflow fails, it opens or updates an issue titled `CI Failures for
 - `ci.yml` closes every open `ci-failure` issue whenever the pipeline succeeds using the built-in `GITHUB_TOKEN`.
 - The workflow uploads a `ci-logs` artifact with the full job log for download after each run.
 
+## Forked Pull Requests
+
+`${{ secrets.GITHUB_TOKEN }}` is read-only when a pull request originates from a
+fork. To update or close issues from those builds, you need a token granted
+`issues: write` permissions. Use a personal access token or run the workflow in
+`pull_request_target` to access repository secrets safely.
+
 ## Root Cause Summaries
 
 The workflow automatically runs `scripts/ci_log_audit.py` on the CI job log when a step fails and appends the resulting `audit.md` to the failure issue comment.


### PR DESCRIPTION
## Summary
- warn that `GITHUB_TOKEN` is read-only on forked pull requests
- link to this new requirement from the Issues and Pull Requests docs
- record the change in the changelog

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686cc1bfa350832083b7ec576cdc24cf