### PR TITLE
Add owner column for bot governance checklist

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -533,6 +533,7 @@ All notable changes to this project will be recorded in this file.
   LanguageTool runs only when `LANGUAGETOOL_URL` is set.
 
 - Added governance checklist for bot permissions in `docs/governance/bot_access_governance.md`.
+- Added an **Owner** column to that checklist and assigned responsible teams to each task.
 - Documented token requirements for forked pull requests in `docs/ci-failure-issues.md` and referenced it from the documentation README.
 - Added a debug step to `cleanup-ci-failure.yml` to print token status and open issue numbers before closing them.
 ## [0.1.0] - 2025-06-14

--- a/docs/governance/bot_access_governance.md
+++ b/docs/governance/bot_access_governance.md
@@ -2,54 +2,61 @@
 
 ## 1. GitHub Permissions
 
-- [ ] Audit all current GitHub bot/service account scopes and access levels for DevOnboarder automation.
-- [ ] Restrict each bot to the minimum required **API scopes** for their tasks (e.g., `pull_requests`, `repo`, specific org permissions).
-- [ ] Migrate to **deploy keys** or machine users for CI/CD where possible, scoped only to specific repositories.
-- [ ] Remove or avoid any unnecessary admin/org-wide tokens from automation scripts or workflow configs.
-- [ ] Require GitHub Actions **Environments** for dev/staging/prod, with manual approval gates for sensitive (e.g., production) deployments.
-- [ ] Configure **secrets management** in GitHub Actions: ensure only workflows in the correct environment can access relevant secrets, using OIDC where feasible.
-- [ ] Rotate all access tokens/keys regularly; document the rotation schedule.
-- [ ] Ensure all bot actions (PRs, merges, issue edits, etc.) are logged and reviewable via the GitHub audit log.
+| Task | Owner |
+| ---- | ----- |
+| - [ ] Audit all current GitHub bot/service account scopes and access levels for DevOnboarder automation. | Security Team |
+| - [ ] Restrict each bot to the minimum required **API scopes** for their tasks (e.g., `pull_requests`, `repo`, specific org permissions). | Security Team |
+| - [ ] Migrate to **deploy keys** or machine users for CI/CD where possible, scoped only to specific repositories. | DevOps Team |
+| - [ ] Remove or avoid any unnecessary admin/org-wide tokens from automation scripts or workflow configs. | DevOps Team |
+| - [ ] Require GitHub Actions **Environments** for dev/staging/prod, with manual approval gates for sensitive (e.g., production) deployments. | DevOps Team |
+| - [ ] Configure **secrets management** in GitHub Actions: ensure only workflows in the correct environment can access relevant secrets, using OIDC where feasible. | DevOps Team |
+| - [ ] Rotate all access tokens/keys regularly; document the rotation schedule. | Security Team |
+| - [ ] Ensure all bot actions (PRs, merges, issue edits, etc.) are logged and reviewable via the GitHub audit log. | Security Team |
 
 ## 2. Discord Permissions
 
-- [ ] Review the OAuth2 scopes on all Discord bots; restrict to `bot` and `applications.commands` only.
-- [ ] Limit Discord bot permission bitmask to only the minimum (e.g., Send Messages, Use Slash Commands). Avoid “Manage Server” unless strictly required.
-- [ ] Implement Discord RBAC: restrict bot commands/visibility by channel and role as appropriate.
-- [ ] Document bot permissions and justify any elevated rights.
+| Task | Owner |
+| ---- | ----- |
+| - [ ] Review the OAuth2 scopes on all Discord bots; restrict to `bot` and `applications.commands` only. | Discord Admins |
+| - [ ] Limit Discord bot permission bitmask to only the minimum (e.g., Send Messages, Use Slash Commands). Avoid “Manage Server” unless strictly required. | Discord Admins |
+| - [ ] Implement Discord RBAC: restrict bot commands/visibility by channel and role as appropriate. | Discord Admins |
+| - [ ] Document bot permissions and justify any elevated rights. | Discord Admins |
 
 ## 3. Pipeline & Environment Access
 
