### PR TITLE
Add OpenAPI generation script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,15 @@ jobs:
               run: pip install -e .
             - name: Enforce Potato ignore policy
               run: bash scripts/check_potato_ignore.sh
+            - name: Generate OpenAPI spec
+              run: python scripts/generate_openapi.py
+            - name: Check committed OpenAPI spec
+              run: |
+                  git diff --quiet src/devonboarder/openapi.json || {
+                      echo "::error::openapi.json is outdated. Run 'make openapi'" \
+                           " and commit the changes.";
+                      exit 1;
+                  }
             - name: Validate OpenAPI contract
               run: openapi-spec-validator src/devonboarder/openapi.json
             - name: Alembic migration lint

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: deps gen-secrets up test
+.PHONY: deps gen-secrets up test openapi
 
 deps:
 	docker compose -f docker-compose.dev.yaml build
@@ -7,7 +7,10 @@ gen-secrets:
 	./scripts/generate-secrets.sh
 
 up: gen-secrets deps
-        docker compose -f docker-compose.dev.yaml up
+	docker compose -f docker-compose.dev.yaml up
 
 test:
-	bash scripts/run_tests.sh
+	        bash scripts/run_tests.sh
+
+openapi:
+	python scripts/generate_openapi.py

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be recorded in this file.
 ## [Unreleased]
 
 - Wrapped HTTP requests in scripts with try/except to exit on connection errors.
+- Added `scripts/generate_openapi.py` and a `make openapi` target for regenerating the FastAPI spec.
 
 - Added a Python shebang to `scripts/check_docstrings.py` and made the file executable.
 

--- a/docs/merge-checklist.md
+++ b/docs/merge-checklist.md
@@ -8,6 +8,7 @@ Reviewers must verify the following before merging a pull request:
 - [ ] Documentation passes `bash scripts/check_docs.sh`.
 - [ ] Environment variable docs match `.env.example` files via
       `python scripts/check_env_docs.py`.
+- [ ] Run `make openapi` if API routes changed to update `openapi.json`.
 - [ ] The pull request contains a completed reviewer sign-off section.
 - [ ] Secret variable issues use the [Secret Alignment template](../.github/ISSUE_TEMPLATE/secret-alignment.md).
 

--- a/scripts/generate_openapi.py
+++ b/scripts/generate_openapi.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+"""Generate the OpenAPI specification for the auth service."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import os
+
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+os.environ.setdefault("APP_ENV", "development")
+
+from devonboarder.auth_service import create_app  # noqa: E402
+
+
+def main() -> None:
+    """Write the application's OpenAPI spec to ``src/devonboarder/openapi.json``."""
+    app = create_app()
+    spec = app.openapi()
+    output = ROOT / "src" / "devonboarder" / "openapi.json"
+    output.write_text(json.dumps(spec, indent=2))
+    print(f"Wrote {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/devonboarder/openapi.json
+++ b/src/devonboarder/openapi.json
@@ -1,73 +1,449 @@
 {
-  "openapi": "3.0.0",
-  "info": {"title": "DevOnboarder API", "version": "1.0.0"},
+  "openapi": "3.1.0",
+  "info": {
+    "title": "FastAPI",
+    "version": "0.1.0"
+  },
   "paths": {
-    "/api/user/onboarding-status": {
+    "/health": {
       "get": {
-        "summary": "User onboarding status",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "username",
-            "required": true,
-            "schema": {"type": "string"}
-          }
-        ],
+        "summary": "Health",
+        "description": "Return service health status.",
+        "operationId": "health_health_get",
         "responses": {
           "200": {
-            "description": "Onboarding status",
-            "content": {"application/json": {"schema": {"type": "object"}}}
-          }
-        }
-      }
-    },
-    "/api/user/level": {
-      "get": {
-        "summary": "User level",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "username",
-            "required": true,
-            "schema": {"type": "string"}
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Level",
-            "content": {"application/json": {"schema": {"type": "object"}}}
-          }
-        }
-      }
-    },
-    "/api/user/contribute": {
-      "post": {
-        "summary": "Record a contribution and award XP",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {"description": {"type": "string"}},
-                "required": ["description"]
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Contribution recorded",
+            "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
                   "type": "object",
-                  "properties": {"recorded": {"type": "string"}}
+                  "title": "Response Health Health Get"
                 }
               }
             }
           }
         }
