### PR TITLE
Fix cleanup workflow

### DIFF
--- a/.github/workflows/cleanup-ci-failure.yml
+++ b/.github/workflows/cleanup-ci-failure.yml
@@ -19,24 +19,25 @@ jobs:
               env:
                 GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               continue-on-error: true
-            - run: |
-                  gh_bin=$(which gh)
-                  failed=0
-                  closed=0
-                  for n in $($gh_bin issue list --label ci-failure --state open --json number --jq '.[].number'); do
-                    if "$gh_bin" issue close "$n" --reason completed; then
-                      closed=$((closed+1))
-                    else
-                      failed=1
+              - run: |
+                    gh_bin=$(which gh)
+                    failed=0
+                    closed=0
+                    issues=$($gh_bin issue list --label ci-failure --state open --json number --jq '.[].number') || failed=1
+                    for n in $issues; do
+                      if "$gh_bin" issue close "$n" --reason completed; then
+                        closed=$((closed+1))
+                      else
+                        failed=1
+                      fi
+                    done
+                    if [ "$failed" -ne 0 ]; then
+                      echo "::error::Cleanup failed"
+                      "$gh_bin" issue create --title "Cleanup CI failure issues failed" \
+                        --body "Automatic cleanup could not close one or more ci-failure issues." \
+                        --label ci-failure || true
+                      exit 1
                     fi
-                  done
-                  if [ "$failed" -ne 0 ]; then
-                    echo "::error::Cleanup failed"
-                    "$gh_bin" issue create --title "Cleanup CI failure issues failed" \
-                      --body "Automatic cleanup could not close one or more ci-failure issues." \
-                      --label ci-failure || true
-                    exit 1
-                  fi
-                  echo "Closed $closed ci-failure issues"
+                    echo "Closed $closed ci-failure issues"
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -560,7 +560,7 @@ All notable changes to this project will be recorded in this file.
 - Documented token requirements for forked pull requests in `docs/ci-failure-issues.md` and referenced it from the documentation README.
 - Added a debug step to `cleanup-ci-failure.yml` to print token status and open issue numbers before closing them.
 - Linked the network exception list from the docs overview so newcomers can find firewall rules.
-- The cleanup workflow now exits with an error when issue closing fails and opens a follow-up issue.
+ - The cleanup workflow now exits with an error when any `gh` command fails and opens a follow-up issue.
 - The cleanup workflow prints `Closed N ci-failure issues` on success or `::error::Cleanup failed` in the job log.
 ## [0.1.0] - 2025-06-14
 


### PR DESCRIPTION
## Summary
- exit cleanup workflow when any `gh` command fails
- mention new behaviour in the changelog

## Testing
- `pre-commit run --files .github/workflows/cleanup-ci-failure.yml docs/CHANGELOG.md` *(fails: InvalidConfigError)*
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686d64b462508320aba63dff1f5945f9