### PR TITLE
Add Python shebang to check_headers script

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be recorded in this file.
 
 - Added a Python shebang to `scripts/check_docstrings.py` and made the file executable.
 
+- Added a Python shebang to `scripts/check_headers.py` and made the file executable.
+
 - Added SECURITY.md outlining supported versions, reporting instructions, and a
   30-day response timeframe.
 

--- a/scripts/check_headers.py
+++ b/scripts/check_headers.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """Smoke test that verifies CORS and security headers are present."""
 
 import os


### PR DESCRIPTION
# Summary
- make `scripts/check_headers.py` executable with a Python shebang
- document the update in the changelog

# Testing
- `bash scripts/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_686e8dff69ac83209e83dcd4697b0662