### PR TITLE
Document universal container languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,21 @@ The full recovery story lives in [docs/origin.md](docs/origin.md).
 - `config/devonboarder.config.yml` – Config for the `devonboarder` tool.
 - `.env.example` – Sample variables shared across services.
 
+## Language Versions
+
+`scripts/setup-env.sh` pulls the `ghcr.io/openai/codex-universal` image to provide a unified runtime.
+
+| Language | Version |
+| --- | --- |
+| Python | 3.12 |
+| Node.js | 20 |
+| Ruby | 3.4.4 |
+| Rust | 1.87.0 |
+| Go | 1.24.3 |
+| Bun | 1.2.14 |
+| Java | 21 |
+| Swift | 6.1 |
+
 ## Documentation and Onboarding
 
 Workflow documentation lives under the [docs/](docs/) directory. New contributors should:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -670,3 +670,5 @@ All notable changes to this project will be recorded in this file.
 - `scripts/alembic_migration_check.sh` now sets `set -euo pipefail` and quotes `$DATABASE_URL`.
 - Added a Quickstart bullet recommending `bash scripts/run_tests.sh` with a link
   to `docs/troubleshooting.md` for troubleshooting help.
+- Documented the language versions provided by `ghcr.io/openai/codex-universal`
+  and noted that `scripts/setup-env.sh` pulls this image.


### PR DESCRIPTION
## Summary
- list language versions in the universal Codex image
- note that `scripts/setup-env.sh` pulls the image

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686e9f01b5348320981cdb85731b75d1