### PR TITLE
Update docs with network exception reference

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -121,6 +121,8 @@ platforms. Please report any issues you encounter on your operating system.
 - [Merge checklist](merge-checklist.md) &ndash; steps maintainers use before merging.
 - [Network troubleshooting](network-troubleshooting.md#pre-commit-nodeenv-ssl-errors)
   &ndash; work around pre-commit `nodeenv` SSL errors and other network restrictions.
+- [Network exception list](network-exception-list.md)
+  &ndash; domains that must be reachable for setup and CI tasks.
 - [Offline setup](offline-setup.md) &ndash; download Python wheels and npm packages on another machine.
 - [Project origin & recovery story](origin.md) &ndash; why DevOnboarder exists.
 - [Pull request template](pull_request_template.md) &ndash; describe your changes and verify the checklist.


### PR DESCRIPTION
## Summary
- list `network-exception-list.md` in the main docs README

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'passlib')*
- `npm run coverage` in `bot/` *(fails: jest not found)*
- `npm run coverage` in `frontend/` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d3eb431588320acc0552b7899f1e7