### PR TITLE
style(docs): wrap long lines for MD013

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,12 +64,16 @@ docs: Document built-in GITHUB_TOKEN usage for CI failure issues
 - Updates changelog with policy details
 ```
 
-See [docs/git-guidelines.md](./docs/git-guidelines.md) and the files under [docs/git/](./docs/git/) for additional Git best practices.
+See [docs/git-guidelines.md](./docs/git-guidelines.md) and the files under
+[docs/git/](./docs/git/) for additional Git best practices.
 
 ## Commit History Policy: No Rewriting or Force-Pushing
 
-- **Commit messages on pushed commits cannot be changed.** Once a commit is pushed to a shared branch, avoid `git commit --amend`, interactive rebases, and `git push --force`.
-- If a commit message is unclear, add context in a new commit or the pull request description instead of rewriting history.
+- **Commit messages on pushed commits cannot be changed.** Once a commit is
+  pushed to a shared branch, avoid `git commit --amend`, interactive rebases,
+  and `git push --force`.
+- If a commit message is unclear, add context in a new commit or the pull request
+  description instead of rewriting history.
 - This rule preserves repository integrity and auditability.
 
 ## Potato Ignore Policy

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,4 +6,6 @@ Please install our commit message hook after cloning:
 bash scripts/install_commit_msg_hook.sh
 ```
 
-The hook prevents bad commit messages from reaching CI. See [docs/git-guidelines.md](docs/git-guidelines.md) for style rules and [docs/README.md](docs/README.md) for environment setup tips.
+The hook prevents bad commit messages from reaching CI. See
+[docs/git-guidelines.md](docs/git-guidelines.md) for style rules and
+[docs/README.md](docs/README.md) for environment setup tips.

--- a/Codex_Contributor_Dashboard.md
+++ b/Codex_Contributor_Dashboard.md
@@ -12,17 +12,17 @@
 
 # 🧩 Codex Contributor Dashboard – MVP
 
-This dashboard provides a live snapshot of module status, responsibilities, and onboarding readiness for Codex contributors.
-
-| Module         | Path                      | Description                                                        | Status          |
-|----------------|---------------------------|--------------------------------------------------------------------|-----------------|
-| **auth_service** | `services/auth_service`    | Implement Discord OAuth2 login and session issuance.               | ✅ Complete      |
-| **xp_api**       | `services/xp_api`          | Fix XP endpoint logic and add contribution POST route.             | ✅ Complete      |
-| **discord_bot**  | `bot`                      | Modularize commands and integrate token-based API calls.           | ✅ Complete      |
-| **frontend**     | `frontend`                 | Scaffold OAuth callback, onboarding UI, and XP dashboard.         | 🚧 In Progress   |
-| **infra_docs**   | `infra`                    | Environment templates, Docker Compose, CI/CD scripts.             | ✅ Complete      |
-| **codex_docs**   | `codex`                    | Codex plan, tasks, and automation metadata files.                  | ✅ Complete      |
-| **project_docs** | `docs`                     | General docs, merge guides, changelog, and onboarding markdown.    | ✅ Complete      |
+This dashboard provides a live snapshot of module status and responsibilities.
+It also tracks onboarding readiness for Codex contributors.
+| Module | Path | Description | Status |
+| ------ | ---- | ----------- | ------ |
+| **auth_service** | `services/auth_service` | Implement Discord OAuth2 login and session issuance. | ✅ Complete |
+| **xp_api** | `services/xp_api` | Fix XP endpoint logic and add contribution POST route. | ✅ Complete |
+| **discord_bot** | `bot` | Modularize commands and integrate token-based API calls. | ✅ Complete |
+| **frontend** | `frontend` | Scaffold OAuth callback, onboarding UI, and XP dashboard. | 🚧 In Progress |
+| **infra_docs** | `infra` | Environment templates, Docker Compose, CI/CD scripts. | ✅ Complete |
+| **codex_docs** | `codex` | Codex plan, tasks, and automation metadata files. | ✅ Complete |
+| **project_docs** | `docs` | General docs, merge guides, changelog, and onboarding markdown. | ✅ Complete |
 
 ## ✅ Summary
 

--- a/agents/index.md
+++ b/agents/index.md
@@ -1,6 +1,8 @@
 # Agents Overview
 
-This directory documents the services and integrations that make up the DevOnboarder platform. Each agent has its own page describing the purpose and how it fits into the workflow.
+This directory documents the services and integrations that make up the
+DevOnboarder platform. Each agent has its own page describing the purpose and
+how it fits into the workflow.
 
 ## Available Agents
 
@@ -36,7 +38,8 @@ The table below lists environment variables used across DevOnboarder agents. Kee
 | DISCORD_CLIENT_SECRET        | Discord application client secret          |
 | DISCORD_REDIRECT_URI         | OAuth callback URL for Discord             |
 | DISCORD_API_TIMEOUT          | HTTP timeout in seconds for Discord API calls |
-| JWT_SECRET_KEY               | Secret key for JWT signing (required; service errors if empty or "secret" outside `development`) |
+| JWT_SECRET_KEY               | Secret key for JWT signing (required; service
+errors if empty or "secret" outside `development`) |
 | JWT_ALGORITHM                | Algorithm for JWT signing (default `HS256`) |
 | DISCORD_BOT_TOKEN            | Token for the Discord bot                  |
 | DISCORD_GUILD_IDS            | Guilds where the bot operates              |

--- a/codex.plan.md
+++ b/codex.plan.md
@@ -8,7 +8,10 @@ updated: "04 July 2025 10:00 (EST)"
 
 # DevOnboarder – Codex Execution Plan
 
