### PR TITLE
Count closed CI-failure issues

### DIFF
--- a/.github/workflows/cleanup-ci-failure.yml
+++ b/.github/workflows/cleanup-ci-failure.yml
@@ -22,8 +22,13 @@ jobs:
             - run: |
                   gh_bin=$(which gh)
                   failed=0
+                  closed=0
                   for n in $($gh_bin issue list --label ci-failure --state open --json number --jq '.[].number'); do
-                    "$gh_bin" issue close "$n" --reason completed || failed=1
+                    if "$gh_bin" issue close "$n" --reason completed; then
+                      closed=$((closed+1))
+                    else
+                      failed=1
+                    fi
                   done
                   if [ "$failed" -ne 0 ]; then
                     echo "::error::Cleanup failed"
@@ -32,5 +37,6 @@ jobs:
                       --label ci-failure || true
                     exit 1
                   fi
+                  echo "Closed $closed ci-failure issues"
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -555,6 +555,7 @@ All notable changes to this project will be recorded in this file.
 - Added a debug step to `cleanup-ci-failure.yml` to print token status and open issue numbers before closing them.
 - Linked the network exception list from the docs overview so newcomers can find firewall rules.
 - The cleanup workflow now exits with an error when issue closing fails and opens a follow-up issue.
+- The cleanup workflow prints `Closed N ci-failure issues` on success or `::error::Cleanup failed` in the job log.
 ## [0.1.0] - 2025-06-14
 
 - Added `src/app.py` with `greet` function and updated smoke tests. [#21](https://github.com/theangrygamershowproductions/DevOnboarder/pull/21)


### PR DESCRIPTION
## Summary
- count how many CI-failure issues are closed
- print `Closed N ci-failure issues` on success
- record change in CHANGELOG

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686d59b9e5c883209871455bd608bb74