### PR TITLE
Link first PR guide and architecture diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,25 +55,27 @@ Workflow documentation lives under the [docs/](docs/) directory. New contributor
 9. See [docs/founders/README.md](docs/founders/README.md) for Founder's Circle guidelines.
 10. Follow our [emails/style-guide.md](emails/style-guide.md) when crafting invitations.
 11. Check [docs/sample-pr.md](docs/sample-pr.md) for a small example update.
-12. Run `./scripts/check_docs.sh` to lint documentation with **Vale**.
+12. Review [docs/first-pr-guide.md](docs/first-pr-guide.md) for a full pull request walkthrough.
+13. View the [docs/architecture.svg](docs/architecture.svg) diagram for an overview of our services.
+14. Run `./scripts/check_docs.sh` to lint documentation with **Vale**.
     - The script automatically downloads Vale if it isn’t installed and
       prints a warning if the download fails. See
       [docs/README.md#documentation-quality-checks](docs/README.md#documentation-quality-checks)
       for more details.
     - LanguageTool checks are optional; start a local server and set
       `LANGUAGETOOL_URL` to enable them.
-13. Install the Vale CLI (version 3.12.0+) with `brew install vale` on macOS or
+15. Install the Vale CLI (version 3.12.0+) with `brew install vale` on macOS or
     `choco install vale` on Windows. You can also download it from the
     [Vale releases page](https://github.com/errata-ai/vale/releases).
     If the binary isn't in your `PATH`, set the `VALE_BINARY` environment variable
     and install Python dependencies from `requirements-dev.txt` so the
     documentation checks work locally.
-14. Browse the [agents overview](agents/index.md) for individual service specs.
-15. Keep the sentinel word `Potato` and the file `Potato.md` listed in `.gitignore`, `.dockerignore`, and `.codespell-ignore`.
+16. Browse the [agents overview](agents/index.md) for individual service specs.
+17. Keep the sentinel word `Potato` and the file `Potato.md` listed in `.gitignore`, `.dockerignore`, and `.codespell-ignore`.
     See [AGENTS.md](AGENTS.md) for the full policy. Both pre-commit and CI run `scripts/check_potato_ignore.sh`
     to confirm the entries exist. Do not remove them without approval.
-16. Review the [builder ethics dossier](docs/builder_ethics_dossier.md) outlining contributor ethics and a simple template.
-17. Prefix a commit message with `[no-ci]` to skip the CI workflow on direct pushes. Pull requests always run CI. See
+18. Review the [builder ethics dossier](docs/builder_ethics_dossier.md) outlining contributor ethics and a simple template.
+19. Prefix a commit message with `[no-ci]` to skip the CI workflow on direct pushes. Pull requests always run CI. See
     [AGENTS.md](AGENTS.md) for details.
 
 These files expand on the steps listed in the Quickstart section.


### PR DESCRIPTION
## Summary
- link `docs/first-pr-guide.md` under Documentation and Onboarding
- link the architecture diagram so newcomers can view service layout

## Testing
- `./scripts/check_docs.sh` *(fails: unable to download Vale)*
- `pytest -k 'dummy'` *(fails: missing Python dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686d3c08def08320855eaf0d99e7b6b4