### PR TITLE
Add Node engines requirement

### DIFF
--- a/bot/package.json
+++ b/bot/package.json
@@ -28,21 +28,24 @@
     "preset": "ts-jest",
     "testEnvironment": "node",
     "collectCoverage": true,
-  "coverageReporters": [
-    "text",
-    "lcov"
-  ],
-  "coveragePathIgnorePatterns": [
-    "<rootDir>/src/commands",
-    "<rootDir>/src/utils/loadFiles.ts"
-  ],
-  "coverageThreshold": {
-    "global": {
-      "branches": 95,
-      "functions": 95,
-      "lines": 95,
+    "coverageReporters": [
+      "text",
+      "lcov"
+    ],
+    "coveragePathIgnorePatterns": [
+      "<rootDir>/src/commands",
+      "<rootDir>/src/utils/loadFiles.ts"
+    ],
+    "coverageThreshold": {
+      "global": {
+        "branches": 95,
+        "functions": 95,
+        "lines": 95,
         "statements": 95
       }
     }
+  },
+  "engines": {
+    "node": ">=20"
   }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -619,6 +619,7 @@ All notable changes to this project will be recorded in this file.
  - The cleanup workflow now exits with an error when any `gh` command fails and opens a follow-up issue.
 - The cleanup workflow prints `Closed N ci-failure issues` on success or `::error::Cleanup failed` in the job log.
 - Added tests for `scripts/show_network_exceptions.sh` validating the domain list matches the documentation.
+- Required Node.js 20+ via the `engines` field in all package.json files.
   
 ## [0.1.0] - 2025-06-14
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,40 +1,43 @@
 {
-    "name": "devonboarder-frontend",
-    "version": "0.1.0",
-    "license": "MIT",
-    "private": true,
-    "scripts": {
-        "dev": "vite",
-        "build": "vite build",
-        "preview": "vite preview",
-        "start": "vite",
-        "test": "vitest run --coverage",
-        "coverage": "vitest run --coverage",
-        "test:e2e": "playwright test",
-        "test:a11y": "playwright test e2e/accessibility.spec.ts",
-        "perf": "npm run build && lhci autorun",
-        "lint": "eslint \"src/**/*.{js,ts,tsx}\"",
-        "format": "prettier --write \"src/**/*.{js,ts,tsx}\""
-    },
-    "dependencies": {
-        "react": "^19.1.0",
-        "react-dom": "^19.1.0"
-    },
-    "devDependencies": {
-        "@axe-core/playwright": "^4.10.2",
-        "@lhci/cli": "^0.15.1",
-        "@playwright/test": "^1.53.2",
-        "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.3.0",
-        "@types/react": "^19.1.8",
-        "@types/react-dom": "^19.1.6",
-        "@vitejs/plugin-react": "^4.6.0",
-        "@vitest/coverage-v8": "^3.2.4",
-        "eslint": "^9.30.0",
-        "jsdom": "^26.1.0",
-        "prettier": "^3.6.2",
-        "typescript": "^5.8.3",
-        "vite": "^7.0.2",
-        "vitest": "^3.2.4"
-    }
+  "name": "devonboarder-frontend",
+  "version": "0.1.0",
+  "license": "MIT",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "start": "vite",
+    "test": "vitest run --coverage",
+    "coverage": "vitest run --coverage",
+    "test:e2e": "playwright test",
+    "test:a11y": "playwright test e2e/accessibility.spec.ts",
+    "perf": "npm run build && lhci autorun",
+    "lint": "eslint \"src/**/*.{js,ts,tsx}\"",
+    "format": "prettier --write \"src/**/*.{js,ts,tsx}\""
+  },
+  "dependencies": {
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0"
+  },
+  "devDependencies": {
+    "@axe-core/playwright": "^4.10.2",
+    "@lhci/cli": "^0.15.1",
+    "@playwright/test": "^1.53.2",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.3.0",
+    "@types/react": "^19.1.8",
+    "@types/react-dom": "^19.1.6",
+    "@vitejs/plugin-react": "^4.6.0",
+    "@vitest/coverage-v8": "^3.2.4",
+    "eslint": "^9.30.0",
+    "jsdom": "^26.1.0",
+    "prettier": "^3.6.2",
+    "typescript": "^5.8.3",
+    "vite": "^7.0.2",
+    "vitest": "^3.2.4"
+  },
+  "engines": {
+    "node": ">=20"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -3,5 +3,8 @@
   "private": true,
   "devDependencies": {
     "markdownlint-cli2": "^0.18.1"
+  },
+  "engines": {
+    "node": ">=20"
   }
 }


### PR DESCRIPTION
## Summary
- require Node 20 in all package manifests
- document Node engines requirement in changelog

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686e6c1a03bc83209de56403ebad1b9e