### PR TITLE
Add ghcr.io to network exception list

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be recorded in this file.
   `scripts/install_gh_cli.sh`.
 - `scripts/trivy_scan.sh` now downloads the pinned Trivy release tarball instead
   of piping the install script. Offline instructions updated accordingly.
+- Added `ghcr.io` to the network exception list with references to `scripts/setup-env.sh` and `docker-compose.codex.yml`.
 - Documented Bandit and npm audit steps in `docs/ci-workflow.md`.
 - `monitor-ci` now runs `ruff --fix` and `pre-commit run --files` on lint
   failures and commits the patch when safe.

--- a/docs/network-exception-list.md
+++ b/docs/network-exception-list.md
@@ -10,6 +10,7 @@ The following external domains must be reachable for normal setup and CI tasks. 
 - `api.languagetool.org` and `languagetool.org` – used by LanguageTool. See `docs/network-troubleshooting.md` lines 10‑16 and `docs/doc-quality-onboarding.md` line 44.
 - `dev.languagetool.org` – documentation for running a local LanguageTool server. See `docs/README.md` line 182.
 - `quay.io` – Docker image for a local LanguageTool server. See `docs/doc-quality-onboarding.md` lines 39‑41.
+- `ghcr.io` – container image for Codex universal setup. See `scripts/setup-env.sh` lines 17‑20 and `docker-compose.codex.yml` line 3.
 - `img.shields.io` – coverage badge fetched during CI. See `scripts/update_coverage_badge.py` line 33.
 
 These domains may require explicit firewall or proxy exceptions in restricted environments.


### PR DESCRIPTION
## Summary
- document `ghcr.io` usage in the network exception list
- note the change in the changelog

## Testing
- `scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686d3c2823c0832095fe7a89f78e0e00