### PR TITLE
Implement Discord Integration agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,14 @@ devonboarder-auth
 
 The auth service listens on `http://localhost:8002`.
 
+To link Discord accounts and fetch roles separately, run:
+
+```bash
+devonboarder-integration
+```
+
+This service listens on `http://localhost:8081`.
+
 The CI pipeline uses `docker-compose.ci.yaml` to start the Postgres database during tests.
 Workflows rely on the preinstalled GitHub CLI or run `./scripts/install_gh_cli.sh`.
 

--- a/codex.tasks.json
+++ b/codex.tasks.json
@@ -1,14 +1,6 @@
 {
   "tasks": [
     {
-      "id": "integration-001",
-      "title": "Implement Discord Integration agent",
-      "module": "discord_integration",
-      "description": "Create `/oauth` and `/roles` routes for Discord account linking and role lookup.",
-      "status": "deferred",
-      "milestone": "v0.4.0"
-    },
-    {
       "id": "feedback-001",
       "title": "Implement Feedback Dashboard API",
       "module": "feedback_service",
@@ -50,6 +42,13 @@
     }
   ],
   "completedTasks": [
+    {
+      "id": "integration-001",
+      "title": "Implement Discord Integration agent",
+      "module": "discord_integration",
+      "description": "Create `/oauth` and `/roles` routes for Discord account linking and role lookup.",
+      "status": "complete"
+    },
     {
       "id": "auth-001",
       "title": "Implement Discord OAuth2 Flow",

--- a/docs/Agents.md
+++ b/docs/Agents.md
@@ -43,7 +43,7 @@ and Codex automation can keep the platform healthy.
 | Agent Name          | Endpoint(s)                      | Port | Healthcheck | Depends On | Status   |
 | ------------------- | -------------------------------- | ---- | ----------- | ---------- | -------- |
 | Auth Server         | `/api/*`, `/health`              | 8002 | `/health`   | db         | updating |
-| Discord Integration | `/oauth`, `/roles`               | 8081 | `TBD`       | Auth, db   | deferred |
+| Discord Integration | `/oauth`, `/roles`               | 8081 | `/health`   | Auth, db   | verify   |
 | Frontend Agent      | `/`, `/session`                  | 3000 | N/A         | Auth       | stable   |
 | XP API              | `/xp`, `/health`                 | 8001 | `/health`   | db         | verify   |
 | Database (Postgres) | N/A                              | 5432 | docker      | N/A        | stable   |
@@ -93,11 +93,11 @@ and Codex automation can keep the platform healthy.
 
 ## Discord Integration Agent
 
-**Status:** Deferred – planned endpoints `/oauth` and `/roles` are not yet implemented.
+**Status:** Verify – exposes `/oauth` and `/roles` for account linking and role lookups. 
 
-**Purpose:** Handles Discord OAuth flows and role lookups once the service is built.
+**Purpose:** Handles Discord OAuth flows and role lookups.
 
-**Key Files:** To be determined when development resumes.
+**Key Files:** `src/discord_integration/api.py`
 
 ---
 
@@ -214,7 +214,7 @@ Use a small loop in your workflow to wait for the auth service before running te
 | ------------------- | ----------- | -------------- | ---------------- |
 | Auth Server         | Yes         | Yes            | Yes              |
 | Frontend            | Yes         | Yes            | Yes              |
-| Discord Integration | N/A         | No             | No               |
+| Discord Integration | Yes         | No             | No               |
 | XP API              | Yes         | Yes            | Yes              |
 | Webhook/Bot Agent   | Optional    | No             | Optional         |
 | Database (Postgres) | Yes         | Yes            | Yes              |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be recorded in this file.
 
 - Added SECURITY.md outlining supported versions, reporting instructions, and a
   30-day response timeframe.
+- Implemented the Discord Integration service with `/oauth` and `/roles` endpoints.
 
 - Added CODE_OF_CONDUCT.md using the Contributor Covenant and linked it from the README and onboarding docs.
 - Documented troubleshooting steps for CI failure issues.

--- a/docs/endpoint-reference.md
+++ b/docs/endpoint-reference.md
@@ -27,6 +27,11 @@ Requests to these endpoints require a valid JWT unless otherwise noted.
 - `GET /api/user/contributions` – list contribution descriptions.
 - `POST /api/user/promote` – admins only; mark another user as an admin.
 
+## Discord Integration
+
+- `POST /oauth` – exchange an OAuth code and link a Discord account.
+- `GET /roles?username=<name>` – return guild role mappings for the user.
+
 ## Discord Command Mapping
 
 The bot in `bot/` calls these routes when users run slash commands:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ devonboarder = "devonboarder.cli:main"
 devonboarder-server = "devonboarder.server:main"
 devonboarder-api = "xp.api:main"
 devonboarder-auth = "devonboarder.auth_service:main"
+devonboarder-integration = "discord_integration.api:main"
 
 [build-system]
 requires = ["setuptools>=61"]

--- a/src/discord_integration/__init__.py
+++ b/src/discord_integration/__init__.py
@@ -1,0 +1,5 @@
+"""Discord Integration package."""
+
+from .api import create_app, main
+
+__all__ = ["create_app", "main"]

--- a/src/discord_integration/api.py
+++ b/src/discord_integration/api.py
@@ -1,0 +1,120 @@
+"""Discord Integration API with OAuth linking and role lookups."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import httpx
+from fastapi import APIRouter, Depends, FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from starlette.middleware.base import BaseHTTPMiddleware
+from sqlalchemy.orm import Session
+
+from utils.cors import get_cors_origins
+from utils.discord import get_user_roles
+from devonboarder import auth_service
+
+API_TIMEOUT = int(os.getenv("DISCORD_API_TIMEOUT", "10"))
+
+router = APIRouter()
+
+
+@router.post("/oauth")
+def exchange_oauth(
+    data: dict[str, Any], db: Session = Depends(auth_service.get_db)
+) -> dict[str, str]:
+    """Exchange a Discord OAuth code for a token and store it."""
+    username = data["username"]
+    code = data["code"]
+    try:
+        resp = httpx.post(
+            "https://discord.com/api/oauth2/token",
+            data={
+                "client_id": os.getenv("DISCORD_CLIENT_ID"),
+                "client_secret": os.getenv("DISCORD_CLIENT_SECRET"),
+                "grant_type": "authorization_code",
+                "code": code,
+                "redirect_uri": os.getenv(
+                    "DISCORD_REDIRECT_URI", "http://localhost:8081/oauth"
+                ),
+            },
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            timeout=API_TIMEOUT,
+        )
+    except httpx.TimeoutException as exc:
+        raise HTTPException(status_code=504, detail="Discord API timeout") from exc
+
+    resp.raise_for_status()
+    token = resp.json()["access_token"]
+    user = db.query(auth_service.User).filter_by(username=username).first()
+    if user is None:
+        user = auth_service.User(
+            username=username,
+            password_hash=auth_service.pwd_context.hash(""),
+            discord_token=token,
+        )
+        db.add(user)
+    else:
+        user.discord_token = token
+    db.commit()
+    return {"linked": username}
+
+
+@router.get("/roles")
+def get_roles(
+    username: str, db: Session = Depends(auth_service.get_db)
+) -> dict[str, Any]:
+    """Return guild role mappings for the specified user."""
+    user = db.query(auth_service.User).filter_by(username=username).first()
+    if user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    try:
+        roles = get_user_roles(user.discord_token)
+    except httpx.TimeoutException as exc:
+        raise HTTPException(status_code=504, detail="Discord API timeout") from exc
+
+    return {"roles": roles}
+
+
+def create_app() -> FastAPI:
+    """Build the Discord Integration FastAPI application."""
+
+    app = FastAPI()
+    cors_origins = get_cors_origins()
+
+    class _SecurityHeadersMiddleware(BaseHTTPMiddleware):
+        async def dispatch(self, request, call_next):  # type: ignore[override]
+            resp = await call_next(request)
+            resp.headers.setdefault("X-Content-Type-Options", "nosniff")
+            resp.headers.setdefault(
+                "Access-Control-Allow-Origin", cors_origins[0] if cors_origins else "*"
+            )
+            return resp
+
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=cors_origins,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+    app.add_middleware(_SecurityHeadersMiddleware)
+
+    @app.get("/health")
+    def health() -> dict[str, str]:
+        return {"status": "ok"}
+
+    app.include_router(router)
+    return app
+
+
+def main() -> None:
+    """Run the Discord Integration service."""
+    import uvicorn
+
+    uvicorn.run(create_app(), host="0.0.0.0", port=8081)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/test_discord_integration.py
+++ b/tests/test_discord_integration.py
@@ -1,0 +1,100 @@
+from fastapi.testclient import TestClient
+import httpx
+
+from discord_integration import create_app
+from devonboarder import auth_service
+import discord_integration.api as di_api
+
+
+def setup_function(function):
+    auth_service.Base.metadata.drop_all(bind=auth_service.engine)
+    auth_service.init_db()
+
+
+def _create_user(username: str, token: str) -> None:
+    with auth_service.SessionLocal() as db:
+        user = auth_service.User(
+            username=username, password_hash="x", discord_token=token
+        )
+        db.add(user)
+        db.commit()
+
+
+class StubResponse:
+    def __init__(self, data: dict[str, str]):
+        self.data = data
+        self.status_code = 200
+
+    def json(self) -> dict[str, str]:
+        return self.data
+
+    def raise_for_status(self) -> None:
+        pass
+
+
+def test_oauth_links_account(monkeypatch):
+    app = create_app()
+    client = TestClient(app)
+
+    def fake_post(url: str, data: dict, headers: dict, *, timeout=None):
+        assert data["code"] == "abc"
+        return StubResponse({"access_token": "tok"})
+
+    monkeypatch.setattr(httpx, "post", fake_post)
+
+    resp = client.post("/oauth", json={"username": "alice", "code": "abc"})
+    assert resp.status_code == 200
+    assert resp.json() == {"linked": "alice"}
+
+    with auth_service.SessionLocal() as db:
+        user = db.query(auth_service.User).filter_by(username="alice").first()
+        assert user.discord_token == "tok"
+
+
+def test_roles_returns_mapping(monkeypatch):
+    _create_user("bob", "tok")
+    app = create_app()
+    client = TestClient(app)
+
+    monkeypatch.setattr(
+        di_api, "get_user_roles", lambda token: {"1": ["a", "b"]}
+    )
+
+    resp = client.get("/roles", params={"username": "bob"})
+    assert resp.status_code == 200
+    assert resp.json() == {"roles": {"1": ["a", "b"]}}
+
+
+def test_roles_user_not_found():
+    app = create_app()
+    client = TestClient(app)
+
+    resp = client.get("/roles", params={"username": "none"})
+    assert resp.status_code == 404
+
+
+def test_timeout_handled(monkeypatch):
+    _create_user("tim", "tok")
+    app = create_app()
+    client = TestClient(app)
+
+    def raise_timeout(*args, **kwargs):
+        raise httpx.TimeoutException("timeout")
+
+    monkeypatch.setattr(di_api, "get_user_roles", raise_timeout)
+
+    resp = client.get("/roles", params={"username": "tim"})
+    assert resp.status_code == 504
+
+
+def test_oauth_timeout(monkeypatch):
+    app = create_app()
+    client = TestClient(app)
+
+    def raise_timeout(*args, **kwargs):
+        raise httpx.TimeoutException("timeout")
+
+    monkeypatch.setattr(httpx, "post", raise_timeout)
+
+    resp = client.post("/oauth", json={"username": "eve", "code": "123"})
+    assert resp.status_code == 504


### PR DESCRIPTION
## Summary
- add Discord Integration service with `/oauth` and `/roles` routes
- document the new service and endpoints
- expose `devonboarder-integration` script
- mark integration-001 task complete
- test OAuth linking and role lookup

## Testing
- `ruff check .`
- `pytest --cov=src --cov-fail-under=95`
- `bash scripts/check_docs.sh`


------
https://chatgpt.com/codex/tasks/task_e_686ec964b72c83209abd301044db98b7