### PR TITLE
Add VITE_FEEDBACK_URL docs

### DIFF
--- a/agents/index.md
+++ b/agents/index.md
@@ -49,7 +49,7 @@ errors if empty or "secret" outside `development`) |
 | CHECK_HEADERS_URL            | Endpoint used by header checks (default `http://localhost:8002/api/user`) |
 | VITE_AUTH_URL                | Auth service URL for the frontend          |
 | VITE_API_URL                 | XP API URL for the frontend                |
-| VITE_FEEDBACK_URL            | Feedback service URL                       |
+| VITE_FEEDBACK_URL            | Base URL for the feedback service          |
 | VITE_DISCORD_CLIENT_ID       | Discord client ID for the frontend         |
 | VITE_SESSION_REFRESH_INTERVAL| How often the frontend refreshes sessions  |
 | INIT_DB_ON_STARTUP           | Auto-run migrations when the auth service starts |


### PR DESCRIPTION
## Summary
- clarify description for `VITE_FEEDBACK_URL` in the agent docs

## Testing
- `python3 scripts/check_env_docs.py`


------
https://chatgpt.com/codex/tasks/task_e_686f438852f88320b284c2e59bad0dcd