### PR TITLE
fix(cleanup): run closing step separately

### DIFF
--- a/.github/workflows/cleanup-ci-failure.yml
+++ b/.github/workflows/cleanup-ci-failure.yml
@@ -19,25 +19,27 @@ jobs:
               env:
                 GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               continue-on-error: true
-              - run: |
-                    gh_bin=$(which gh)
-                    failed=0
-                    closed=0
-                    issues=$($gh_bin issue list --label ci-failure --state open --json number --jq '.[].number') || failed=1
-                    for n in $issues; do
-                      if "$gh_bin" issue close "$n" --reason completed; then
-                        closed=$((closed+1))
-                      else
-                        failed=1
-                      fi
-                    done
-                    if [ "$failed" -ne 0 ]; then
-                      echo "::error::Cleanup failed"
-                      "$gh_bin" issue create --title "Cleanup CI failure issues failed" \
-                        --body "Automatic cleanup could not close one or more ci-failure issues." \
-                        --label ci-failure || true
-                      exit 1
-                    fi
-                    echo "Closed $closed ci-failure issues"
+
+            - name: Close ci-failure issues
+              run: |
+                gh_bin=$(which gh)
+                failed=0
+                closed=0
+                issues=$($gh_bin issue list --label ci-failure --state open --json number --jq '.[].number') || failed=1
+                for n in $issues; do
+                  if "$gh_bin" issue close "$n" --reason completed; then
+                    closed=$((closed+1))
+                  else
+                    failed=1
+                  fi
+                done
+                if [ "$failed" -ne 0 ]; then
+                  echo "::error::Cleanup failed"
+                  "$gh_bin" issue create --title "Cleanup CI failure issues failed" \
+                    --body "Automatic cleanup could not close one or more ci-failure issues." \
+                    --label ci-failure || true
+                  exit 1
+                fi
+                echo "Closed $closed ci-failure issues"
               env:
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,8 @@ All notable changes to this project will be recorded in this file.
 - Clarified that `pip install -e .` and `pip install -r requirements-dev.txt` must run before executing tests.
 
 - Removed the Codecov badge from the README and deleted the upload step.
+- Fixed indentation in `cleanup-ci-failure.yml` so the closing step runs as a
+  separate action and prints `Closed N ci-failure issues` on success.
 - Updated README star and issue links to point to the repository.
 - CI now commits a coverage.svg badge using coverage-summary.md.
 

--- a/docs/ci-failure-issues.md
+++ b/docs/ci-failure-issues.md
@@ -107,4 +107,7 @@ Schedule it with a `schedule:` trigger if you want regular cleanup.
   verify the token scopes in `gh_cli.log`.
 - Download `gh_cli.log` and `audit.md` from the run's **Artifacts** section to
   inspect GitHub CLI output and the log audit summary.
+- Downloading workflow run logs with `curl` or `gh run download` requires a
+  token granted the `actions: read` scope. The built-in `GITHUB_TOKEN` only
+  works inside GitHub Actions.
 - Duplicate or missing issues are usually caused by insufficient token permissions or leftover issues from earlier runs.


### PR DESCRIPTION
## Summary
- ensure cleanup job closes stale CI failure issues in its own step
- clarify token requirements for downloading logs
- note workflow update in the changelog

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686d706106388320966ef7a15a2f0a75