### PR TITLE
Add Dependabot documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,3 +18,4 @@ pre-commit install
 The hook prevents bad commit messages from reaching CI. See
 [docs/git-guidelines.md](docs/git-guidelines.md) for style rules and
 [docs/README.md](docs/README.md) for environment setup tips.
+See [docs/dependencies.md](docs/dependencies.md) for the Dependabot update workflow.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -652,3 +652,4 @@ All notable changes to this project will be recorded in this file.
 - Added Black formatting checks in CI. The workflow runs `black --check .` after installing dev dependencies.
 - Logged `gh auth status` before creating CI failure issues and stopped the job
   when the GitHub CLI exits with an error.
+- Documented Dependabot PR review steps in docs/dependencies.md and linked the page from CONTRIBUTING.

--- a/docs/README.md
+++ b/docs/README.md
@@ -144,6 +144,7 @@ platforms. Please report any issues you encounter on your operating system.
 - [First PR walkthrough](first-pr-guide.md) &ndash; clone, install hooks and open your first pull request.
 - [Service architecture diagram](architecture.svg) &ndash; high-level view of the auth, XP API, frontend and bot.
 - [Security audit](security-audit-2025-07-01.md) &ndash; latest dependency check results.
+- [Dependency update policy](dependencies.md) &ndash; how Dependabot PRs are reviewed and merged.
 - [FIPS compliance for Go services](fips-golang.md) &ndash; guidelines for running a Go project in FIPS mode.
 - [Builder ethics dossier](builder_ethics_dossier.md) &ndash; outlines contributor ethics and provides a template.
 - [Task management](task-management.md) &ndash; archive completed items in `codex.tasks.json`.

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -1,0 +1,11 @@
+# Dependency Update Process
+
+Dependabot checks our npm and pip packages every week. It opens pull requests when new versions are available.
+Maintainers review each PR as follows:
+
+- Verify CI passes without new warnings or test failures.
+- Read the release notes to spot breaking changes.
+- Update the changelog entry if a significant upgrade lands.
+- Merge the PR using the squash option once checks succeed.
+
+They follow [merge-checklist.md](merge-checklist.md) before finalizing the pull request.


### PR DESCRIPTION
## Summary
- document Dependabot update policy
- link new page from the docs overview and CONTRIBUTING
- note Dependabot review policy in the changelog

## Testing
- `bash scripts/run_tests.sh`
- `bash scripts/check_docs.sh`

------
https://chatgpt.com/codex/tasks/task_e_686e72be718883208357a9e002da57bd