### PR TITLE
Fix feedback status board state updates

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -689,3 +689,4 @@ All notable changes to this project will be recorded in this file.
 - Added `VITE_FEEDBACK_URL` configuration and implemented React components for the feedback form, status board, and analytics snapshot.
 - Implemented Llama2 Agile Helper service exposing `/sprint-summary` and `/groom-backlog` endpoints.
 - Validated feedback components handle failed requests and show error messages.
+- Ensured the feedback status board uses functional state updates so concurrent changes aren't lost.

--- a/frontend/src/components/FeedbackForm.test.tsx
+++ b/frontend/src/components/FeedbackForm.test.tsx
@@ -33,4 +33,16 @@ describe("FeedbackForm", () => {
     );
     expect(fetchMock).toHaveBeenCalledWith(`${URL}/feedback`, expect.any(Object));
   });
+
+  it("shows an error when submission fails", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<FeedbackForm />);
+    fireEvent.click(screen.getByRole("button"));
+
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent(/failed/i)
+    );
+  });
 });

--- a/frontend/src/components/FeedbackStatusBoard.test.tsx
+++ b/frontend/src/components/FeedbackStatusBoard.test.tsx
@@ -40,4 +40,29 @@ describe("FeedbackStatusBoard", () => {
       )
     );
   });
+
+  it("shows an error when update fails", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            feedback: [
+              { id: 1, type: "bug", status: "open", description: "bad" },
+            ],
+          }),
+      })
+      .mockResolvedValueOnce({ ok: false });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<FeedbackStatusBoard />);
+    await screen.findByText("bad");
+    fireEvent.change(screen.getByLabelText("status-1"), {
+      target: { value: "closed" },
+    });
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent(/failed/i)
+    );
+  });
 });

--- a/frontend/src/components/FeedbackStatusBoard.tsx
+++ b/frontend/src/components/FeedbackStatusBoard.tsx
@@ -34,7 +34,7 @@ export default function FeedbackStatusBoard() {
         if (!r.ok) throw new Error('Failed to update status');
       })
       .then(() => {
-        setItems(items.map(i => (i.id === id ? { ...i, status } : i)));
+        setItems(prev => prev.map(i => (i.id === id ? { ...i, status } : i)));
       })
       .catch(() => setError('Failed to update status'));
   }


### PR DESCRIPTION
## Summary
- handle concurrent updates by using a functional state setter
- test error states for feedback components
- document the improvement in CHANGELOG

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686ef22766b483209fc2cec3bdcc68b5