### PR TITLE
Add first PR guide and diagram

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be recorded in this file.
 ## [Unreleased]
 
 - Documented troubleshooting steps for CI failure issues.
+- Added a first PR guide and service architecture diagram with links from the docs overview.
 
 - Removed the Codecov badge from the README and deleted the upload step.
 - Updated README star and issue links to point to the repository.

--- a/docs/README.md
+++ b/docs/README.md
@@ -123,6 +123,8 @@ platforms. Please report any issues you encounter on your operating system.
 - [Project origin & recovery story](origin.md) &ndash; why DevOnboarder exists.
 - [Pull request template](pull_request_template.md) &ndash; describe your changes and verify the checklist.
 - [Sample pull request](sample-pr.md) &ndash; walkthrough of a minimal docs update.
+- [First PR walkthrough](first-pr-guide.md) &ndash; clone, install hooks and open your first pull request.
+- [Service architecture diagram](architecture.svg) &ndash; high-level view of the auth, XP API, frontend and bot.
 - [Security audit](security-audit-2025-07-01.md) &ndash; latest dependency check results.
 - [FIPS compliance for Go services](fips-golang.md) &ndash; guidelines for running a Go project in FIPS mode.
 - [Builder ethics dossier](builder_ethics_dossier.md) &ndash; outlines contributor ethics and provides a template.

--- a/docs/architecture.svg
+++ b/docs/architecture.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="200" viewBox="0 0 400 200">
+  <rect x="20" y="20" width="90" height="40" fill="white" stroke="black"/>
+  <text x="65" y="45" font-size="12" text-anchor="middle">Auth</text>
+
+  <rect x="150" y="20" width="90" height="40" fill="white" stroke="black"/>
+  <text x="195" y="45" font-size="12" text-anchor="middle">XP API</text>
+
+  <rect x="280" y="20" width="90" height="40" fill="white" stroke="black"/>
+  <text x="325" y="45" font-size="12" text-anchor="middle">Frontend</text>
+
+  <rect x="150" y="120" width="90" height="40" fill="white" stroke="black"/>
+  <text x="195" y="145" font-size="12" text-anchor="middle">Bot</text>
+
+  <path d="M110 40 L150 40" stroke="black" marker-end="url(#arrow)"/>
+  <path d="M240 40 L280 40" stroke="black" marker-end="url(#arrow)"/>
+  <path d="M195 60 L195 120" stroke="black" marker-end="url(#arrow)"/>
+  <path d="M325 60 L195 120" stroke="black" marker-end="url(#arrow)"/>
+
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="5" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="black" />
+    </marker>
+  </defs>
+</svg>

--- a/docs/first-pr-guide.md
+++ b/docs/first-pr-guide.md
@@ -1,0 +1,31 @@
+# First PR Walkthrough
+
+This short guide shows how to make your first contribution. It assumes you have already set up Docker, Node.js and Python as described in the main README.
+
+1. **Clone the repository**
+   ```bash
+   git clone https://github.com/your-username/DevOnboarder.git
+   cd DevOnboarder
+   ```
+2. **Install git hooks** so lint and test checks run before each commit.
+   ```bash
+   pre-commit install
+   ```
+3. **Create a branch** from `main` for your change.
+   ```bash
+   git checkout -b feature/my-first-change
+   ```
+4. **Run the checks**. The helper script installs requirements and runs the linters and tests with coverage.
+   ```bash
+   bash scripts/run_tests.sh
+   ```
+   If any step fails, fix the issues and re-run the script until everything passes.
+5. **Commit and push** your work.
+   ```bash
+   git add <files>
+   git commit -m "docs(first-pr): Add walkthrough"
+   git push origin feature/my-first-change
+   ```
+6. **Open a pull request** on GitHub and fill out the template. CI must pass before the PR can be merged.
+
+Refer to `docs/sample-pr.md` for a minimal example and `docs/git-guidelines.md` for commit message conventions.


### PR DESCRIPTION
## Summary
- document a walkthrough for first-time contributors
- draw a basic service architecture diagram
- link new resources from docs README
- note them in the changelog

## Testing
- `pre-commit run --files docs/first-pr-guide.md docs/README.md docs/CHANGELOG.md docs/architecture.svg` *(fails: CalledProcessError: git checkout v3.6.2)*
- `bash scripts/check_docs.sh`
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686d2aa891808320ba1c671616e2b61a