### PR TITLE
Update doc quality checks

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -196,6 +196,8 @@ See [doc-quality-onboarding.md](doc-quality-onboarding.md) for a step-by-step gu
 - Install Python dev dependencies with `pip install -r requirements-dev.txt`.
 - Set `LANGUAGETOOL_URL` when running your own LanguageTool server if you want
   local grammar checks. See the [LanguageTool HTTP server guide](https://dev.languagetool.org/http-server).
+- Markdown files must not exceed 120 characters per line (MD013). See
+  [doc-quality-onboarding.md](doc-quality-onboarding.md) for details.
 
 ## Issues and Pull Requests
 


### PR DESCRIPTION
## Summary
- note 120-char line length rule in docs README

## Testing
- `CI=1 bash scripts/check_docs.sh`
- `ruff check .` *(fails: line too long)*
- `pytest` *(fails: ModuleNotFoundError: fastapi)*
- `npm run coverage` in bot *(fails: jest not found)*
- `npm run coverage` in frontend *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d7a869ef483209253bc3113f1dfa3