### PR TITLE
DOCS(commit-style): Use uppercase commit types

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ All contributors **must** follow these standards for commit messages:
 #### Example
 
 ```plaintext
-docs: Document built-in GITHUB_TOKEN usage for CI failure issues
+DOCS(ci): Document built-in GITHUB_TOKEN usage for CI failure issues
 
 - Clarifies workflow token use in README
 - Updates changelog with policy details

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be recorded in this file.
 - Wrapped long documentation lines to satisfy markdownlint rule MD013.
 - Additional documentation line wrapping for MD013.
 - Clarified that `pip install -e .` and `pip install -r requirements-dev.txt` must run before executing tests.
+- Updated AGENTS and the first PR guide to use uppercase commit types.
 
 - Removed the Codecov badge from the README and deleted the upload step.
 - Fixed indentation in `cleanup-ci-failure.yml` so the closing step runs as a

--- a/docs/first-pr-guide.md
+++ b/docs/first-pr-guide.md
@@ -24,7 +24,7 @@ It assumes you have already set up Docker, Node.js and Python as described in th
 5. **Commit and push** your work.
    ```bash
    git add <files>
-   git commit -m "docs(first-pr): Add walkthrough"
+   git commit -m "DOCS(first-pr): Add walkthrough"
    git push origin feature/my-first-change
    ```
 6. **Open a pull request** on GitHub and fill out the template. CI must pass before the PR can be merged.

--- a/docs/git-guidelines.md
+++ b/docs/git-guidelines.md
@@ -31,6 +31,9 @@ Add login form UI
 Includes basic username and password fields.
 ```
 
+Commit types like `FEAT`, `FIX` and `DOCS` must be uppercase as shown in
+[AGENTS.md](../AGENTS.md).
+
 Summarize the purpose of the change in the first line. For example:
 
 ```text


### PR DESCRIPTION
## Summary
- update AGENTS.md example to use an uppercase commit type
- show an uppercase commit example in first-pr-guide
- note the uppercase requirement in git-guidelines
- record the change in the changelog

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686db30818ac832098ec426f83383539