### PR TITLE
Update docs for commit-msg hook

### DIFF
--- a/docs/first-pr-guide.md
+++ b/docs/first-pr-guide.md
@@ -8,25 +8,29 @@ It assumes you have already set up Docker, Node.js and Python as described in th
    git clone https://github.com/your-username/DevOnboarder.git
    cd DevOnboarder
    ```
-2. **Install git hooks** so lint and test checks run before each commit.
+2. **Install the commit message hook** so your commits pass CI checks.
+   ```bash
+   bash scripts/install_commit_msg_hook.sh
+   ```
+3. **Install git hooks** so lint and test checks run before each commit.
    ```bash
    pre-commit install
    ```
-3. **Create a branch** from `main` for your change.
+4. **Create a branch** from `main` for your change.
    ```bash
    git checkout -b feature/my-first-change
    ```
-4. **Run the checks**. The helper script installs requirements and runs the linters and tests with coverage.
+5. **Run the checks**. The helper script installs requirements and runs the linters and tests with coverage.
    ```bash
    bash scripts/run_tests.sh
    ```
    If any step fails, fix the issues and re-run the script until everything passes.
-5. **Commit and push** your work.
+6. **Commit and push** your work.
    ```bash
    git add <files>
    git commit -m "DOCS(first-pr): Add walkthrough"
    git push origin feature/my-first-change
    ```
-6. **Open a pull request** on GitHub and fill out the template. CI must pass before the PR can be merged.
+7. **Open a pull request** on GitHub and fill out the template. CI must pass before the PR can be merged.
 
 Refer to `docs/sample-pr.md` for a minimal example and `docs/git-guidelines.md` for commit message conventions.

--- a/docs/git-guidelines.md
+++ b/docs/git-guidelines.md
@@ -34,6 +34,9 @@ Includes basic username and password fields.
 Commit types like `FEAT`, `FIX` and `DOCS` must be uppercase as shown in
 [AGENTS.md](../AGENTS.md).
 
+See the **commit-message policy** in [../AGENTS.md](../AGENTS.md) for a detailed
+explanation of the required format and history rules.
+
 Summarize the purpose of the change in the first line. For example:
 
 ```text


### PR DESCRIPTION
## Summary
- mention commit-msg hook in the first PR walkthrough
- link to the commit-message policy from the git guidelines

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686ea0908dd88320b6e565f15ee284a9