### PR TITLE
Add plugin system

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The full recovery story lives in [docs/origin.md](docs/origin.md).
 - `bot/` – Discord bot written in TypeScript.
 - `frontend/` – Vite-based React application.
 - `auth/` – Environment files for the authentication service.
+- `plugins/` – Optional Python packages that extend functionality.
 - `config/devonboarder.config.yml` – Config for the `devonboarder` tool.
 - `.env.example` – Sample variables shared across services.
 
@@ -146,6 +147,15 @@ GITHUB_TOKEN=<token> OPENAI_API_KEY=<key> \
 
 The container reads `codex.ci.yml` and `codex.automation.bundle.json` from the
 project root.
+
+## Plugins
+
+The package automatically loads modules found under the top-level `plugins/`
+directory. Each plugin lives in its own subfolder with an `__init__.py` file.
+Importing :mod:`devonboarder` populates ``devonboarder.PLUGINS`` with the
+discovered modules. Enable a plugin by adding a new package under
+`plugins/` and providing any initialization logic in its ``register``
+function.
 
 ## Production Deployment
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,8 @@ All notable changes to this project will be recorded in this file.
 - Removed pnpm lockfile commit instructions from `frontend/README.md`.
 - Added mdformat to pre-commit with `--wrap 120` and documented running `pre-commit install` in CONTRIBUTING.
 - Documented CI environment variables used in the workflows.
+- Added a plugin registry that loads modules from `plugins/` and documented the
+  structure in the READMEs.
 - Warns when the CI failure issue search fails and logs the message in `gh_cli.log`.
 - Searches the CI failure issue title and body for the commit SHA and logs the search exit code.
 - Added a first PR guide and service architecture diagram with links from the docs overview.

--- a/docs/README.md
+++ b/docs/README.md
@@ -176,6 +176,13 @@ who has contributed and when.
 - `.python-version` &ndash; indicates the Python version for pyenv.
 - `.nvmrc` &ndash; defines the Node.js version for nvm.
 
+## Plugin Development
+
+Place optional extensions under the repository's `plugins/` directory. Each
+plugin lives in its own folder with an `__init__.py` file and a `register`
+function. Importing :mod:`devonboarder` loads these modules into the global
+``devonboarder.PLUGINS`` dictionary.
+
 ## Documentation Quality Checks
 
 All Markdown files are checked with **Vale** for style. The docs script prints a

--- a/plugins/sample/__init__.py
+++ b/plugins/sample/__init__.py
@@ -1,0 +1,7 @@
+"""Sample plugin for DevOnboarder."""
+
+MESSAGE = "Sample plugin loaded"
+
+def register() -> str:
+    """Return a sample registration message."""
+    return MESSAGE

--- a/src/devonboarder/__init__.py
+++ b/src/devonboarder/__init__.py
@@ -1,5 +1,32 @@
-"""DevOnboarder package."""
+"""DevOnboarder package with basic plugin support."""
+
+from importlib import util
+from pathlib import Path
+from typing import Dict
 
 from .app import greet
 
-__all__ = ["greet"]
+
+def _discover_plugins() -> Dict[str, object]:
+    """Return a mapping of plugin names to imported modules."""
+    registry: Dict[str, object] = {}
+    plugins_dir = Path(__file__).resolve().parents[2] / "plugins"
+    if not plugins_dir.is_dir():
+        return registry
+    for path in plugins_dir.iterdir():
+        if path.is_dir() and (path / "__init__.py").exists():
+            module_name = f"plugins.{path.name}"
+            spec = util.spec_from_file_location(module_name, path / "__init__.py")
+            if spec and spec.loader:
+                module = util.module_from_spec(spec)
+                try:
+                    spec.loader.exec_module(module)
+                except Exception:  # pragma: no cover - plugin import failure
+                    continue
+                registry[path.name] = module
+    return registry
+
+
+PLUGINS = _discover_plugins()
+
+__all__ = ["greet", "PLUGINS"]

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,0 +1,8 @@
+from devonboarder import PLUGINS
+
+
+def test_sample_plugin_loaded():
+    assert 'sample' in PLUGINS
+    plugin = PLUGINS['sample']
+    assert hasattr(plugin, 'register')
+    assert plugin.register() == 'Sample plugin loaded'


### PR DESCRIPTION
## Summary
- add new `plugins` package with a sample plugin
- load plugins at import time via `devonboarder.PLUGINS`
- document plugin support in README and docs
- list change in changelog
- test plugin discovery

## Testing
- `ruff check .`
- `pytest --cov=src --cov-fail-under=95`
- `bash scripts/check_docs.sh`


------
https://chatgpt.com/codex/tasks/task_e_686ea1f4c6088320a74dbce1c0129ac5