### PR TITLE
Update docs for service health checks

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be recorded in this file.
 
 ## [Unreleased]
 
+- Documented health-check curl commands for local and production use and cross-linked from onboarding guide.
+
 - Wrapped HTTP requests in scripts with try/except to exit on connection errors.
 
 - Added a Python shebang to `scripts/check_docstrings.py` and made the file executable.

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -2,6 +2,8 @@
 
 This page collects helpful tips for new contributors. Follow
 [docs/README.md](README.md) for a complete development setup.
+See the [Service Health Checks](README.md#service-health-checks) section for
+monitoring endpoints available locally and in production.
 Please review our [Code of Conduct](../CODE_OF_CONDUCT.md) before contributing.
 
 ## Requesting a Codex QA Assessment

--- a/docs/README.md
+++ b/docs/README.md
@@ -92,6 +92,17 @@ The compose files define common service settings using YAML anchors. Each
 environment file overrides differences like `env_file` or exposed ports below the
 `<<` merge key.
 
+### Service Health Checks
+
+After starting the services with `make up`, confirm each one is running:
+
+```bash
+curl http://localhost:8002/health
+curl http://localhost:8001/health
+```
+
+Production environments expose the same endpoints for monitoring.
+
 ### Platform Verification
 
 These instructions were tested on Windows 11 (with WSL&nbsp;2), macOS Ventura,


### PR DESCRIPTION
## Summary
- document API health checks in docs/README.md
- note production endpoints are the same
- reference the section from ONBOARDING.md
- log the change in docs/CHANGELOG.md

## Testing
- `bash scripts/check_docs.sh` *(fails: markdownlint and vale issues)*
- `pre-commit run --files docs/README.md docs/ONBOARDING.md docs/CHANGELOG.md` *(fails: repository checkout)*
- `pytest -q` *(fails: ModuleNotFoundError: fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_686ea86a8dbc8320ac939427fcf2b4a4