### PR TITLE
Fix migration check quoting

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -653,3 +653,4 @@ All notable changes to this project will be recorded in this file.
 - Logged `gh auth status` before creating CI failure issues and stopped the job
   when the GitHub CLI exits with an error.
 - Documented Dependabot PR review steps in docs/dependencies.md and linked the page from CONTRIBUTING.
+- `scripts/alembic_migration_check.sh` now sets `set -euo pipefail` and quotes `$DATABASE_URL`.

--- a/scripts/alembic_migration_check.sh
+++ b/scripts/alembic_migration_check.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
-set -e
-if grep -q "sqlite" <<< "$DATABASE_URL"; then
+set -euo pipefail
+
+database_url="${DATABASE_URL:-}"
+
+if grep -q "sqlite" <<< "$database_url"; then
   alembic upgrade --sql head
 else
   echo "Non-SQLite DB; skipping SQLite-only migration check."


### PR DESCRIPTION
## Summary
- make `alembic_migration_check.sh` safer with `set -euo pipefail`
- handle empty DATABASE_URL and quote the variable
- document the update in the changelog

## Testing
- `bash scripts/run_tests.sh`
- `bash scripts/check_docs.sh`


------
https://chatgpt.com/codex/tasks/task_e_686e847f779483209ac1791a027c3310