### PR TITLE
Add debug step to cleanup job

### DIFF
--- a/.github/workflows/cleanup-ci-failure.yml
+++ b/.github/workflows/cleanup-ci-failure.yml
@@ -11,6 +11,14 @@ jobs:
               run: ./scripts/install_gh_cli.sh
             - name: Show gh version
               run: which gh && gh --version
+            - name: Debug token and permissions
+              run: |
+                gh auth status
+                gh api rate_limit
+                gh issue list --label ci-failure --state open --json number --jq '.[].number'
+              env:
+                GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              continue-on-error: true
             - run: |
                   gh_bin=$(which gh)
                   for n in $($gh_bin issue list --label ci-failure --state open --json number --jq '.[].number'); do

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -532,6 +532,7 @@ All notable changes to this project will be recorded in this file.
 
 - Added governance checklist for bot permissions in `docs/governance/bot_access_governance.md`.
 - Documented token requirements for forked pull requests in `docs/ci-failure-issues.md` and referenced it from the documentation README.
+- Added a debug step to `cleanup-ci-failure.yml` to print token status and open issue numbers before closing them.
 ## [0.1.0] - 2025-06-14
 
 - Added `src/app.py` with `greet` function and updated smoke tests. [#21](https://github.com/theangrygamershowproductions/DevOnboarder/pull/21)

--- a/docs/README.md
+++ b/docs/README.md
@@ -187,7 +187,7 @@ See [doc-quality-onboarding.md](doc-quality-onboarding.md) for a step-by-step gu
 6. When CI fails, an issue titled `CI Failures for <sha>` is opened or updated with a summary of the failing tests and links to the artifacts.
 7. The CI workflow uses the built-in `GITHUB_TOKEN` with `issues: write` permission. When the pipeline succeeds, it closes every open `ci-failure` issue.
 8. `${{ secrets.GITHUB_TOKEN }}` is read-only on pull requests from forks. Use a token with `issues: write` permission or a `pull_request_target` workflow as explained in [ci-failure-issues.md](ci-failure-issues.md#forked-pull-requests).
-9. A nightly job (`cleanup-ci-failure.yml`) closes any open `ci-failure` issues so the board stays tidy.
+9. A nightly job (`cleanup-ci-failure.yml`) logs token details and closes any open `ci-failure` issues so the board stays tidy.
 
 10. A weekly job (`security-audit.yml`) runs dependency audits and uploads the report as an artifact.
 11. CODEOWNERS automatically requests reviews from the maintainer team.


### PR DESCRIPTION
## Summary
- log auth status before closing CI failure issues
- document nightly job change
- note debug step in changelog

## Testing
- `scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686d270ada188320a3911e9a53e90e63