### PR TITLE
Document CI security scanning

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be recorded in this file.
   `scripts/install_gh_cli.sh`.
 - `scripts/trivy_scan.sh` now downloads the pinned Trivy release tarball instead
   of piping the install script. Offline instructions updated accordingly.
+- Documented Bandit and npm audit steps in `docs/ci-workflow.md`.
 - `monitor-ci` now runs `ruff --fix` and `pre-commit run --files` on lint
   failures and commits the patch when safe.
 - Detects documentation-only pushes and sets `steps.filter.outputs.code` to `false`.

--- a/docs/ci-workflow.md
+++ b/docs/ci-workflow.md
@@ -55,6 +55,17 @@ The `env-doc-alignment.yml` workflow runs when this step fails. It reruns
 Secret Alignment issue with the commit SHA. The issue lists the missing
 variables so maintainers know which entries to add to `agents/index.md`.
 
+## Security Scans
+
+After the environment checks, the job runs three dependency audits:
+
+- `bandit -r src -ll` scans the Python code for vulnerabilities.
+- `npm audit --audit-level=high` runs in both `frontend/` and `bot/`.
+
+Any reported high severity issues cause the workflow to fail. The detailed
+results appear in the job log, which is uploaded as a CI artifact so
+maintainers can review the findings.
+
 ## Codex CI Monitoring
 
 Codex watches the CI workflow using `codex.ci.yml`. When a job fails due to lint


### PR DESCRIPTION
## Summary
- describe Bandit and npm audit steps in the CI workflow docs
- note CI stops on vulnerabilities and uploads logs

## Testing
- `bash scripts/check_docs.sh` *(fails: Unable to download Vale)*
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686d39c28a548320a5eaf10fe025adcd