### PR TITLE
Document PAT usage for forked PR workflows

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be recorded in this file.
 - Documented CI environment variables used in the workflows.
 - Warns when the CI failure issue search fails and logs the message in `gh_cli.log`.
 - Added a first PR guide and service architecture diagram with links from the docs overview.
+- Documented how maintainers can provide a personal access token for workflows on forked pull requests.
 
 - Removed the Codecov badge from the README and deleted the upload step.
 - Updated README star and issue links to point to the repository.

--- a/docs/README.md
+++ b/docs/README.md
@@ -197,7 +197,7 @@ See [doc-quality-onboarding.md](doc-quality-onboarding.md) for a step-by-step gu
 5. See the Codex CI Monitoring Policy in [../AGENTS.md](../AGENTS.md) for how failed CI jobs automatically create tasks.
 6. When CI fails, an issue titled `CI Failures for <sha>` is opened or updated with a summary of the failing tests and links to the artifacts.
 7. The CI workflow uses the built-in `GITHUB_TOKEN` with `issues: write` permission. When the pipeline succeeds, it closes every open `ci-failure` issue.
-8. `${{ secrets.GITHUB_TOKEN }}` is read-only on pull requests from forks. Use a token with `issues: write` permission or a `pull_request_target` workflow as explained in [ci-failure-issues.md](ci-failure-issues.md#forked-pull-requests).
+8. `${{ secrets.GITHUB_TOKEN }}` is read-only on pull requests from forks. Use a token with `issues: write` permission or a `pull_request_target` workflow as explained in [ci-failure-issues.md](ci-failure-issues.md#forked-pull-requests). Maintainers can supply a personal access token as described in [ci-failure-issues.md#maintainer-token-setup].
 9. A nightly job (`cleanup-ci-failure.yml`) logs token details, closes any open `ci-failure` issues, and opens a follow-up ticket if cleanup fails.
 
 10. A weekly job (`security-audit.yml`) runs dependency audits and uploads the report as an artifact.

--- a/docs/ci-failure-issues.md
+++ b/docs/ci-failure-issues.md
@@ -14,6 +14,18 @@ fork. To update or close issues from those builds, you need a token granted
 `issues: write` permissions. Use a personal access token or run the workflow in
 `pull_request_target` to access repository secrets safely.
 
+### Maintainer Token Setup
+
+Create a personal access token with `issues: write` permission when you need to
+rerun CI on a contributor fork. Provide it via `GH_TOKEN` so the GitHub CLI can
+comment on the failure issue:
+
+```bash
+GH_TOKEN=your_personal_token gh workflow run ci.yml -F ref=<branch>
+```
+
+Remove the token after the run completes.
+
 ## Root Cause Summaries
 
 The workflow automatically runs `scripts/ci_log_audit.py` on the CI job log when a step fails and appends the resulting `audit.md` to the failure issue comment.


### PR DESCRIPTION
## Summary
- explain how maintainers can supply a personal access token for forked PRs in `ci-failure-issues.md`
- clarify README bullet about the limitation with a link to the new section
- note change in `CHANGELOG`

## Testing
- `pre-commit run --files docs/CHANGELOG.md docs/README.md docs/ci-failure-issues.md` *(fails: CalledProcessError: git checkout v3.6.2)*
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686d523881dc8320b102e5e7e8e0e920