-This document defines the roadmap and execution logic for Codex tasks during the MVP push. It is synchronized with `codex.tasks.json` and ensures unified delivery across the backend (auth, XP), Discord bot, and future frontend modules.
+This document defines the roadmap and execution logic for Codex tasks during the
+MVP push. It is synchronized with `codex.tasks.json` and ensures unified
+delivery across the backend (auth, XP), Discord bot, and future frontend
+modules.
 
 ---
 
@@ -61,7 +64,9 @@ This document defines the roadmap and execution logic for Codex tasks during the
 
 ### 🚧 Phase 5: Llama2 Agile Helper Integration
 
-- [agile-001] Connect Llama2 Agile Helper agent for sprint summaries and backlog suggestions. See [codex/tasks/llama2-agile-helper.yaml](codex/tasks/llama2-agile-helper.yaml).
+- [agile-001] Connect Llama2 Agile Helper agent for sprint summaries and backlog
+  suggestions. See
+  [codex/tasks/llama2-agile-helper.yaml](codex/tasks/llama2-agile-helper.yaml).
 
 ---
 

--- a/codex/journal/2025-07-05.md
+++ b/codex/journal/2025-07-05.md
@@ -1,6 +1,7 @@
 ## ✅ Ethics Dossier Added
 
-Created `docs/builder_ethics_dossier.md` to formally document builder intent, boundaries, and reproducible ethical guidelines for future contributors.
+Created `docs/builder_ethics_dossier.md` to formally document builder intent,
+boundaries, and reproducible ethical guidelines for future contributors.
 
 Removed the outdated duplicate `docs/builder-ethics-dossier.md`.
 

--- a/codex/tasks/confirm_doc_alignment.md
+++ b/codex/tasks/confirm_doc_alignment.md
@@ -40,4 +40,5 @@ date: 2025-07-05
 ---
 
 **Action:**
-All issues verified as resolved. This note confirms compliance for audit tracking and closes internal doc alignment tasks.
+All issues verified as resolved. This note confirms compliance for audit
+tracking and closes internal doc alignment tasks.

--- a/docs/ci-failure-issues.md
+++ b/docs/ci-failure-issues.md
@@ -35,7 +35,8 @@ Remove the token after the run completes.
 
 ## Root Cause Summaries
 
-The workflow automatically runs `scripts/ci_log_audit.py` on the CI job log when a step fails and appends the resulting `audit.md` to the failure issue comment.
+The workflow automatically runs `scripts/ci_log_audit.py` on the CI job log when
+ a step fails and appends the resulting `audit.md` to the failure issue comment.
 
 Run the script manually on a downloaded log if you need to dig deeper:
 

--- a/docs/discord/configuration.md
+++ b/docs/discord/configuration.md
@@ -9,4 +9,5 @@ This guide explains how to configure the Discord server used by the project.
 3. Configure channels and roles as needed for your community.
 4. **Enable the Widget** in the server settings so the website can display the server's online status.
 
-With the Widget enabled, the marketing site and other tools can show who is online without requiring users to open Discord.
+With the Widget enabled, the marketing site and other tools can show who is
+online without requiring users to open Discord.

--- a/docs/endpoint-reference.md
+++ b/docs/endpoint-reference.md
@@ -37,4 +37,6 @@ The bot in `bot/` calls these routes when users run slash commands:
 | `/profile` | `GET /api/user/level` |
 | `/contribute` | `POST /api/user/contributions` |
 
-For example, typing `/verify` in Discord triggers a request to `/api/user/onboarding-status` and echoes the resulting status back to the channel.
+For example, typing `/verify` in Discord triggers a request to
+`/api/user/onboarding-status` and echoes the resulting status back to the
+channel.

--- a/docs/founders/README.md
+++ b/docs/founders/README.md
@@ -20,7 +20,8 @@ Members of the Founder's Circle help guide the long-term vision of the project.
 5. Read the [Founder's Circle charter](charter.md) to understand expectations.
 
 ## Founder Feature Flag
-Set `IS_FOUNDER=true` in your `.env.dev` file to unlock founder-only routes. The `.env.example` file lists this variable for reference.
+Set `IS_FOUNDER=true` in your `.env.dev` file to unlock founder-only routes. The
+`.env.example` file lists this variable for reference.
 
 Need a reference email? See [emails/founders_invite.md](../../emails/founders_invite.md) for a template you can adapt.
 Refer to [emails/style-guide.md](../../emails/style-guide.md) for tone guidelines when you reach out.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -2,7 +2,8 @@
 
 This directory houses the DevOnboarder React application built with Vite.
 
-Install dependencies with `pnpm install` (or `npm install` if `pnpm` is not available`). Commit the generated lockfile (`pnpm-lock.yaml` or `package-lock.json`).
+Install dependencies with `pnpm install` (or `npm install` if `pnpm` is not
+available`). Commit the generated lockfile (`pnpm-lock.yaml` or `package-lock.json`).
 Start the development server with `npm run dev`.
 Run `npm run lint` to check code style and `npm run format` to apply Prettier formatting.
 Environment variables are defined in `.env.example`.

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,6 +1,8 @@
 # Running the Test Suite
 
-Install the project and its development requirements before executing the tests so Python can resolve all imports. **These commands must run before invoking `pytest`.**
+Install the project and its development requirements before executing the tests
+so Python can resolve all imports. **These commands must run before invoking
+`pytest`.**
 
 ```bash
 pip install -e .


### PR DESCRIPTION
## Summary
- wrap long Markdown lines to satisfy MD013
- ensure docs fit within 120 characters per line

## Testing
- `npx -y markdownlint-cli2 '**/*.md' '!**/node_modules'`
- `scripts/check_docs.sh`

------
https://chatgpt.com/codex/tasks/task_e_686d6b9898848320af887edd7ee9524c