### PR TITLE
Update CI failure docs

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be recorded in this file.
 
 ## [Unreleased]
 
+- Documented troubleshooting steps for CI failure issues.
+
 - Removed the Codecov badge from the README and deleted the upload step.
 - Updated README star and issue links to point to the repository.
 - CI now commits a coverage.svg badge using coverage-summary.md.

--- a/docs/ci-failure-issues.md
+++ b/docs/ci-failure-issues.md
@@ -79,3 +79,9 @@ jobs:
 ```
 
 Trigger the workflow from the **Actions** tab using the **Run workflow** button. Schedule it with a `schedule:` trigger if you want regular cleanup.
+
+## Troubleshooting
+
+- Run `gh auth status` to confirm your token includes the `repo` and `issues: write` scopes. Missing scopes prevent the workflow from creating or updating issues.
+- Download `gh_cli.log` and `audit.md` from the run's **Artifacts** section to inspect GitHub CLI output and the log audit summary.
+- Duplicate or missing issues are usually caused by insufficient token permissions or leftover issues from earlier runs.


### PR DESCRIPTION
## Summary
- document troubleshooting steps for CI failure issues
- mention the update in the changelog

## Testing
- `pre-commit run --files docs/CHANGELOG.md docs/ci-failure-issues.md` *(fails: pathspec 'v3.6.2' did not match)*
- `bash scripts/check_docs.sh`
- `python scripts/check_env_docs.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686d293e6e9c8320972ca01c86422b82