### PR TITLE
Add network exception list test

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -612,6 +612,7 @@ All notable changes to this project will be recorded in this file.
 - Linked the network exception list from the docs overview so newcomers can find firewall rules.
  - The cleanup workflow now exits with an error when any `gh` command fails and opens a follow-up issue.
 - The cleanup workflow prints `Closed N ci-failure issues` on success or `::error::Cleanup failed` in the job log.
+- Added tests for `scripts/show_network_exceptions.sh` validating the domain list matches the documentation.
 ## [0.1.0] - 2025-06-14
 
 - Added `src/app.py` with `greet` function and updated smoke tests.

--- a/tests/test_show_network_exceptions.py
+++ b/tests/test_show_network_exceptions.py
@@ -1,0 +1,38 @@
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+
+def parse_domains(doc_path: Path) -> list[str]:
+    pattern = re.compile(r"^[A-Za-z0-9.-]+\.(?:com|org|io|sh)$")
+    domains = []
+    for line in doc_path.read_text(encoding="utf-8").splitlines():
+        if line.startswith("- "):
+            for token in line.split():
+                token = token.strip("`")
+                if pattern.fullmatch(token):
+                    domains.append(token)
+    return domains
+
+
+def test_show_network_exceptions(tmp_path):
+    """Output of show_network_exceptions.sh matches the doc."""
+    repo_root = Path(__file__).resolve().parents[1]
+    script = repo_root / "scripts" / "show_network_exceptions.sh"
+    docs_dst = tmp_path / "docs"
+    scripts_dst = tmp_path / "scripts"
+    docs_dst.mkdir()
+    scripts_dst.mkdir()
+    shutil.copy(repo_root / "docs" / "network-exception-list.md", docs_dst / "network-exception-list.md")
+    shutil.copy(script, scripts_dst / "show_network_exceptions.sh")
+
+    result = subprocess.check_output(
+        ["bash", str(scripts_dst / "show_network_exceptions.sh")],
+        cwd=tmp_path,
+        text=True,
+    )
+
+    output_domains = result.strip().splitlines()
+    expected_domains = parse_domains(repo_root / "docs" / "network-exception-list.md")
+    assert output_domains == expected_domains


### PR DESCRIPTION
## Summary
- add pytest for `show_network_exceptions.sh`
- note new test in changelog

## Testing
- `pip install -e .`
- `pip install -r requirements-dev.txt`
- `pytest --cov=src --cov-fail-under=95`

------
https://chatgpt.com/codex/tasks/task_e_686d77c0028c83208d6f82035353c3fa