### PR TITLE
Add Llama2 Agile Helper service

### DIFF
--- a/agents/llama2-agile-helper.md
+++ b/agents/llama2-agile-helper.md
@@ -1,5 +1,5 @@
 # Llama2 Agile Helper Agent
-**Status:** Planned.
+**Status:** Active.
 
 **Purpose:** Offers agile planning suggestions and coaching using the Llama2 language model.
 
@@ -42,6 +42,11 @@ Prompt files live in the `prompts/` folder.
 | Slack/Teams Trigger | Invoke `/retro-summary` or `/groom-backlog` in chat |
 | GitHub Action Hook | Run on PRs labeled `planning` or `retrospective` |
 | Frontend Button | Manual trigger in the dashboard |
+
+## Endpoints
+
+- `POST /sprint-summary` – return a summary for sprint notes.
+- `POST /groom-backlog` – suggest priorities and labels for backlog tickets.
 
 ## Metrics
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -687,3 +687,4 @@ All notable changes to this project will be recorded in this file.
   and noted that `scripts/setup-env.sh` pulls this image.
 - Invited contributors to share onboarding feedback by linking a short survey in docs/pull_request_template.md.
 - Added `VITE_FEEDBACK_URL` configuration and implemented React components for the feedback form, status board, and analytics snapshot.
+- Implemented Llama2 Agile Helper service exposing `/sprint-summary` and `/groom-backlog` endpoints.

--- a/prompts/ticket_classifier.prompt
+++ b/prompts/ticket_classifier.prompt
@@ -1,0 +1,2 @@
+# Ticket Classifier Prompt
+Classify backlog items by priority and suggest labels.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ devonboarder-api = "xp.api:main"
 devonboarder-auth = "devonboarder.auth_service:main"
 devonboarder-integration = "discord_integration.api:main"
 devonboarder-feedback = "feedback_service.api:main"
+devonboarder-agile = "llama2_agile_helper.api:main"
 
 [build-system]
 requires = ["setuptools>=61"]

--- a/src/llama2_agile_helper/__init__.py
+++ b/src/llama2_agile_helper/__init__.py
@@ -1,0 +1,5 @@
+"""Llama2 Agile Helper package."""
+
+from .api import create_app, main
+
+__all__ = ["create_app", "main"]

