### PR TITLE
Add unit tests for role helpers

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be recorded in this file.
 ## [Unreleased]
 
 - Wrapped HTTP requests in scripts with try/except to exit on connection errors.
+- Added unit tests for `resolve_verification_type` and `resolve_user_flags`.
 
 - Added a Python shebang to `scripts/check_docstrings.py` and made the file executable.
 

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -8,23 +8,77 @@ package.__path__ = [str(src_dir)]
 sys.modules.setdefault("src", package)
 sys.path.insert(0, str(src_dir))
 
-from src.utils.roles import resolve_user_flags  # noqa: E402
+from src.utils.roles import resolve_user_flags, resolve_verification_type  # noqa: E402
+import pytest  # noqa: E402
 
 
-def test_resolve_user_flags_admin_and_verified(monkeypatch):
-    """Return flags when admin and verified roles are present."""
+@pytest.fixture(autouse=True)
+def _set_role_env(monkeypatch):
     monkeypatch.setenv("OWNER_ROLE_ID", "owner")
     monkeypatch.setenv("ADMINISTRATOR_ROLE_ID", "admin")
     monkeypatch.setenv("MODERATOR_ROLE_ID", "mod")
-    monkeypatch.setenv("VERIFIED_USER_ROLE_ID", "verified")
-    monkeypatch.setenv("VERIFIED_MEMBER_ROLE_ID", "vmember")
+    monkeypatch.setenv("VERIFIED_USER_ROLE_ID", "v_user")
+    monkeypatch.setenv("VERIFIED_MEMBER_ROLE_ID", "v_member")
     monkeypatch.setenv("GOVERNMENT_ROLE_ID", "gov")
     monkeypatch.setenv("MILITARY_ROLE_ID", "mil")
     monkeypatch.setenv("EDUCATION_ROLE_ID", "edu")
 
-    flags = resolve_user_flags(["admin", "verified"])
+
+def test_resolve_verification_type_all_roles():
+    assert resolve_verification_type(["gov"]) == "government"
+    assert resolve_verification_type(["mil"]) == "military"
+    assert resolve_verification_type(["edu"]) == "education"
+    assert resolve_verification_type(["v_member"]) == "member"
+    assert resolve_verification_type(["v_user"]) == "member"
+    assert resolve_verification_type([]) is None
+
+
+@pytest.mark.parametrize("admin_key,role", [
+    ("OWNER_ROLE_ID", "owner"),
+    ("ADMINISTRATOR_ROLE_ID", "admin"),
+    ("MODERATOR_ROLE_ID", "mod"),
+])
+def test_resolve_user_flags_admin_only(monkeypatch, admin_key, role):
+    flags = resolve_user_flags([role])
+    assert flags == {
+        "isAdmin": True,
+        "isVerified": False,
+        "verificationType": None,
+    }
+
+
+@pytest.mark.parametrize("admin_role", ["owner", "admin", "mod"])
+@pytest.mark.parametrize(
+    "verification_role,expected",
+    [
+        ("gov", "government"),
+        ("mil", "military"),
+        ("edu", "education"),
+        ("v_member", "member"),
+        ("v_user", "member"),
+    ],
+)
+def test_resolve_user_flags_admin_and_verified(admin_role, verification_role, expected):
+    flags = resolve_user_flags([admin_role, verification_role])
     assert flags == {
         "isAdmin": True,
         "isVerified": True,
-        "verificationType": "member",
+        "verificationType": expected,
+    }
+
+
+def test_resolve_user_flags_verified_only():
+    flags = resolve_user_flags(["edu"])
+    assert flags == {
+        "isAdmin": False,
+        "isVerified": True,
+        "verificationType": "education",
+    }
+
+
+def test_resolve_user_flags_no_roles():
+    assert resolve_user_flags([]) == {
+        "isAdmin": False,
+        "isVerified": False,
+        "verificationType": None,
     }


### PR DESCRIPTION
## Summary
- cover resolve_verification_type and resolve_user_flags with new tests
- document the new tests in the changelog

## Testing
- `ruff check tests/test_roles.py`
- `bash scripts/check_docs.sh`
- `pip install -e .`
- `pip install -r requirements-dev.txt`
- `pytest --cov=src --cov-fail-under=95`

------
https://chatgpt.com/codex/tasks/task_e_686ea5e1d6908320afd7925d22359046