### PR TITLE
Update markdownlint offline steps

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -46,6 +46,8 @@ All notable changes to this project will be recorded in this file.
   doc-quality guide notes this dependency.
 - CI installs markdownlint dependencies before running documentation checks and
   uses `npx -y` with an offline hint on failure.
+- Documented how to cache `markdownlint-cli2` for offline runs and clarified that
+  `scripts/check_docs.sh` invokes `npx -y markdownlint-cli2`.
 - Codex now attempts `ruff --fix` and `pre-commit run --files` when linting fails
   and commits the patch automatically if safe. Otherwise it opens a "chore:
   auto-fix lint errors via Codex" pull request.

--- a/docs/doc-quality-onboarding.md
+++ b/docs/doc-quality-onboarding.md
@@ -19,6 +19,11 @@ npm install
 `npm install` installs **markdownlint-cli2**, which `scripts/check_docs.sh` runs
 before Vale to enforce Markdown style.
 
+To use `markdownlint-cli2` without internet access, run `npm ci --cache ~/devonboarder-offline/npm` on an online
+machine and copy the `devonboarder-offline` directory to your offline system. Installing from this cache lets
+`npx --offline -y markdownlint-cli2` work as expected. See [offline-setup.md](offline-setup.md#documentation-tooling-markdownlint-cli2)
+for details.
+
 Run these commands **before executing tests or documentation checks** so Python
 imports resolve correctly.
 
@@ -72,7 +77,10 @@ bash scripts/check_docs.sh
 ```
 
 This script runs `markdownlint-cli2` and Vale to lint all Markdown files. It
-generates `vale-results.json` for machine-readable output, which CI stores as an
+invokes `npx -y markdownlint-cli2` so the command never prompts for input. When
+you cache the dependency as described above you can run it offline with
+`npx --offline -y markdownlint-cli2`. The script generates `vale-results.json`
+for machine-readable output, which CI stores as an
 artifact.
 Markdownlint enforces a 120-character maximum line length via MD013 in `.markdownlint.json`.
 To check for violations manually, run:

--- a/docs/offline-setup.md
+++ b/docs/offline-setup.md
@@ -61,6 +61,27 @@ development system.
 
 After installing dependencies, run the usual setup commands such as `make deps` or `pre-commit install`.
 
+## Documentation tooling (markdownlint-cli2)
+
+`scripts/check_docs.sh` calls `npx -y markdownlint-cli2`. Cache this package so the
+command works offline:
+
+1. On the online machine, prime the npm cache from the repository root:
+
+   ```bash
+   mkdir -p ~/devonboarder-offline/npm
+   npm ci --cache ~/devonboarder-offline/npm
+   ```
+
+2. Copy the `devonboarder-offline` folder to your offline machine.
+
+3. Install the package from the cache and run the linter offline:
+
+   ```bash
+   npm ci --offline --cache /path/to/devonboarder-offline/npm
+   npx --offline -y markdownlint-cli2
+   ```
+
 ## Trivy
 
 1. On a machine with internet access, download the Trivy binary:


### PR DESCRIPTION
## Summary
- document caching markdownlint-cli2 in doc onboarding
- mention npx usage and offline caching instructions
- add offline setup steps for markdownlint
- update changelog

## Testing
- `scripts/check_docs.sh`
- `scripts/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_686e958f58848320b2521a6e5d80cef5