### PR TITLE
Implement feedback API

### DIFF
--- a/codex.tasks.json
+++ b/codex.tasks.json
@@ -1,14 +1,6 @@
 {
   "tasks": [
     {
-      "id": "feedback-001",
-      "title": "Implement Feedback Dashboard API",
-      "module": "feedback_service",
-      "description": "Add endpoints for submitting feedback, tracking status, and generating analytics as outlined in docs/prd/feedback-dashboard.md.",
-      "status": "planned",
-      "milestone": "v0.5.0"
-    },
-    {
       "id": "feedback-002",
       "title": "Create Feedback Dashboard UI",
       "module": "frontend",
@@ -42,6 +34,13 @@
     }
   ],
   "completedTasks": [
+    {
+      "id": "feedback-001",
+      "title": "Implement Feedback Dashboard API",
+      "module": "feedback_service",
+      "description": "Add endpoints for submitting feedback, tracking status, and generating analytics as outlined in docs/prd/feedback-dashboard.md.",
+      "status": "complete"
+    },
     {
       "id": "integration-001",
       "title": "Implement Discord Integration agent",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be recorded in this file.
 
 - Added weekly `ci-health.yml` workflow that tests active branches and opens an issue on failures.
 
+- Implemented feedback submission and analytics API.
+
 - Documented health-check curl commands for local and production use and cross-linked from onboarding guide.
 
 - Wrapped HTTP requests in scripts with try/except to exit on connection errors.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ devonboarder-server = "devonboarder.server:main"
 devonboarder-api = "xp.api:main"
 devonboarder-auth = "devonboarder.auth_service:main"
 devonboarder-integration = "discord_integration.api:main"
+devonboarder-feedback = "feedback_service.api:main"
 
 [build-system]
 requires = ["setuptools>=61"]

--- a/src/feedback_service/__init__.py
+++ b/src/feedback_service/__init__.py
@@ -1,0 +1,5 @@
+"""Feedback service package."""
+
+from .api import create_app, main
+
+__all__ = ["create_app", "main"]

--- a/src/feedback_service/api.py
+++ b/src/feedback_service/api.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from fastapi import APIRouter, Depends, FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from sqlalchemy import Column, Integer, String, func
+from sqlalchemy.orm import Session
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from utils.cors import get_cors_origins
+from devonboarder import auth_service
+
+
+class Feedback(auth_service.Base):
+    __tablename__ = "feedback"
+
+    id = Column(Integer, primary_key=True)
+    type = Column(String, nullable=False)
+    status = Column(String, default="open", nullable=False)
+    description = Column(String, nullable=False)
+
+
+router = APIRouter()
+
+
+@router.post("/feedback")
+def submit_feedback(
+    data: dict[str, Any],
+    db: Session = Depends(auth_service.get_db),
+) -> dict[str, Any]:
+    item = Feedback(
+        type=data["type"],
+        description=data["description"],
+        status="open",
+    )
+    db.add(item)
+    db.commit()
+    db.refresh(item)
+    return {"id": item.id, "status": item.status}
+
+
+@router.patch("/feedback/{item_id}")
+def update_status(
+    item_id: int,
+    data: dict[str, Any],
+    db: Session = Depends(auth_service.get_db),
+) -> dict[str, Any]:
+    item = db.get(Feedback, item_id)
+    if item is None:
+        raise HTTPException(status_code=404, detail="Item not found")
+    item.status = data.get("status", item.status)
+    db.commit()
+    return {"updated": item.id, "status": item.status}
+
+
+@router.get("/feedback")
+def list_feedback(db: Session = Depends(auth_service.get_db)) -> dict[str, Any]:
+    items = db.query(Feedback).all()
+    return {
+        "feedback": [
+            {
+                "id": f.id,
+                "type": f.type,
+                "status": f.status,
+                "description": f.description,
+            }
+            for f in items
+        ]
+    }
+
+
+@router.get("/feedback/analytics")
+def analytics(db: Session = Depends(auth_service.get_db)) -> dict[str, Any]:
+    rows = (
+        db.query(Feedback.type, Feedback.status, func.count(Feedback.id))
+        .group_by(Feedback.type, Feedback.status)
+        .all()
+    )
+    summary: dict[str, dict[str, int]] = {}
+    for type_, status, count in rows:
+        summary.setdefault(type_, {})[status] = count
+    total = db.query(func.count(Feedback.id)).scalar() or 0
+    return {"total": total, "breakdown": summary}
+
+
+def create_app() -> FastAPI:
+    if os.getenv("INIT_DB_ON_STARTUP"):
+        auth_service.init_db()
+        auth_service.Base.metadata.create_all(bind=auth_service.engine)
+
+    app = FastAPI()
+    cors_origins = get_cors_origins()
+
+    class _SecurityHeadersMiddleware(BaseHTTPMiddleware):
+        async def dispatch(self, request, call_next):
+            resp = await call_next(request)
+            resp.headers.setdefault("X-Content-Type-Options", "nosniff")
+            resp.headers.setdefault(
+                "Access-Control-Allow-Origin", cors_origins[0] if cors_origins else "*"
+            )
+            return resp
+
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=cors_origins,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+    app.add_middleware(_SecurityHeadersMiddleware)
+
+    @app.get("/health")
+    def health() -> dict[str, str]:
+        return {"status": "ok"}
+
+    app.include_router(router)
+    return app
+
+
+def main() -> None:  # pragma: no cover
+    import uvicorn
+
+    uvicorn.run(create_app(), host="0.0.0.0", port=8090)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/test_feedback_api.py
+++ b/tests/test_feedback_api.py
@@ -1,0 +1,46 @@
+from fastapi.testclient import TestClient
+
+from feedback_service import create_app
+from devonboarder import auth_service
+
+
+def setup_function(function):
+    auth_service.Base.metadata.drop_all(bind=auth_service.engine)
+    auth_service.init_db()
+    auth_service.get_user_roles = lambda token: {}
+    auth_service.resolve_user_flags = lambda roles: {
+        "isAdmin": False,
+        "isVerified": False,
+        "verificationType": None,
+    }
+    auth_service.get_user_profile = lambda token: {
+        "id": "0",
+        "username": "",
+        "avatar": None,
+    }
+
+
+def test_submit_and_analytics():
+    app = create_app()
+    client = TestClient(app)
+
+    resp = client.post(
+        "/feedback",
+        json={"type": "bug", "description": "broken"},
+    )
+    assert resp.status_code == 200
+    item_id = resp.json()["id"]
+
+    resp = client.get("/feedback")
+    assert resp.status_code == 200
+    data = resp.json()["feedback"]
+    assert data[0]["id"] == item_id
+    assert data[0]["status"] == "open"
+
+    resp = client.patch(f"/feedback/{item_id}", json={"status": "closed"})
+    assert resp.status_code == 200
+
+    resp = client.get("/feedback/analytics")
+    assert resp.status_code == 200
+    assert resp.json()["total"] == 1
+    assert resp.json()["breakdown"]["bug"]["closed"] == 1


### PR DESCRIPTION
## Summary
- implement feedback service with FastAPI
- add tests for feedback endpoints
- update packaging and changelog
- mark `feedback-001` complete in task tracker

## Testing
- `ruff check .`
- `pytest -q`
- `bash scripts/check_docs.sh` *(fails: Markdownlint issues found)*

------
https://chatgpt.com/codex/tasks/task_e_686edd9a55bc8320a228ae762b0b873b