### PR TITLE
Add CI env vars doc

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be recorded in this file.
 ## [Unreleased]
 
 - Documented troubleshooting steps for CI failure issues.
+- Documented CI environment variables used in the workflows.
 - Added a first PR guide and service architecture diagram with links from the docs overview.
 
 - Removed the Codecov badge from the README and deleted the upload step.

--- a/docs/README.md
+++ b/docs/README.md
@@ -105,6 +105,8 @@ platforms. Please report any issues you encounter on your operating system.
   &ndash; how automatic cleanup works and how to close old issues.
 - [CI workflow](ci-workflow.md)
   &ndash; overview of job steps, caching, concurrency, and coverage requirements.
+- [CI environment variables](ci-env-vars.md)
+  &ndash; summary of tokens and other variables used by the workflows.
 - [Discord message templates](discord/discord-message-templates.md) &ndash; sample posts for the community.
 - [Discord server configuration](discord/configuration.md) &ndash; enable the widget for status display.
 - [Doc QA onboarding](doc-quality-onboarding.md) &ndash; quickstart for documentation checks.

--- a/docs/ci-env-vars.md
+++ b/docs/ci-env-vars.md
@@ -1,0 +1,17 @@
+# CI Environment Variables
+
+This page summarizes variables referenced in GitHub Actions workflows. Use these values when running CI jobs locally or configuring new workflows.
+
+| Variable | Where to set | Required scopes | Purpose | Notes |
+| -------- | ------------ | --------------- | ------- | ----- |
+| `GITHUB_TOKEN` | Auto-injected by GitHub | Determined by `permissions` in the workflow | Authenticate API requests and push commits during CI | Provided automatically; expires after each job |
+| `GH_TOKEN` | GitHub Actions secret or local environment | `issues: write`, `pull_requests: write` if used for cross-repo operations | Token consumed by the GitHub CLI to comment on PRs and manage issues | Usually set to `${{ secrets.GITHUB_TOKEN }}` in workflows |
+| `NPM_TOKEN` | GitHub Actions secret | `publish` (npm) | Authenticate `npm publish` when releasing packages | Not currently used but reserved for future publishing steps |
+| `VALE_VERSION` | Workflow `env` block or local environment | n/a | Choose the Vale linter version for docs checks | Defaults to `3.12.0` |
+| `TRIVY_VERSION` | Workflow `env` block | n/a | Selects the Trivy version for container scanning | Defaults to `0.47.0` |
+| `AUTH_URL` | Workflow `env` block | n/a | Base URL for auth service during E2E tests | Set to `http://localhost:8002` in CI |
+| `CHECK_HEADERS_URL` | Workflow `env` block | n/a | Endpoint checked by `scripts/check_headers.py` | Defaults to the auth user endpoint |
+| `GITHUB_SERVER_URL` | Auto-injected by GitHub | n/a | Hostname for the current GitHub instance | Used by `post_coverage_comment.py` |
+| `GITHUB_REPOSITORY` | Auto-injected by GitHub | n/a | `owner/repo` string identifying the project | Used by `post_coverage_comment.py` |
+| `GITHUB_RUN_ID` | Auto-injected by GitHub | n/a | Unique ID for the workflow run | Used when generating coverage links |
+


### PR DESCRIPTION
## Summary
- document CI environment variables used by the workflows
- reference the new doc from the documentation overview
- note the CI env var list in the changelog

## Testing
- `python scripts/check_env_docs.py`
- `bash scripts/check_docs.sh docs/ci-env-vars.md` *(fails: unable to download Vale)*
- `pre-commit run --files docs/ci-env-vars.md docs/README.md docs/CHANGELOG.md` *(fails: error checking out Prettier)*

------
https://chatgpt.com/codex/tasks/task_e_686d3f18142c8320b4046045bbafe613