### PR TITLE
Add service status dashboard

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -644,6 +644,7 @@ All notable changes to this project will be recorded in this file.
 - Added tests for `scripts/show_network_exceptions.sh` validating the domain list matches the documentation.
 - Required Node.js 20+ via the `engines` field in all package.json files.
 - Documented the Node.js 20 requirement in the bot and frontend READMEs and referenced `.nvmrc`.
+- Added `docs/service-status.md` summarizing core service health and linked it from the documentation overview.
   
 ## [0.1.0] - 2025-06-14
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -154,6 +154,7 @@ platforms. Please report any issues you encounter on your operating system.
 - [Sample pull request](sample-pr.md) &ndash; walkthrough of a minimal docs update.
 - [First PR walkthrough](first-pr-guide.md) &ndash; clone, install hooks and open your first pull request.
 - [Service architecture diagram](architecture.svg) &ndash; high-level view of the auth, XP API, frontend and bot.
+- [Service status dashboard](service-status.md) &ndash; checkbox view of core service health.
 - [Security audit](security-audit-2025-07-01.md) &ndash; latest dependency check results.
 - [Dependency update policy](dependencies.md) &ndash; how Dependabot PRs are reviewed and merged.
 - [FIPS compliance for Go services](fips-golang.md) &ndash; guidelines for running a Go project in FIPS mode.

--- a/docs/service-status.md
+++ b/docs/service-status.md
@@ -1,0 +1,9 @@
+# Service Status Dashboard
+
+This page tracks the health of core services. Check off a service when it is operating normally.
+
+- [x] **Auth Server** – running and serving `/health`
+- [x] **XP API** – running and serving `/health`
+- [x] **Frontend** – serving the React app
+- [x] **Discord Bot** – online and responding to commands
+- [x] **Database** – accepting connections


### PR DESCRIPTION
## Summary
- show health of each core service in `docs/service-status.md`
- link dashboard from docs overview
- log update in changelog

## Testing
- `bash scripts/check_docs.sh`
- `bash scripts/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_686eaa181d688320b34c360b5a4063b0