### PR TITLE
Update monitor-ci lint auto-fix

### DIFF
--- a/codex.ci.yml
+++ b/codex.ci.yml
@@ -8,6 +8,10 @@ codex-tasks:
         - propose-fix:
             generate-patch: true
             include-commit-message: true
+            on: lint
+            run: |
+                ruff --fix $FILES
+                pre-commit run --files $FILES
         - apply-fix:
             if: safe
             then: commit

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,8 @@ All notable changes to this project will be recorded in this file.
   `scripts/install_gh_cli.sh`.
 - `scripts/trivy_scan.sh` now downloads the pinned Trivy release tarball instead
   of piping the install script. Offline instructions updated accordingly.
+- `monitor-ci` now runs `ruff --fix` and `pre-commit run --files` on lint
+  failures and commits the patch when safe.
 - Detects documentation-only pushes and sets `steps.filter.outputs.code` to `false`.
 - Skips the `test` job when only docs or Markdown files change using
   `dorny/paths-filter`.

--- a/docs/ci-workflow.md
+++ b/docs/ci-workflow.md
@@ -54,3 +54,11 @@ The `env-doc-alignment.yml` workflow runs when this step fails. It reruns
 `check_env_docs.py`, parses the missing variables from the output, and opens a
 Secret Alignment issue with the commit SHA. The issue lists the missing
 variables so maintainers know which entries to add to `agents/index.md`.
+
+## Codex CI Monitoring
+
+Codex watches the CI workflow using `codex.ci.yml`. When a job fails due to lint
+errors, the `monitor-ci` task attempts an automatic fix by running `ruff --fix`
+and `pre-commit run --files` on the affected files. If the patch applies safely,
+Codex commits the change and reruns the build; otherwise it opens a pull
+request.


### PR DESCRIPTION
## Summary
- run `ruff --fix` and `pre-commit run --files` when monitor-ci encounters lint errors
- document the auto-fix behavior in the CI workflow guide
- note the new monitor-ci behavior in the changelog

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686d344471788320808075add423f6fa