### PR TITLE
Update codex CI auto-fix handling

### DIFF
--- a/codex.ci.yml
+++ b/codex.ci.yml
@@ -5,6 +5,11 @@ codex-tasks:
         - analyze-error:
             summarize: true
             classify: [lint, test, dependency, infra, config]
+        - if: lint
+          then:
+            run: |
+              ruff --fix {files}
+              pre-commit run --files {files}
         - propose-fix:
             generate-patch: true
             include-commit-message: true

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,9 @@ All notable changes to this project will be recorded in this file.
 
 - CI workflow caches Playwright browsers to reuse ~/.cache/ms-playwright.
 - Skip Codex container setup when running in CI.
+- Codex now attempts `ruff --fix` and `pre-commit run --files` when linting fails
+  and commits the patch automatically if safe. Otherwise it opens a "chore:
+  auto-fix lint errors via Codex" pull request.
 - Added Bandit and npm audit checks to fail CI when high severity issues are found.
 - Install the GitHub CLI in CI using the preinstalled binary or
   `scripts/install_gh_cli.sh`.

--- a/docs/ci-workflow.md
+++ b/docs/ci-workflow.md
@@ -34,6 +34,14 @@ Workflows rely on the GitHub CLI that comes preinstalled in the container image 
 
 The job runs `black --check .` after installing development requirements. Formatting issues cause the build to fail.
 
+## Codex Auto-Fixes
+
+Codex's `monitor-ci` task watches this workflow. When a lint step fails, the bot
+runs `ruff --fix` and `pre-commit run --files` on the affected files. If the
+patch applies cleanly, Codex commits the changes. Otherwise it opens a pull
+request titled **"chore: auto-fix lint errors via Codex"** summarizing the
+adjustments.
+
 ## Environment Variable Audit
 
 After `.env.dev` is generated, the workflow runs `scripts/audit_env_vars.sh`.


### PR DESCRIPTION
## Summary
- run `ruff --fix` and pre-commit when linting fails in `monitor-ci`
- document Codex lint auto-fix behavior
- note lint auto-fix automation in the changelog

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686d30ef66708320931ae0f02d74ce45