### PR TITLE
Fix cleanup workflow failure handling

### DIFF
--- a/.github/workflows/cleanup-ci-failure.yml
+++ b/.github/workflows/cleanup-ci-failure.yml
@@ -21,8 +21,16 @@ jobs:
               continue-on-error: true
             - run: |
                   gh_bin=$(which gh)
+                  failed=0
                   for n in $($gh_bin issue list --label ci-failure --state open --json number --jq '.[].number'); do
-                    "$gh_bin" issue close "$n" --reason completed
+                    "$gh_bin" issue close "$n" --reason completed || failed=1
                   done
+                  if [ "$failed" -ne 0 ]; then
+                    echo "::error::Cleanup failed"
+                    "$gh_bin" issue create --title "Cleanup CI failure issues failed" \
+                      --body "Automatic cleanup could not close one or more ci-failure issues." \
+                      --label ci-failure || true
+                    exit 1
+                  fi
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -552,6 +552,7 @@ All notable changes to this project will be recorded in this file.
 - Documented token requirements for forked pull requests in `docs/ci-failure-issues.md` and referenced it from the documentation README.
 - Added a debug step to `cleanup-ci-failure.yml` to print token status and open issue numbers before closing them.
 - Linked the network exception list from the docs overview so newcomers can find firewall rules.
+- The cleanup workflow now exits with an error when issue closing fails and opens a follow-up issue.
 ## [0.1.0] - 2025-06-14
 
 - Added `src/app.py` with `greet` function and updated smoke tests. [#21](https://github.com/theangrygamershowproductions/DevOnboarder/pull/21)

--- a/docs/README.md
+++ b/docs/README.md
@@ -198,7 +198,7 @@ See [doc-quality-onboarding.md](doc-quality-onboarding.md) for a step-by-step gu
 6. When CI fails, an issue titled `CI Failures for <sha>` is opened or updated with a summary of the failing tests and links to the artifacts.
 7. The CI workflow uses the built-in `GITHUB_TOKEN` with `issues: write` permission. When the pipeline succeeds, it closes every open `ci-failure` issue.
 8. `${{ secrets.GITHUB_TOKEN }}` is read-only on pull requests from forks. Use a token with `issues: write` permission or a `pull_request_target` workflow as explained in [ci-failure-issues.md](ci-failure-issues.md#forked-pull-requests).
-9. A nightly job (`cleanup-ci-failure.yml`) logs token details and closes any open `ci-failure` issues so the board stays tidy.
+9. A nightly job (`cleanup-ci-failure.yml`) logs token details, closes any open `ci-failure` issues, and opens a follow-up ticket if cleanup fails.
 
 10. A weekly job (`security-audit.yml`) runs dependency audits and uploads the report as an artifact.
 11. CODEOWNERS automatically requests reviews from the maintainer team.


### PR DESCRIPTION
## Summary
- ensure the cleanup workflow exits when issue closing fails
- document cleanup failure handling

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686d507717808320ba380b58462d5668