### PR TITLE
Add shebang to check_docstrings script

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be recorded in this file.
 
 ## [Unreleased]
 
+- Added a Python shebang to `scripts/check_docstrings.py` and made the file executable.
+
 - Added SECURITY.md outlining supported versions, reporting instructions, and a
   30-day response timeframe.
 

--- a/scripts/check_docstrings.py
+++ b/scripts/check_docstrings.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """Checks that all FastAPI endpoints have docstrings.
 
 Usage: ``python scripts/check_docstrings.py [PATH]``


### PR DESCRIPTION
## Summary
- make `scripts/check_docstrings.py` executable by adding a `python3` shebang
- note the script change in the changelog

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686e88f6d410832083ad72da8ea7acb6