-- [ ] Migrate all pipeline/service credentials to deploy keys or service accounts with limited repo access.
-- [ ] Separate environment secrets for dev/staging/prod. Ensure prod secrets require manual approval for use in workflows.
-- [ ] Remove any broad Personal Access Tokens (PATs) or admin tokens from pipeline configuration.
-- [ ] Ensure all pipeline jobs log their activities (builds, tests, deployments) and store results for auditing.
-- [ ] Configure alerting for failed builds, suspicious deployments, or pipeline anomalies.
+| Task | Owner |
+| ---- | ----- |
+| - [ ] Migrate all pipeline/service credentials to deploy keys or service accounts with limited repo access. | DevOps Team |
+| - [ ] Separate environment secrets for dev/staging/prod. Ensure prod secrets require manual approval for use in workflows. | DevOps Team |
+| - [ ] Remove any broad Personal Access Tokens (PATs) or admin tokens from pipeline configuration. | DevOps Team |
+| - [ ] Ensure all pipeline jobs log their activities (builds, tests, deployments) and store results for auditing. | DevOps Team |
+| - [ ] Configure alerting for failed builds, suspicious deployments, or pipeline anomalies. | DevOps Team |
 
 ## 4. Metrics & Transparency
 
-- [ ] Implement metrics collection for the following:
-  - [ ] Open/closed issue and PR counts, and merge/close rates (track over time).
-  - [ ] Last-activity timestamps on commits, PRs, and issues.
-  - [ ] CI/CD job health: build success rate, mean build time, test coverage, etc.
-  - [ ] Code quality/vulnerability scan results.
-  - [ ] Discord bot usage stats: commands run, user engagement, error rates.
-- [ ] Set up an internal dashboard or report system for visibility of these metrics.
-- [ ] Document all metric sources and update methods.
+| Task | Owner |
+| ---- | ----- |
+| - [ ] Implement metrics collection for the following: Open/closed issue and PR counts; last-activity timestamps; CI/CD health; code quality scans; Discord bot usage stats. | Metrics Team |
+| - [ ] Set up an internal dashboard or report system for visibility of these metrics. | Metrics Team |
+| - [ ] Document all metric sources and update methods. | Metrics Team |
 
 ## 5. Checks & Balances (Quarterly Review)
 
-- [ ] Schedule a **quarterly audit** of all bot/service account permissions in both GitHub and Discord.
-- [ ] Review GitHub audit logs and Discord audit logs for unexpected actions or privilege escalations.
-- [ ] Revoke or rotate any unused or excess keys/tokens.
-- [ ] Update and document permission scopes as project requirements evolve.
-- [ ] Treat each review as a lightweight security audit; document findings and any remediations.
+| Task | Owner |
+| ---- | ----- |
+| - [ ] Schedule a **quarterly audit** of all bot/service account permissions in both GitHub and Discord. | Security Team |
+| - [ ] Review GitHub audit logs and Discord audit logs for unexpected actions or privilege escalations. | Security Team |
+| - [ ] Revoke or rotate any unused or excess keys/tokens. | Security Team |
+| - [ ] Update and document permission scopes as project requirements evolve. | Security Team |
+| - [ ] Treat each review as a lightweight security audit; document findings and any remediations. | Security Team |
 
 ## 6. Documentation & Governance
 
-- [ ] Maintain a public/visible governance document listing all bot/service accounts, their permissions, and last reviewed date.
-- [ ] Add human approval gates and permission review tasks to the project management backlog as recurring items.
-- [ ] Link to relevant GitHub/Discord best practices and security docs.
+| Task | Owner |
+| ---- | ----- |
+| - [ ] Maintain a public/visible governance document listing all bot/service accounts, their permissions, and last reviewed date. | Documentation Team |
+| - [ ] Add human approval gates and permission review tasks to the project management backlog as recurring items. | Project Management Team |
+| - [ ] Link to relevant GitHub/Discord best practices and security docs. | Documentation Team |
 
 ---
 


### PR DESCRIPTION
## Summary
- add table with Owner column to governance checklist
- list teams responsible for each task
- log the new owner column in the changelog

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686d2bbc167c8320a4f1b41f0080c2fc