--- a/src/llama2_agile_helper/api.py
+++ b/src/llama2_agile_helper/api.py
@@ -1,0 +1,100 @@
+"""FastAPI service providing sprint summaries and backlog grooming via Llama2."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import httpx
+from fastapi import APIRouter, FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from utils.cors import get_cors_origins
+
+API_KEY = os.getenv("LLAMA2_API_KEY", "")
+API_TIMEOUT = int(os.getenv("LLAMA2_API_TIMEOUT", "10"))
+BASE_URL = os.getenv("LLAMA2_URL", "https://api.llama2.ai/generate")
+PROMPT_DIR = Path(__file__).resolve().parents[2] / "prompts"
+
+router = APIRouter()
+
+
+def _load_prompt(name: str) -> str:
+    return (PROMPT_DIR / name).read_text()
+
+
+def _call_llama2(prompt: str) -> str:
+    if not API_KEY:
+        raise HTTPException(status_code=503, detail="LLAMA2_API_KEY not set")
+    try:
+        resp = httpx.post(
+            BASE_URL,
+            json={"prompt": prompt},
+            headers={"Authorization": f"Bearer {API_KEY}"},
+            timeout=API_TIMEOUT,
+        )
+    except httpx.TimeoutException as exc:  # pragma: no cover - network issue
+        raise HTTPException(status_code=504, detail="Llama2 API timeout") from exc
+    resp.raise_for_status()
+    data = resp.json()
+    return data.get("text", "")
+
+
+@router.post("/sprint-summary")
+def sprint_summary(data: dict[str, str]) -> dict[str, str]:
+    """Return a sprint summary generated from raw notes."""
+    notes = data["notes"]
+    prompt = _load_prompt("retro_analysis.prompt") + "\n" + notes
+    summary = _call_llama2(prompt)
+    return {"summary": summary}
+
+
+@router.post("/groom-backlog")
+def groom_backlog(data: dict[str, list[str]]) -> dict[str, str]:
+    """Return backlog grooming suggestions for the given tickets."""
+    tickets = "\n".join(f"- {t}" for t in data["tickets"])
+    prompt = _load_prompt("ticket_classifier.prompt") + "\n" + tickets
+    suggestions = _call_llama2(prompt)
+    return {"suggestions": suggestions}
+
+
+def create_app() -> FastAPI:
+    """Instantiate and configure the FastAPI application."""
+
+    app = FastAPI()
+    cors_origins = get_cors_origins()
+
+    class _SecurityHeadersMiddleware(BaseHTTPMiddleware):
+        async def dispatch(self, request, call_next):  # type: ignore[override]
+            resp = await call_next(request)
+            resp.headers.setdefault("X-Content-Type-Options", "nosniff")
+            resp.headers.setdefault(
+                "Access-Control-Allow-Origin", cors_origins[0] if cors_origins else "*"
+            )
+            return resp
+
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=cors_origins,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+    app.add_middleware(_SecurityHeadersMiddleware)
+
+    @app.get("/health")
+    def health() -> dict[str, str]:
+        return {"status": "ok"}
+
+    app.include_router(router)
+    return app
+
+
+def main() -> None:  # pragma: no cover - convenience runner
+    import uvicorn
+
+    uvicorn.run(create_app(), host="0.0.0.0", port=8100)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/test_llama2_agile_helper.py
+++ b/tests/test_llama2_agile_helper.py
@@ -1,0 +1,79 @@
+import importlib
+import httpx
+from fastapi.testclient import TestClient
+
+import llama2_agile_helper.api as agile_api
+
+
+def _stub_response(text: str):
+    class StubResponse:
+        def __init__(self) -> None:
+            self.status_code = 200
+
+        def json(self) -> dict[str, str]:
+            return {"text": text}
+
+        def raise_for_status(self) -> None:
+            pass
+
+    return StubResponse()
+
+
+def _reload(monkeypatch):
+    importlib.reload(agile_api)
+    return agile_api.create_app()
+
+
+def test_sprint_summary(monkeypatch):
+    monkeypatch.setenv("LLAMA2_API_KEY", "key")
+    app = _reload(monkeypatch)
+    client = TestClient(app)
+
+    def fake_post(url: str, json: dict, headers: dict, *, timeout=None):
+        assert headers["Authorization"] == "Bearer key"
+        assert "prompt" in json
+        return _stub_response("summary")
+
+    monkeypatch.setattr(httpx, "post", fake_post)
+
+    resp = client.post("/sprint-summary", json={"notes": "done"})
+    assert resp.status_code == 200
+    assert resp.json() == {"summary": "summary"}
+
+
+def test_groom_backlog(monkeypatch):
+    monkeypatch.setenv("LLAMA2_API_KEY", "key")
+    app = _reload(monkeypatch)
+    client = TestClient(app)
+
+    monkeypatch.setattr(httpx, "post", lambda *a, **kw: _stub_response("tips"))
+
+    resp = client.post("/groom-backlog", json={"tickets": ["bug", "feature"]})
+    assert resp.status_code == 200
+    assert resp.json() == {"suggestions": "tips"}
+
+
+def test_timeout(monkeypatch):
+    monkeypatch.setenv("LLAMA2_API_KEY", "key")
+    app = _reload(monkeypatch)
+    client = TestClient(app)
+
+    def raise_timeout(*args, **kwargs):
+        raise httpx.TimeoutException("timeout")
+
+    monkeypatch.setattr(httpx, "post", raise_timeout)
+
+    resp = client.post("/sprint-summary", json={"notes": "x"})
+    assert resp.status_code == 504
+
+
+def test_health_and_missing_key(monkeypatch):
+    monkeypatch.delenv("LLAMA2_API_KEY", raising=False)
+    app = _reload(monkeypatch)
+    client = TestClient(app)
+
+    resp = client.get("/health")
+    assert resp.json() == {"status": "ok"}
+
+    resp = client.post("/sprint-summary", json={"notes": "x"})
+    assert resp.status_code == 503


### PR DESCRIPTION
## Summary
- implement new `llama2_agile_helper` FastAPI service
- document endpoints in the agent spec
- enable running the service via `devonboarder-agile`
- add backlog ticket classifier prompt
- log change in changelog
- test sprint summary and backlog grooming endpoints

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686eebe31d8083208ca65c3febb6a66c