### PR TITLE
Add pip-audit to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,16 @@ jobs:
                       echo "Pip install failed. See docs/offline-setup.md for offline instructions." >&2
                       exit 1
                   }
+            - name: Python dependency audit
+              run: |
+                  if ! pip-audit; then
+                      code=$?
+                      if [ "$code" -eq 1 ]; then
+                          exit 1
+                      else
+                          echo "pip-audit failed. See docs/offline-setup.md for offline instructions." >&2
+                      fi
+                  fi
             - name: Run Black
               run: black --check .
             - name: Validate env docs

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -38,6 +38,7 @@ All notable changes to this project will be recorded in this file.
   and commits the patch automatically if safe. Otherwise it opens a "chore:
   auto-fix lint errors via Codex" pull request.
 - Added Bandit and npm audit checks to fail CI when high severity issues are found.
+- `scripts/security_audit.sh` now exits with code 1 when `pip-audit` reports vulnerabilities, and CI runs `pip-audit` after installing Python requirements with offline guidance on failures.
 - Install the GitHub CLI in CI using the preinstalled binary or
   `scripts/install_gh_cli.sh`.
 - `scripts/trivy_scan.sh` now downloads the pinned Trivy release tarball instead

--- a/docs/README.md
+++ b/docs/README.md
@@ -241,3 +241,4 @@ bash scripts/security_audit.sh
 The script runs `pip-audit`, `bandit -r src -ll`, and `npm audit --audit-level=high`
 in both `frontend/` and `bot/`. Each command fails when vulnerabilities are
 detected.
+CI also runs `pip-audit` immediately after installing Python requirements. If this step fails to reach the vulnerability database, see [docs/offline-setup.md](offline-setup.md).

--- a/scripts/security_audit.sh
+++ b/scripts/security_audit.sh
@@ -10,9 +10,12 @@ OUT="docs/security-audit-${DATE}.md"
   echo "We ran dependency audits for Python and Node packages and scanned the code with Bandit."
   echo
   echo "## Python (\`pip-audit\`)"
-  if pip-audit >/tmp/pip_audit.log 2>&1; then
-    cat /tmp/pip_audit.log
-  else
+  audit_status=0
+  pip-audit >/tmp/pip_audit.log 2>&1 || audit_status=$?
+  cat /tmp/pip_audit.log
+  if [ "$audit_status" -eq 1 ]; then
+    exit 1
+  elif [ "$audit_status" -gt 1 ]; then
     echo "\`pip-audit\` could not complete in the Codex environment due to restricted network access."
   fi
   echo


### PR DESCRIPTION
## Summary
- make `security_audit.sh` fail when `pip-audit` finds issues
- run `pip-audit` early in CI after installing Python requirements
- document the new audit step
- log the change in the changelog

## Testing
- `ruff check scripts/security_audit.sh .github/workflows/ci.yml docs/README.md docs/CHANGELOG.md`
- `pytest --cov=src --cov-fail-under=95`
- `bash scripts/check_docs.sh` *(fails: Markdownlint issues found)*

------
https://chatgpt.com/codex/tasks/task_e_686e6addbd648320bde235927607d84a