### PR TITLE
Add Contributor Covenant Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,129 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+<contact@example.com>.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the
+[Contributor Covenant](https://www.contributor-covenant.org/), version 2.1,
+available at
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct/>.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/inclusion).
+
+For answers to common questions about this code of conduct, see the FAQ at
+<https://www.contributor-covenant.org/faq/>. Translations are available at
+<https://www.contributor-covenant.org/translations/>.
+

--- a/README.md
+++ b/README.md
@@ -58,30 +58,31 @@ Workflow documentation lives under the [docs/](docs/) directory. New contributor
 8. Review [docs/alpha/README.md](docs/alpha/README.md) if you are an early tester.
 9. See [docs/founders/README.md](docs/founders/README.md) for Founder's Circle guidelines.
 10. Follow our [emails/style-guide.md](emails/style-guide.md) when crafting invitations.
-11. Check [docs/sample-pr.md](docs/sample-pr.md) for a small example update.
-12. Review [docs/first-pr-guide.md](docs/first-pr-guide.md) for a full pull request walkthrough.
-13. View the [docs/architecture.svg](docs/architecture.svg) diagram for an overview of our services.
-14. Run `./scripts/check_docs.sh` to lint documentation with **Vale**.
+11. Review our [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) to learn our community expectations.
+12. Check [docs/sample-pr.md](docs/sample-pr.md) for a small example update.
+13. Review [docs/first-pr-guide.md](docs/first-pr-guide.md) for a full pull request walkthrough.
+14. View the [docs/architecture.svg](docs/architecture.svg) diagram for an overview of our services.
+15. Run `./scripts/check_docs.sh` to lint documentation with **Vale**.
     - The script automatically downloads Vale if it isn’t installed and
       prints a warning if the download fails. See
       [docs/README.md#documentation-quality-checks](docs/README.md#documentation-quality-checks)
       for more details.
     - LanguageTool checks are optional; start a local server and set
       `LANGUAGETOOL_URL` to enable them.
-15. Install the Vale CLI (version 3.12.0+) with `brew install vale` on macOS or
+16. Install the Vale CLI (version 3.12.0+) with `brew install vale` on macOS or
     `choco install vale` on Windows. You can also download it from the
     [Vale releases page](https://github.com/errata-ai/vale/releases).
     If the binary isn't in your `PATH`, set the `VALE_BINARY` environment variable
     and install Python dependencies from `requirements-dev.txt` so the
     documentation checks work locally.
-16. Browse the [agents overview](agents/index.md) for individual service specs.
-17. Keep the sentinel word `Potato` and the file `Potato.md` listed in `.gitignore`,
+17. Browse the [agents overview](agents/index.md) for individual service specs.
+18. Keep the sentinel word `Potato` and the file `Potato.md` listed in `.gitignore`,
     `.dockerignore`, and `.codespell-ignore`.
     See [AGENTS.md](AGENTS.md) for the full policy. Both pre-commit and CI run `scripts/check_potato_ignore.sh`
     to confirm the entries exist. Do not remove them without approval.
-18. Review the [builder ethics dossier](docs/builder_ethics_dossier.md)
+19. Review the [builder ethics dossier](docs/builder_ethics_dossier.md)
     outlining contributor ethics and a simple template.
-19. Prefix a commit message with `[no-ci]` to skip the CI workflow on direct pushes. Pull requests always run CI. See
+20. Prefix a commit message with `[no-ci]` to skip the CI workflow on direct pushes. Pull requests always run CI. See
     [AGENTS.md](AGENTS.md) for details.
 
 These files expand on the steps listed in the Quickstart section.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be recorded in this file.
 - Added SECURITY.md outlining supported versions, reporting instructions, and a
   30-day response timeframe.
 
+- Added CODE_OF_CONDUCT.md using the Contributor Covenant and linked it from the README and onboarding docs.
 - Documented troubleshooting steps for CI failure issues.
 - Documented CI environment variables used in the workflows.
 - Warns when the CI failure issue search fails and logs the message in `gh_cli.log`.

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -2,6 +2,7 @@
 
 This page collects helpful tips for new contributors. Follow
 [docs/README.md](README.md) for a complete development setup.
+Please review our [Code of Conduct](../CODE_OF_CONDUCT.md) before contributing.
 
 ## Requesting a Codex QA Assessment
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -108,6 +108,7 @@ platforms. Please report any issues you encounter on your operating system.
 - [Automatic Codex issue closing](codex-issue-autoclose.md)
   &ndash; merged PRs with `Fixes #<issue>` close the linked Codex ticket.
 - [Changelog](CHANGELOG.md) &ndash; record notable updates for each release.
+- [Code of Conduct](../CODE_OF_CONDUCT.md) &ndash; expected behavior in our community.
 - [CI failure issue management](ci-failure-issues.md)
   &ndash; how automatic cleanup works and how to close old issues.
 - [CI workflow](ci-workflow.md)

--- a/docs/doc-quality-onboarding.md
+++ b/docs/doc-quality-onboarding.md
@@ -2,6 +2,7 @@
 
 ## 🚀 Quickstart for Contributors
 
+Please review our [Code of Conduct](../CODE_OF_CONDUCT.md) before contributing.
 Welcome to the project! Documentation style is checked with **markdownlint** and
 **Vale**. Grammar checks with **LanguageTool** are optional.
 


### PR DESCRIPTION
## Summary
- add CODE_OF_CONDUCT.md
- link to code of conduct from README and onboarding docs
- document in changelog

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686d760997788320af997f05f1b08474