### PR TITLE
Handle test failures in monitor CI

### DIFF
--- a/codex.ci.yml
+++ b/codex.ci.yml
@@ -5,6 +5,9 @@ codex-tasks:
         - analyze-error:
             summarize: true
             classify: [lint, test, dependency, infra, config]
+        - if: test
+          then:
+            run: pytest --lf
         - if: lint
           then:
             run: |


### PR DESCRIPTION
## Summary
- rerun failing tests when monitor-ci detects test failures

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686eaeb8563483208cb83b3dd6fa97e4