### PR TITLE
Recommend run_tests.sh in README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,7 +336,7 @@ jobs:
             - name: Wait for auth service
               run: bash scripts/wait_for_service.sh http://localhost:8002/health 30 2 auth
             - name: Check CORS & security headers
-              run: python scripts/check_headers.py
+              run: ./scripts/check_headers.py
               env:
                   CHECK_HEADERS_URL: http://localhost:8002/api/user
             - name: Run security audit

--- a/README.md
+++ b/README.md
@@ -180,7 +180,8 @@ docker compose -f docker-compose.prod.yaml --env-file .env.prod up -d
    **Note:** both installs must finish before running `pytest` or the tests may
    fail with `ModuleNotFoundError`. See
    [tests/README.md](tests/README.md) for details.
-8. Run `bash scripts/run_tests.sh` to execute all tests. See
+8. Run `./scripts/run_tests.sh` to install dependencies and execute all tests.
+   This wrapper prints helpful hints when packages are missing. See
    [docs/troubleshooting.md](docs/troubleshooting.md) if any failures occur.
 9. Install git hooks with `pre-commit install` so lint checks run automatically.
 10. The CI workflow enforces a minimum of **95% code coverage** for all projects

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be recorded in this file.
 - Removed pnpm lockfile commit instructions from `frontend/README.md`.
 - Added mdformat to pre-commit with `--wrap 120` and documented running `pre-commit install` in CONTRIBUTING.
 - Documented CI environment variables used in the workflows.
+- Documented `./scripts/run_tests.sh` as the preferred way to run tests.
 - Warns when the CI failure issue search fails and logs the message in `gh_cli.log`.
 - Searches the CI failure issue title and body for the commit SHA and logs the search exit code.
 - Added a first PR guide and service architecture diagram with links from the docs overview.


### PR DESCRIPTION
## Summary
- point `ci.yml` to run header check script directly
- recommend `./scripts/run_tests.sh` in README
- record the update in the changelog

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686e9d5025508320b63d5d5b20d87473