### PR TITLE
Add security scan steps to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,6 +325,14 @@ jobs:
                   CHECK_HEADERS_URL: http://localhost:8002/api/user
             - name: Run security audit
               run: bash scripts/security_audit.sh
+            - name: Bandit Security Scan
+              run: bandit -r src -ll
+            - name: NPM Audit (high severity)
+              run: npm audit --audit-level=high
+              working-directory: frontend
+            - name: NPM Audit (bot)
+              run: npm audit --audit-level=high
+              working-directory: bot
             - name: Stop docker compose
               if: always()
               run: docker compose -f docker-compose.ci.yaml --env-file .env.dev down

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be recorded in this file.
 
 - CI workflow caches Playwright browsers to reuse ~/.cache/ms-playwright.
 - Skip Codex container setup when running in CI.
+- Added Bandit and npm audit checks to fail CI when high severity issues are found.
 - Install the GitHub CLI in CI using the preinstalled binary or
   `scripts/install_gh_cli.sh`.
 - `scripts/trivy_scan.sh` now downloads the pinned Trivy release tarball instead

--- a/docs/README.md
+++ b/docs/README.md
@@ -199,3 +199,14 @@ See [doc-quality-onboarding.md](doc-quality-onboarding.md) for a step-by-step gu
 We track coverage locally using `pytest --cov=src` and `npm run coverage`. This
 project does **not** use external uploaders like Codecov because remote scripts
 pose a supply chain risk. Only local, inspectable tools are permitted.
+
+Run the same security checks locally before pushing:
+
+```bash
+bash scripts/security_audit.sh
+bandit -r src -ll
+npm audit --audit-level=high --prefix frontend
+npm audit --audit-level=high --prefix bot
+```
+
+Each command fails when vulnerabilities are detected.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,3 +9,4 @@ vale==3.12.0  # LTS as of 2025-06
 language-tool-python==2.9.4  # LTS as of 2025-06
 pip-audit==2.9.0  # LTS as of 2025-06
 mypy==1.16.1  # LTS as of 2025-06
+bandit==1.8.6  # LTS as of 2025-06


### PR DESCRIPTION
## Summary
- run Bandit and npm audits in CI
- describe local security scans in the docs
- document new CI checks in the changelog
- pin Bandit in development requirements

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686d2c7ca7388320bef07014a750fd1b