### PR TITLE
Update docs on line-length limit

### DIFF
--- a/docs/doc-quality-onboarding.md
+++ b/docs/doc-quality-onboarding.md
@@ -70,6 +70,12 @@ bash scripts/check_docs.sh
 This script runs `markdownlint-cli2` and Vale to lint all Markdown files. It
 generates `vale-results.json` for machine-readable output, which CI stores as an
 artifact.
+Markdownlint enforces a 120-character maximum line length via MD013 in `.markdownlint.json`.
+To check for violations manually, run:
+
+```bash
+grep -Rnw '.{121}' docs
+```
 
 CI also saves `test-results/pytest-results.xml` when running the test suite. You
 can download both artifacts from the **Artifacts** section of each GitHub


### PR DESCRIPTION
## Summary
- document 120 character line limit in `docs/doc-quality-onboarding.md`
- show command to grep for long lines

## Testing
- `bash scripts/run_tests.sh`
- `pre-commit run --files docs/doc-quality-onboarding.md` *(fails: InvalidConfigError)*

------
https://chatgpt.com/codex/tasks/task_e_686d68b3c4188320af0826c8514325b6