### PR TITLE
Add offline coverage badge option

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ docker compose -f docker-compose.prod.yaml --env-file .env.prod up -d
    npm run coverage --prefix bot
    npm run coverage --prefix frontend
    ```
+   Set `OFFLINE_BADGE=1` if `img.shields.io` is unreachable to skip the badge
+   update.
    **Note:** both installs must finish before running `pytest` or the tests may
    fail with `ModuleNotFoundError`. See
    [tests/README.md](tests/README.md) for details.

--- a/docs/offline-setup.md
+++ b/docs/offline-setup.md
@@ -103,3 +103,10 @@ Use `scripts/trivy_scan.sh` to scan the images built with `docker-compose.ci.yam
    ```
 
 The hooks will run without needing network access.
+
+## Coverage badge
+
+`scripts/update_coverage_badge.py` contacts `img.shields.io` to generate the
+coverage badge. Set `OFFLINE_BADGE=1` before running the script to skip the
+request. When the variable is set, the script uses `scripts/offline_badge_template.svg`
+if present or prints a message that badge generation was skipped.

--- a/scripts/offline_badge_template.svg
+++ b/scripts/offline_badge_template.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="108" height="20" role="img" aria-label="coverage: {pct}">
+  <title>coverage: {pct}</title>
+  <linearGradient id="s" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+  <clipPath id="r">
+    <rect width="108" height="20" rx="3" fill="#fff"/>
+  </clipPath>
+  <g clip-path="url(#r)">
+    <rect width="61" height="20" fill="#555"/>
+    <rect x="61" width="47" height="20" fill="{color}"/>
+    <rect width="108" height="20" fill="url(#s)"/>
+  </g>
+  <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
+    <text aria-hidden="true" x="315" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="510">coverage</text>
+    <text x="315" y="140" transform="scale(.1)" fill="#fff" textLength="510">coverage</text>
+    <text aria-hidden="true" x="835" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370">{pct}</text>
+    <text x="835" y="140" transform="scale(.1)" fill="#fff" textLength="370">{pct}</text>
+  </g>
+</svg>

--- a/scripts/update_coverage_badge.py
+++ b/scripts/update_coverage_badge.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import re
 import sys
+import os
 from pathlib import Path
 
 import requests
@@ -29,6 +30,25 @@ def badge_color(pct: float) -> str:
 
 
 def fetch_badge(pct: float) -> bytes:
+    """Return an SVG badge for the given coverage percentage."""
+    if os.getenv("OFFLINE_BADGE") == "1":
+        template = Path("scripts/offline_badge_template.svg")
+        if template.exists():
+            color_map = {
+                "brightgreen": "#4c1",
+                "yellow": "#dfb317",
+                "orange": "#fe7d37",
+                "red": "#e05d44",
+            }
+            color = color_map[badge_color(pct)]
+            return (
+                template.read_text(encoding="utf-8")
+                .format(pct=f"{pct:.1f}%", color=color)
+                .encode()
+            )
+        print("OFFLINE_BADGE=1 set; skipping badge generation")
+        return b""
+
     color = badge_color(pct)
     url = f"https://img.shields.io/badge/coverage-{pct:.1f}%25-{color}.svg"
     resp = requests.get(url, timeout=10)
@@ -41,8 +61,9 @@ def main() -> None:
     output = Path(sys.argv[2] if len(sys.argv) > 2 else "coverage.svg")
     pct = read_coverage(summary)
     svg = fetch_badge(pct)
-    output.write_bytes(svg)
-    print(f"Badge updated to {pct:.1f}%")
+    if svg:
+        output.write_bytes(svg)
+        print(f"Badge updated to {pct:.1f}%")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- allow skipping the badge fetch with `OFFLINE_BADGE=1`
- provide local badge template for offline mode
- document the environment variable in offline setup instructions
- mention offline badge generation in README

## Testing
- `ruff check scripts/update_coverage_badge.py docs/offline-setup.md README.md`
- `pytest --cov=src --cov-fail-under=95`
- `bash scripts/check_docs.sh`

------
https://chatgpt.com/codex/tasks/task_e_686e7ef5602c832096137243d71e8ca5