### PR TITLE
Update doc quality guide with offline steps

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be recorded in this file.
 - Added unit tests for `resolve_verification_type` and `resolve_user_flags`.
 - Added `scripts/generate_openapi.py` and a `make openapi` target for regenerating the FastAPI spec.
 - Documented `pip-audit` failure behavior and offline steps in `docs/ci-workflow.md` per task docs-qa-101.
+- Documented offline markdownlint usage in `docs/doc-quality-onboarding.md` per task docs-qa-102.
 
 - Added a Python shebang to `scripts/check_docstrings.py` and made the file executable.
 

--- a/docs/doc-quality-onboarding.md
+++ b/docs/doc-quality-onboarding.md
@@ -24,6 +24,15 @@ machine and copy the `devonboarder-offline` directory to your offline system. In
 `npx --offline -y markdownlint-cli2` work as expected. See [offline-setup.md](offline-setup.md#documentation-tooling-markdownlint-cli2)
 for details.
 
+When working offline, install dependencies from the cache and run the linter directly:
+
+```bash
+npm ci --offline --cache /path/to/devonboarder-offline/npm
+npx --offline -y markdownlint-cli2
+```
+
+This note implements **docs-qa-102**.
+
 Run these commands **before executing tests or documentation checks** so Python
 imports resolve correctly.
 


### PR DESCRIPTION
## Summary
- document offline `markdownlint-cli2` usage per docs-qa-102
- log this change in the changelog

## Testing
- `bash scripts/run_tests.sh` *(fails: Operation cancelled by user)*

------
https://chatgpt.com/codex/tasks/task_e_686f174f564c83208139d76cf81652b4