### PR TITLE
Install markdownlint-cli2 offline for docs lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,12 @@ jobs:
               run: ruff check --output-format=github .
             - name: Run mypy
               run: mypy src/devonboarder
+            - name: Install docs dependencies
+              run: |
+                  npm ci || {
+                      echo "npm install failed. See docs/offline-setup.md for offline instructions." >&2
+                      exit 1
+                  }
             - name: Install Vale
               run: |
                   curl -fsSL https://github.com/errata-ai/vale/releases/download/v3.12.0/vale_3.12.0_Linux_64-bit.tar.gz | tar xz # pinned version

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -34,6 +34,8 @@ All notable changes to this project will be recorded in this file.
 - Added `markdownlint-cli2` to documentation checks and pre-commit.
 - `check_docs.sh` now runs `markdownlint-cli2 "**/*.md"` before Vale and the
   doc-quality guide notes this dependency.
+- CI installs markdownlint dependencies before running documentation checks and
+  uses `npx -y` with an offline hint on failure.
 - Codex now attempts `ruff --fix` and `pre-commit run --files` when linting fails
   and commits the patch automatically if safe. Otherwise it opens a "chore:
   auto-fix lint errors via Codex" pull request.

--- a/scripts/check_docs.sh
+++ b/scripts/check_docs.sh
@@ -3,11 +3,11 @@ set -euo pipefail
 
 # Run markdownlint-cli2 on all Markdown files before Vale
 set +e
-npx markdownlint-cli2 "**/*.md"
+npx -y markdownlint-cli2 "**/*.md"
 ml_status=$?
 set -e
 if [ $ml_status -ne 0 ]; then
-  echo "::warning file=scripts/check_docs.sh,line=$LINENO::Markdownlint issues found"
+  echo "::warning file=scripts/check_docs.sh,line=$LINENO::Markdownlint issues found. See docs/offline-setup.md for offline instructions."
 fi
 
 FILES=$(git ls-files '*.md')


### PR DESCRIPTION
## Summary
- ensure CI installs doc lint dependencies at the repo root
- run `npx -y markdownlint-cli2` with offline hint in `check_docs.sh`
- note doc lint dependency handling in the changelog

## Testing
- `pre-commit run --files scripts/check_docs.sh .github/workflows/ci.yml docs/CHANGELOG.md` *(fails: pathspec 'v3.6.2' did not match any file)*
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686e6f36314483208e4891447d1ae941