### PR TITLE
fix(ci): warn when issue search fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -360,10 +360,14 @@ jobs:
                   "$gh_bin" auth status 2>&1 | tee -a gh_cli.log
                   search_query="CI Failures for ${{ github.sha }} in:title"
                   echo "Searching with: $search_query" | tee -a gh_cli.log
-                  ISSUE=$($gh_bin issue list --label ci-failure --state open --search "$search_query" --json number --jq '.[0].number' | tee -a gh_cli.log)
-                  if [ -n "$ISSUE" ]; then
+                  set +e
+                  ISSUE=$($gh_bin issue list --label ci-failure --state open --search "$search_query" --json number --jq '.[0].number' 2>&1 | tee -a gh_cli.log)
+                  list_exit=$?
+                  set -e
+                  if [ "$list_exit" -eq 0 ] && [ -n "$ISSUE" ]; then
                       "$gh_bin" issue comment "$ISSUE" --body-file summary.md 2>&1 | tee -a gh_cli.log
                   else
+                      echo "::warning::Issue search failed or returned no results" | tee -a gh_cli.log
                       ISSUE=$($gh_bin issue create --title "CI Failures for ${{ github.sha }}" --body-file summary.md --label ci-failure --json number --jq '.number' | tee -a gh_cli.log)
                   fi
                   echo "issue-number=$ISSUE" >> "$GITHUB_OUTPUT"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be recorded in this file.
 
 - Documented troubleshooting steps for CI failure issues.
 - Documented CI environment variables used in the workflows.
+- Warns when the CI failure issue search fails and logs the message in `gh_cli.log`.
 - Added a first PR guide and service architecture diagram with links from the docs overview.
 
 - Removed the Codecov badge from the README and deleted the upload step.


### PR DESCRIPTION
## Summary
- improve CI failure issue step to warn when issue search fails
- document the warning in CHANGELOG

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686d4ea789d4832088df0747bf0b66d5