### PR TITLE
Update CI docs with pip-audit step

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -61,6 +61,8 @@ All notable changes to this project will be recorded in this file.
 - `scripts/check_network_access.sh` now parses `docs/network-exception-list.md` instead of using a hard-coded domain
     array.
 - Documented Bandit and npm audit steps in `docs/ci-workflow.md`.
+- Documented the pip-audit step in `docs/ci-workflow.md` with a note about
+  offline failures linking to `docs/offline-setup.md`.
 - Updated `scripts/security_audit.sh` to run Bandit and high severity `npm audit`
   checks for both `frontend/` and `bot/`.
 - `monitor-ci` now runs `ruff --fix` and `pre-commit run --files` on lint

--- a/docs/ci-workflow.md
+++ b/docs/ci-workflow.md
@@ -80,6 +80,9 @@ variables so maintainers know which entries to add to `agents/index.md`.
 
 After the environment checks, the job runs three dependency audits:
 
+- `pip-audit` runs after installing Python requirements and fails the workflow
+  if vulnerabilities are found. This step may fail without internet access; see
+  [docs/offline-setup.md](offline-setup.md).
 - `bandit -r src -ll` scans the Python code for vulnerabilities.
 - `npm audit --audit-level=high` runs in both `frontend/` and `bot/`.
 


### PR DESCRIPTION
## Summary
- document pip-audit in docs/ci-workflow
- note offline failures
- record in changelog

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686e8fc469c88320afde69c2aeca7aef