### PR TITLE
Highlight required install steps before tests

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be recorded in this file.
 - Searches the CI failure issue title and body for the commit SHA and logs the search exit code.
 - Added a first PR guide and service architecture diagram with links from the docs overview.
 - Documented how maintainers can provide a personal access token for workflows on forked pull requests.
+- Clarified that `pip install -e .` and `pip install -r requirements-dev.txt` must run before executing tests.
 
 - Removed the Codecov badge from the README and deleted the upload step.
 - Updated README star and issue links to point to the repository.

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,6 +1,6 @@
 # Running the Test Suite
 
-Install the project and its development requirements before executing the tests so Python can resolve all imports:
+Install the project and its development requirements before executing the tests so Python can resolve all imports. **These commands must run before invoking `pytest`.**
 
 ```bash
 pip install -e .


### PR DESCRIPTION
## Summary
- stress that `pip install -e .` and `pip install -r requirements-dev.txt` must run before executing tests
- record the note in the changelog

## Testing
- `pytest --cov=src --cov-fail-under=95`

------
https://chatgpt.com/codex/tasks/task_e_686d5c5b89e08320bc18edca15f386f2