### PR TITLE
Handle HTTP errors in scripts

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be recorded in this file.
 
 ## [Unreleased]
 
+- Wrapped HTTP requests in scripts with try/except to exit on connection errors.
+
 - Added a Python shebang to `scripts/check_docstrings.py` and made the file executable.
 
 - Added SECURITY.md outlining supported versions, reporting instructions, and a

--- a/scripts/check_headers.py
+++ b/scripts/check_headers.py
@@ -5,12 +5,21 @@ import os
 import requests
 
 
+def _fetch_headers(url: str) -> requests.Response:
+    """Return the response from the given service URL."""
+    try:
+        return requests.get(url, timeout=5)
+    except requests.RequestException as exc:
+        print(f"Request failed: {exc}")
+        raise SystemExit(1)
+
+
 SERVICE_URL = os.getenv("CHECK_HEADERS_URL", "http://localhost:8002/api/user")
 
 
 def main() -> None:
     """Verify basic CORS and security headers."""
-    resp = requests.get(SERVICE_URL, timeout=5)
+    resp = _fetch_headers(SERVICE_URL)
     assert "Access-Control-Allow-Origin" in resp.headers, "CORS header missing"
     assert resp.headers.get("X-Content-Type-Options") == "nosniff"
     print("CORS and security headers OK")

--- a/scripts/update_coverage_badge.py
+++ b/scripts/update_coverage_badge.py
@@ -51,8 +51,12 @@ def fetch_badge(pct: float) -> bytes:
 
     color = badge_color(pct)
     url = f"https://img.shields.io/badge/coverage-{pct:.1f}%25-{color}.svg"
-    resp = requests.get(url, timeout=10)
-    resp.raise_for_status()
+    try:
+        resp = requests.get(url, timeout=10)
+        resp.raise_for_status()
+    except requests.RequestException as exc:
+        print(f"Failed to download badge: {exc}")
+        raise SystemExit(1)
     return resp.content
 
 

--- a/tests/test_check_headers.py
+++ b/tests/test_check_headers.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from fastapi.testclient import TestClient
 import requests
+import pytest
 
 # Ensure the repository root is on the import path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
@@ -30,3 +31,19 @@ def test_check_headers(monkeypatch):
     importlib.reload(module)
 
     assert module.main() is None
+
+
+def test_check_headers_error(monkeypatch, capsys):
+    """Script exits with code 1 when the request fails."""
+
+    def raise_error(url: str, timeout: int = 5):
+        raise requests.RequestException("boom")
+
+    monkeypatch.setattr(requests, "get", raise_error)
+    module = importlib.import_module("scripts.check_headers")
+    importlib.reload(module)
+
+    with pytest.raises(SystemExit) as exc:
+        module.main()
+    assert exc.value.code == 1
+    assert "Request failed" in capsys.readouterr().out


### PR DESCRIPTION
## Summary
- exit with status 1 when `requests.get` fails
- test error path for `check_headers.py`
- document robustness improvement in the changelog

## Testing
- `ruff check scripts/check_headers.py scripts/update_coverage_badge.py tests/test_check_headers.py`
- `black scripts/check_headers.py scripts/update_coverage_badge.py tests/test_check_headers.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e8b185e648320bff07d67d2c7b48d