### PR TITLE
Document Node 20 requirement

### DIFF
--- a/bot/README.md
+++ b/bot/README.md
@@ -4,9 +4,11 @@ This service implements a simple Discord bot using `discord.js` v14.
 It loads slash commands and events dynamically on startup and authenticates
 using the token provided in `.env`.
 
+Node.js 20 is required. Run `nvm install` to use the version defined in `.nvmrc`.
 ## Setup
 
-1. Copy the example environment file and add your credentials:
+1. Use Node.js 20 as specified in `.nvmrc` (run `nvm install`).
+2. Copy the example environment file and add your credentials:
    ```bash
    cp .env.example .env
    ```
@@ -14,17 +16,17 @@ using the token provided in `.env`.
    and `BOT_JWT`. The bot sends this token in an `Authorization` header
    when calling the API. See [docs/env.md](../docs/env.md) for details
    about this variable.
-2. Install dependencies and build the bot:
+3. Install dependencies and build the bot:
    ```bash
    npm install
    npm run build
    ```
-3. Lint and format the code:
+4. Lint and format the code:
    ```bash
    npm run lint
    npm run format
    ```
-4. Run the bot locally:
+5. Run the bot locally:
    ```bash
    npm start
    ```

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -630,6 +630,7 @@ All notable changes to this project will be recorded in this file.
 - The cleanup workflow prints `Closed N ci-failure issues` on success or `::error::Cleanup failed` in the job log.
 - Added tests for `scripts/show_network_exceptions.sh` validating the domain list matches the documentation.
 - Required Node.js 20+ via the `engines` field in all package.json files.
+- Documented the Node.js 20 requirement in the bot and frontend READMEs and referenced `.nvmrc`.
   
 ## [0.1.0] - 2025-06-14
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,12 +1,13 @@
 # DevOnboarder Frontend
 
 This directory houses the DevOnboarder React application built with Vite.
+Node.js 20 is required. Run `nvm install` to use the version defined in `.nvmrc`.
 
-Install dependencies with `pnpm install` (or `npm install` if `pnpm` is not
-available`). Commit the generated lockfile (`pnpm-lock.yaml` or `package-lock.json`).
-Start the development server with `npm run dev`.
-Run `npm run lint` to check code style and `npm run format` to apply Prettier formatting.
-Environment variables are defined in `.env.example`.
+## Setup
+1. Install dependencies with `pnpm install` (or `npm install` if `pnpm` is not available`). Commit the generated lockfile (`pnpm-lock.yaml` or `package-lock.json`).
+2. Start the development server with `npm run dev`.
+3. Run `npm run lint` to check code style and `npm run format` to apply Prettier formatting.
+4. Environment variables are defined in `.env.example`.
 
 ## Login Flow
 


### PR DESCRIPTION
## Summary
- note the Node.js 20 requirement for the bot
- document Node.js 20 in the frontend setup
- record the docs update in CHANGELOG

## Testing
- `pre-commit run --files bot/README.md docs/CHANGELOG.md frontend/README.md` *(fails: could not fetch prettier)*
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686e8fcf16e88320b1b6f3ba14c70f48