### PR TITLE
chore(ci): enforce markdownlint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,60 +1,61 @@
+---
 repos:
-    - repo: https://github.com/psf/black
-      rev: 24.3.0
-      hooks:
-          - id: black
-    - repo: https://github.com/charliermarsh/ruff-pre-commit
-      rev: v0.12.0
-      hooks:
-          - id: ruff
-    - repo: https://github.com/pre-commit/mirrors-prettier
-      rev: v3.6.2
-      hooks:
-          - id: prettier
-    - repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v4.4.0
-      hooks:
-          - id: trailing-whitespace
-          - id: end-of-file-fixer
+  - repo: https://github.com/psf/black
+    rev: 24.3.0
+    hooks:
+      - id: black
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.12.0
+    hooks:
+      - id: ruff
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v3.6.2
+    hooks:
+      - id: prettier
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.1
     hooks:
-        - id: codespell
-          files: '\.(md|txt|rst)$'
-          args: ["--ignore-words=.codespell-ignore"]
+      - id: codespell
+        files: '\.(md|txt|rst)$'
+        args: ["--ignore-words=.codespell-ignore"]
   - repo: https://github.com/DavidAnson/markdownlint-cli2
     rev: v0.18.1
     hooks:
-        - id: markdownlint-cli2
+      - id: markdownlint-cli2
   - repo: local
-      hooks:
-          - id: docs-quality
-            name: Docs quality checks
-            entry: bash scripts/check_docs.sh
-            language: system
-            files: \.md$
-          - id: potato-ignore-check
-            name: Potato ignore policy
-            entry: bash scripts/check_potato_ignore.sh
-            language: system
-          - id: env-docs-check
-            name: Environment docs check
-            entry: python scripts/check_env_docs.py
-            language: system
-          - id: frontend-eslint
-            name: Frontend ESLint
-            entry: bash -c 'cd frontend && npm run lint'
-            language: system
-            pass_filenames: false
-            working_directory: frontend
-          - id: bot-eslint
-            name: Bot ESLint
-            entry: bash -c 'cd bot && npm run lint'
-            language: system
-            pass_filenames: false
-            working_directory: bot
-          - id: pytest
-            name: Python tests
-            entry: pytest --cov=src --cov-fail-under=95
-            language: system
-            enabled: false
+    hooks:
+      - id: docs-quality
+        name: Docs quality checks
+        entry: bash scripts/check_docs.sh
+        language: system
+        files: \.md$
+      - id: potato-ignore-check
+        name: Potato ignore policy
+        entry: bash scripts/check_potato_ignore.sh
+        language: system
+      - id: env-docs-check
+        name: Environment docs check
+        entry: python scripts/check_env_docs.py
+        language: system
+      - id: frontend-eslint
+        name: Frontend ESLint
+        entry: bash -c 'cd frontend && npm run lint'
+        language: system
+        pass_filenames: false
+        working_directory: frontend
+      - id: bot-eslint
+        name: Bot ESLint
+        entry: bash -c 'cd bot && npm run lint'
+        language: system
+        pass_filenames: false
+        working_directory: bot
+      - id: pytest
+        name: Python tests
+        entry: pytest --cov=src --cov-fail-under=95
+        language: system
+        enabled: false

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,8 @@ All notable changes to this project will be recorded in this file.
 - CI workflow caches Playwright browsers to reuse ~/.cache/ms-playwright.
 - Skip Codex container setup when running in CI.
 - Added `markdownlint-cli2` to documentation checks and pre-commit.
+- `check_docs.sh` now runs `markdownlint-cli2 "**/*.md"` before Vale and the
+  doc-quality guide notes this dependency.
 - Codex now attempts `ruff --fix` and `pre-commit run --files` when linting fails
   and commits the patch automatically if safe. Otherwise it opens a "chore:
   auto-fix lint errors via Codex" pull request.

--- a/docs/doc-quality-onboarding.md
+++ b/docs/doc-quality-onboarding.md
@@ -15,6 +15,9 @@ pip install -r requirements-dev.txt
 npm install
 ```
 
+`npm install` installs **markdownlint-cli2**, which `scripts/check_docs.sh` runs
+before Vale to enforce Markdown style.
+
 Run these commands **before executing tests or documentation checks** so Python
 imports resolve correctly.
 

--- a/scripts/check_docs.sh
+++ b/scripts/check_docs.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Run markdownlint on all Markdown files (excluding dependencies)
+# Run markdownlint-cli2 on all Markdown files before Vale
 set +e
-npx markdownlint-cli2 '**/*.md' '!**/node_modules'
+npx markdownlint-cli2 "**/*.md"
 ml_status=$?
 set -e
 if [ $ml_status -ne 0 ]; then


### PR DESCRIPTION
## Summary
- run markdownlint-cli2 in check_docs.sh before Vale
- mention markdownlint requirement in doc-quality guide
- note new docs quality step in changelog
- tidy pre-commit config and include markdownlint hook

## Testing
- `pre-commit run --files docs/CHANGELOG.md docs/doc-quality-onboarding.md scripts/check_docs.sh .pre-commit-config.yaml` *(fails: CalledProcessError: checkout v3.6.2)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `bash scripts/check_docs.sh` *(fails: interactive npm prompt)*

------
https://chatgpt.com/codex/tasks/task_e_686d604c30e883209fe825bfae628a27