### PR TITLE
Update CI docs for pip-audit

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be recorded in this file.
 - Wrapped HTTP requests in scripts with try/except to exit on connection errors.
 - Added unit tests for `resolve_verification_type` and `resolve_user_flags`.
 - Added `scripts/generate_openapi.py` and a `make openapi` target for regenerating the FastAPI spec.
+- Documented `pip-audit` failure behavior and offline steps in `docs/ci-workflow.md` per task docs-qa-101.
 
 - Added a Python shebang to `scripts/check_docstrings.py` and made the file executable.
 

--- a/docs/ci-workflow.md
+++ b/docs/ci-workflow.md
@@ -80,9 +80,10 @@ variables so maintainers know which entries to add to `agents/index.md`.
 
 After the environment checks, the job runs three dependency audits:
 
-- `pip-audit` runs after installing Python requirements and fails the workflow
-  if vulnerabilities are found. This step may fail without internet access; see
-  [docs/offline-setup.md](offline-setup.md).
+- `pip-audit` runs immediately after the development requirements install. An
+  exit code of `1` indicates vulnerable dependencies and fails the job. Other
+  non-zero codes usually mean the tool couldn't download the vulnerability database. In that case the step logs `pip-audit failed. See [docs/offline-setup.md](offline-setup.md) for offline instructions.` and
+  continues to the next audit.
 - `bandit -r src -ll` scans the Python code for vulnerabilities.
 - `npm audit --audit-level=high` runs in both `frontend/` and `bot/`.
 

--- a/docs/offline-setup.md
+++ b/docs/offline-setup.md
@@ -125,6 +125,26 @@ Use `scripts/trivy_scan.sh` to scan the images built with `docker-compose.ci.yam
 
 The hooks will run without needing network access.
 
+## pip-audit
+
+`pip-audit` caches its vulnerability database under `~/.cache/pip-audit`. To run
+the audit offline, populate this cache on a machine with internet access and
+copy it to your development system.
+
+1. On the online machine, seed the cache:
+
+   ```bash
+   pip-audit --cache-dir ~/devonboarder-offline/pip-audit || true
+   ```
+
+2. Transfer the `devonboarder-offline` folder to the offline machine.
+
+3. Run the audit using the cached database:
+
+   ```bash
+   pip-audit --cache-dir /path/to/devonboarder-offline/pip-audit
+   ```
+
 ## Coverage badge
 
 `scripts/update_coverage_badge.py` contacts `img.shields.io` to generate the


### PR DESCRIPTION
## Summary
- document pip-audit failure handling in docs/ci-workflow.md
- explain how to run pip-audit offline in offline-setup guide
- note documentation update in changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ef73ff38c8320961333225626d598