### PR TITLE
docs(readme): clarify install order for pytest

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ docker compose -f docker-compose.prod.yaml --env-file .env.prod up -d
 4. Copy each `*.env.example` to `.env` inside its service directory.
 5. Build the containers with `make deps` and start them with `make up`.
 6. Apply database migrations using `bash scripts/run_migrations.sh`.
-7. Install the project and dev requirements, then run the tests:
+7. Install the project **before** running tests. Use editable mode so `pytest` can import the `devonboarder` package:
 
    ```bash
    pip install -e .  # or `pip install -r requirements.txt` if present
@@ -161,8 +161,8 @@ docker compose -f docker-compose.prod.yaml --env-file .env.prod up -d
    npm run coverage --prefix bot
    npm run coverage --prefix frontend
    ```
-   **Note:** `pip install -e .` and `pip install -r requirements-dev.txt` must
-   finish before running `pytest`. See
+   **Note:** both installs must finish before running `pytest` or the tests may
+   fail with `ModuleNotFoundError`. See
    [tests/README.md](tests/README.md) for details.
 8. Install git hooks with `pre-commit install` so lint checks run automatically.
 9. The CI workflow enforces a minimum of **95% code coverage** for all projects (frontend, bot, and backend). Pull requests will fail if any test suite drops below this threshold.

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,8 +17,9 @@ After cloning the repository, run `bash scripts/install_commit_msg_hook.sh` to i
    workflow runs the same script before building containers so your
    environment matches the pipeline.
 3. Build the service containers with `make deps`.
-4. Install the project in editable mode with `pip install -e .`.
-   Install the dev requirements with `pip install -r requirements-dev.txt`.
+4. Install the project in editable mode with `pip install -e .` so the
+   `devonboarder` package can be imported during tests. Then install the dev
+   requirements with `pip install -r requirements-dev.txt`.
 5. Start services with `make up` or run
    `docker compose -f docker-compose.dev.yaml --env-file .env.dev up -d`.
    This launches the auth, bot, XP API, frontend, and Postgres services.
@@ -37,8 +38,9 @@ After cloning the repository, run `bash scripts/install_commit_msg_hook.sh` to i
 13. Verify changes with `ruff check .`, `pytest --cov=src --cov-fail-under=95`, and `npm run coverage` from the `bot/` directory before committing.
     After installing dependencies, run `npm run coverage` in the `frontend/` directory as well
     (see [../frontend/README.md](../frontend/README.md) for details).
-    Install the project and dev requirements **before running the tests**. Running
-    `pytest` without these installs may fail with `ModuleNotFoundError`:
+    Install the project and dev requirements **before running the tests**. Skipping
+    `pip install -e .` often leads to `ModuleNotFoundError` when `pytest` imports
+    the `devonboarder` package:
 
     ```bash
     pip install -e .  # or `pip install -r requirements.txt` if you have one


### PR DESCRIPTION
## Summary
- clarify that tests require `pip install -e .` and dev requirements first
- warn that skipping these installs causes import errors

## Testing
- `ruff check README.md docs/README.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d3006536883209c50a3c86891be42