+      }
+    },
+    "/api/register": {
+      "post": {
+        "summary": "Register",
+        "description": "Create a new user and return an authentication token.",
+        "operationId": "register_api_register_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "type": "object",
+                "title": "Data"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object",
+                  "title": "Response Register Api Register Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/login": {
+      "post": {
+        "summary": "Login",
+        "description": "Authenticate a user and return a JWT.",
+        "operationId": "login_api_login_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "type": "object",
+                "title": "Data"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object",
+                  "title": "Response Login Api Login Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/login/discord": {
+      "get": {
+        "summary": "Discord Login",
+        "description": "Redirect the user to Discord's OAuth consent screen.",
+        "operationId": "discord_login_login_discord_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/login/discord/callback": {
+      "get": {
+        "summary": "Discord Callback",
+        "description": "Exchange the OAuth code for a token and return a JWT.",
+        "operationId": "discord_callback_login_discord_callback_get",
+        "parameters": [
+          {
+            "name": "code",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Code"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "title": "Response Discord Callback Login Discord Callback Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/user/onboarding-status": {
+      "get": {
+        "summary": "Onboarding Status",
+        "description": "Return the user's onboarding progress.",
+        "operationId": "onboarding_status_api_user_onboarding_status_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object",
+                  "title": "Response Onboarding Status Api User Onboarding Status Get"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
+      }
+    },
+    "/api/user/level": {
+      "get": {
+        "summary": "User Level",
+        "description": "Calculate the user's level from accumulated XP.",
+        "operationId": "user_level_api_user_level_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "integer"
+                  },
+                  "type": "object",
+                  "title": "Response User Level Api User Level Get"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
+      }
+    },
+    "/api/user/contributions": {
+      "get": {
+        "summary": "User Contributions",
+        "description": "List the user's recorded contributions.",
+        "operationId": "user_contributions_api_user_contributions_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "type": "object",
+                  "title": "Response User Contributions Api User Contributions Get"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
+      },
+      "post": {
+        "summary": "Add Contribution",
+        "description": "Record a new contribution and award XP.",
+        "operationId": "add_contribution_api_user_contributions_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "type": "object",
+                "title": "Data"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object",
+                  "title": "Response Add Contribution Api User Contributions Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
+      }
+    },
+    "/api/user/promote": {
+      "post": {
+        "summary": "Promote",
+        "description": "Grant admin privileges to another user.",
+        "operationId": "promote_api_user_promote_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "type": "object",
+                "title": "Data"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object",
+                  "title": "Response Promote Api User Promote Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
+      }
+    },
+    "/api/user": {
+      "get": {
+        "summary": "User Info",
+        "description": "Return the current user's Discord profile and role flags.",
+        "operationId": "user_info_api_user_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response User Info Api User Get"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          }
+        },
+        "type": "object",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError"
+      }
+    },
+    "securitySchemes": {
+      "HTTPBearer": {
+        "type": "http",
+        "scheme": "bearer"
       }
     }
   }


### PR DESCRIPTION
## Summary
- write the API specification with `scripts/generate_openapi.py`
- add `make openapi` target
- mention OpenAPI regeneration in `docs/merge-checklist.md`
- run the spec generator and diff check in CI

## Testing
- `bash scripts/run_tests.sh`
- `make openapi`

------
https://chatgpt.com/codex/tasks/task_e_686ea6593e988320ac1d3fe2c1a8eeff