### PR TITLE
Remove pnpm lockfile instructions

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be recorded in this file.
 
 - Added CODE_OF_CONDUCT.md using the Contributor Covenant and linked it from the README and onboarding docs.
 - Documented troubleshooting steps for CI failure issues.
+- Removed pnpm lockfile commit instructions from `frontend/README.md`.
 - Added mdformat to pre-commit with `--wrap 120` and documented running `pre-commit install` in CONTRIBUTING.
 - Documented CI environment variables used in the workflows.
 - Warns when the CI failure issue search fails and logs the message in `gh_cli.log`.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -4,7 +4,7 @@ This directory houses the DevOnboarder React application built with Vite.
 Node.js 20 is required. Run `nvm install` to use the version defined in `.nvmrc`.
 
 ## Setup
-1. Install dependencies with `pnpm install` (or `npm install` if `pnpm` is not available`). Commit the generated lockfile (`pnpm-lock.yaml` or `package-lock.json`).
+1. Install dependencies with `npm install` (or `pnpm install` if you prefer). Commit the generated `package-lock.json`.
 2. Start the development server with `npm run dev`.
 3. Run `npm run lint` to check code style and `npm run format` to apply Prettier formatting.
 4. Environment variables are defined in `.env.example`.


### PR DESCRIPTION
## Summary
- note that only `package-lock.json` should be committed in the frontend README
- mention the change in the changelog

## Testing
- `bash scripts/run_tests.sh`
- `ruff check .`
- `bash scripts/check_docs.sh` *(fails: Markdownlint issues found)*

------
https://chatgpt.com/codex/tasks/task_e_686e9213f33c8320b93641b55430d9ab