### PR TITLE
Fix CI failure issue logging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -345,9 +345,11 @@ jobs:
               if: always()
               id: ci_failure
               run: |
+                  set -euo pipefail
                   printf '\n' >> summary.md
                   cat audit.md >> summary.md
                   gh_bin=$(which gh)
+                  "$gh_bin" auth status 2>&1 | tee -a gh_cli.log
                   search_query="CI Failures for ${{ github.sha }} in:title"
                   echo "Searching with: $search_query" | tee -a gh_cli.log
                   ISSUE=$($gh_bin issue list --label ci-failure --state open --search "$search_query" --json number --jq '.[0].number' | tee -a gh_cli.log)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -551,3 +551,5 @@ All notable changes to this project will be recorded in this file.
 - Updated pytest artifact path in CI workflow to `artifacts/pytest-results.xml`
 - Added `security-audit.yml` workflow to run dependency audits weekly and upload the report as an artifact. Documented the job in `docs/README.md`.
 - Added Black formatting checks in CI. The workflow runs `black --check .` after installing dev dependencies.
+- Logged `gh auth status` before creating CI failure issues and stopped the job
+  when the GitHub CLI exits with an error.

--- a/docs/ci-failure-issues.md
+++ b/docs/ci-failure-issues.md
@@ -82,6 +82,6 @@ Trigger the workflow from the **Actions** tab using the **Run workflow** button.
 
 ## Troubleshooting
 
-- Run `gh auth status` to confirm your token includes the `repo` and `issues: write` scopes. Missing scopes prevent the workflow from creating or updating issues.
+- The workflow logs `gh auth status` before creating the failure issue so you can verify the token scopes in `gh_cli.log`.
 - Download `gh_cli.log` and `audit.md` from the run's **Artifacts** section to inspect GitHub CLI output and the log audit summary.
 - Duplicate or missing issues are usually caused by insufficient token permissions or leftover issues from earlier runs.


### PR DESCRIPTION
## Summary
- log `gh auth status` before opening CI failure issues
- document the additional log in ci-failure troubleshooting
- note the change in the changelog

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686d2ed81de88320ba01d82d82fd1b38