### PR TITLE
Add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,35 @@
+# Security Policy
+
+Thanks for helping make DevOnboarder safe for everyone.
+
+## Supported Versions
+
+We actively maintain the latest release line. Security fixes are backported for
+minor versions released in the last six months. The project targets Python 3.12
+and Node.js 20.
+
+| Version | Supported |
+| ------- | --------- |
+| 0.1.x   | :white_check_mark: |
+| < 0.1   | :x: |
+
+## Reporting a Vulnerability
+
+If you believe you have found a security issue, please contact us via
+<security@example.com>. **Do not report vulnerabilities through public GitHub
+issues, discussions or pull requests.**
+
+Please include as much information as possible:
+
+- A description of the issue and its impact
+- Steps to reproduce the vulnerability
+- Any relevant logs or screenshots
+
+## Response Timeframe
+
+We strive to acknowledge security reports within two business days and provide a
+status update or fix within 30 days.
+
+## Reference
+
+This policy follows [GitHub's standard security policy](https://github.com/github/.github/blob/main/SECURITY.md) format.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be recorded in this file.
 
 ## [Unreleased]
+- Added SECURITY.md outlining supported versions, reporting instructions, and a
+  30-day response timeframe.
 
 - Documented troubleshooting steps for CI failure issues.
 - Documented CI environment variables used in the workflows.


### PR DESCRIPTION
## Summary
- add SECURITY.md following GitHub's standard policy
- note supported versions and response timeframe
- mention policy in changelog

## Testing
- `ruff check .`
- `pytest --cov=src --cov-fail-under=95`
- `bash scripts/check_docs.sh`

------
https://chatgpt.com/codex/tasks/task_e_686d740e48e48320baba1a9cc33a0059