### PR TITLE
Fix codex.tasks feedback milestone

### DIFF
--- a/codex.tasks.json
+++ b/codex.tasks.json
@@ -88,7 +88,8 @@
             "title": "Create Feedback Dashboard UI",
             "module": "frontend",
             "description": "Build React components for the submission form, status board, and analytics snapshot per docs/prd/feedback-dashboard.md.",
-            "status": "complete"
+            "status": "complete",
+            "milestone": "v0.5.0"
         }
     ]
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -651,7 +651,8 @@ All notable changes to this project will be recorded in this file.
 - Required Node.js 20+ via the `engines` field in all package.json files.
 - Documented the Node.js 20 requirement in the bot and frontend READMEs and referenced `.nvmrc`.
 - Added `docs/service-status.md` summarizing core service health and linked it from the documentation overview.
-  
+- Re-added `"milestone": "v0.5.0"` for `feedback-002` in `codex.tasks.json`.
+
 ## [0.1.0] - 2025-06-14
 
 - Added `src/app.py` with `greet` function and updated smoke tests.


### PR DESCRIPTION
## Summary
- restore the milestone field for the `feedback-002` completed task
- record the milestone restoration in the changelog

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686ef4ee8a748320a034a59356702794