### PR TITLE
Add script to list network exception domains

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to this project will be recorded in this file.
   of piping the install script. Offline instructions updated accordingly.
 - Added `ghcr.io` to the network exception list with references to `scripts/setup-env.sh` and `docker-compose.codex.yml`.
 - Linked the network exception list from the docs overview and added `scripts/check_network_access.sh` for preflight checks.
+- Added `scripts/show_network_exceptions.sh` to print the firewall domain list.
 - Documented Bandit and npm audit steps in `docs/ci-workflow.md`.
 - Updated `scripts/security_audit.sh` to run Bandit and high severity `npm audit`
   checks for both `frontend/` and `bot/`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -126,6 +126,7 @@ platforms. Please report any issues you encounter on your operating system.
 - [Network exception list](network-exception-list.md)
   &ndash; required external domains and firewall exceptions.
   &ndash; required firewall exceptions for setup and CI tasks.
+  &ndash; run `scripts/show_network_exceptions.sh` to print the list.
 - [Offline setup](offline-setup.md) &ndash; download Python wheels and npm packages on another machine.
 - [Project origin & recovery story](origin.md) &ndash; why DevOnboarder exists.
 - [Pull request template](pull_request_template.md) &ndash; describe your changes and verify the checklist.

--- a/docs/network-troubleshooting.md
+++ b/docs/network-troubleshooting.md
@@ -3,6 +3,8 @@
 Some development environments restrict outbound network traffic. These tips help you work around common issues.
 See [network-exception-list.md](network-exception-list.md) for a list of domains that CI and setup scripts must reach.
 Run `scripts/check_network_access.sh` to verify connectivity before continuing.
+Run `scripts/show_network_exceptions.sh` to print the domain list if you need to
+update your firewall rules.
 
 ## Vale download blocked
 - Download `vale` from [the releases page](https://github.com/errata-ai/vale/releases) on a machine with internet access.

--- a/scripts/show_network_exceptions.sh
+++ b/scripts/show_network_exceptions.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DOC="$SCRIPT_DIR/../docs/network-exception-list.md"
+
+awk '/^- /{gsub(/`/, ""); for(i=1;i<=NF;i++) if($i ~ /^[A-Za-z0-9.-]+\.(com|org|io|sh)$/) print $i}' "$DOC"


### PR DESCRIPTION
## Summary
- provide `show_network_exceptions.sh` for listing firewall domains
- document how to use the script in network troubleshooting guide
- add reference in docs overview
- record the addition in the changelog

## Testing
- `ruff check .`
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686d46e9adb08320b7cfb6983275c301