### PR TITLE
Add forked PR token note to ci-failure docs

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be recorded in this file.
 - Documented how maintainers can provide a personal access token for workflows on forked pull requests.
 - Added a reminder in `docs/README.md` that forked pull requests require a personal access token or
     `pull_request_target` workflow to update CI failure issues.
+- Expanded `docs/ci-failure-issues.md` with a note linking back to this reminder.
 - Wrapped long documentation lines to satisfy markdownlint rule MD013.
 - Additional documentation line wrapping for MD013.
 - Clarified that `pip install -e .` and `pip install -r requirements-dev.txt` must run before executing tests.

--- a/docs/ci-failure-issues.md
+++ b/docs/ci-failure-issues.md
@@ -16,6 +16,11 @@ fork. To update or close issues from those builds, you need a token granted
 `issues: write` permissions. Use a personal access token or run the workflow in
 `pull_request_target` to access repository secrets safely.
 
+The same guidance appears in the issues section of
+[README.md](README.md#issues-and-pull-requests). Forked pull requests must
+provide a personal access token or run this workflow in `pull_request_target`
+so CI can update the failure issue automatically.
+
 ### Maintainer Token Setup
 
 Create a personal access token with `issues: write` permission when you need to


### PR DESCRIPTION
## Summary
- mention token requirement for forked PRs in `ci-failure-issues.md`
- link to README issues section
- record update in the changelog

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686d68e0f5cc8320b133fa42b6d25133