### PR TITLE
Add link to network exception list

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -542,6 +542,7 @@ All notable changes to this project will be recorded in this file.
 - Added an **Owner** column to that checklist and assigned responsible teams to each task.
 - Documented token requirements for forked pull requests in `docs/ci-failure-issues.md` and referenced it from the documentation README.
 - Added a debug step to `cleanup-ci-failure.yml` to print token status and open issue numbers before closing them.
+- Linked the network exception list from the docs overview so newcomers can find firewall rules.
 ## [0.1.0] - 2025-06-14
 
 - Added `src/app.py` with `greet` function and updated smoke tests. [#21](https://github.com/theangrygamershowproductions/DevOnboarder/pull/21)

--- a/docs/README.md
+++ b/docs/README.md
@@ -121,6 +121,8 @@ platforms. Please report any issues you encounter on your operating system.
 - [Merge checklist](merge-checklist.md) &ndash; steps maintainers use before merging.
 - [Network troubleshooting](network-troubleshooting.md#pre-commit-nodeenv-ssl-errors)
   &ndash; work around pre-commit `nodeenv` SSL errors and other network restrictions.
+- [Network exception list](network-exception-list.md)
+  &ndash; required firewall exceptions for setup and CI tasks.
 - [Offline setup](offline-setup.md) &ndash; download Python wheels and npm packages on another machine.
 - [Project origin & recovery story](origin.md) &ndash; why DevOnboarder exists.
 - [Pull request template](pull_request_template.md) &ndash; describe your changes and verify the checklist.


### PR DESCRIPTION
## Summary
- link to network exception list in docs overview
- note addition in CHANGELOG

## Testing
- `bash scripts/check_docs.sh`
- `pytest -q tests/test_health.py` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686d3ff2096c8320aaff297f2661ab17