### PR TITLE
Add QA checklist command

### DIFF
--- a/bot/README.md
+++ b/bot/README.md
@@ -68,6 +68,7 @@ The repository provides the following built-in commands:
 - `/verify` – show your onboarding status from the XP API.
 - `/profile` – display your current XP level.
 - `/contribute` – record a contribution description.
+- `/qa_checklist` – show the documentation and QA checklist.
 
 ## Future Work
 

--- a/bot/src/commands/qa_checklist.ts
+++ b/bot/src/commands/qa_checklist.ts
@@ -1,0 +1,13 @@
+import { SlashCommandBuilder, ChatInputCommandInteraction } from 'discord.js';
+import { promises as fs } from 'fs';
+import path from 'path';
+
+export const data = new SlashCommandBuilder()
+  .setName('qa_checklist')
+  .setDescription('Display the QA checklist');
+
+export async function execute(interaction: ChatInputCommandInteraction) {
+  const filePath = path.resolve(__dirname, '../../../docs/QA_CHECKLIST.md');
+  const text = await fs.readFile(filePath, 'utf8');
+  await interaction.reply(text);
+}

--- a/bot/tests/qa_checklist.test.ts
+++ b/bot/tests/qa_checklist.test.ts
@@ -1,0 +1,21 @@
+import { execute } from '../src/commands/qa_checklist';
+import { promises as fs } from 'fs';
+
+jest.mock('fs', () => ({ promises: { readFile: jest.fn() } }));
+
+const interaction = {
+  reply: jest.fn(),
+} as any;
+
+const mockedReadFile = fs.readFile as jest.MockedFunction<typeof fs.readFile>;
+
+beforeEach(() => {
+  mockedReadFile.mockResolvedValue('list');
+  interaction.reply.mockReset();
+});
+
+test('qa_checklist command replies with file contents', async () => {
+  await execute(interaction);
+  expect(mockedReadFile).toHaveBeenCalled();
+  expect(interaction.reply).toHaveBeenCalledWith('list');
+});

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be recorded in this file.
 - Documented `pip-audit` failure behavior and offline steps in `docs/ci-workflow.md` per task docs-qa-101.
 - Documented offline markdownlint usage in `docs/doc-quality-onboarding.md` per task docs-qa-102.
 - Fixed ordered list formatting in `AGENTS.md` and updated outreach links.
+- Added `/qa_checklist` bot command and the QA checklist document.
 
 - Added a Python shebang to `scripts/check_docstrings.py` and made the file executable.
 

--- a/docs/QA_CHECKLIST.md
+++ b/docs/QA_CHECKLIST.md
@@ -1,0 +1,26 @@
+# Documentation & QA Checklist
+
+Use this list before requesting a review or when Codex posts a QA report.
+
+- [ ] All Python and JS dependencies installed (`pip install -e .` or `pip install -r requirements.txt`, then `pip install -r requirements-dev.txt`; `npm ci` if needed)
+- [ ] Vale is installed locally (`vale --version`)
+- [ ] All Markdown docs pass checks (`bash scripts/check_docs.sh`)
+- [ ] All new or updated docs are clear, concise, and free of grammar issues
+- [ ] pytest and other test suites pass
+- [ ] Pre-commit hooks installed (`pre-commit install`)
+- [ ] If doc checks failed, issues are resolved before requesting review
+- [ ] If pre-commit cannot download Node.js, review [Network troubleshooting](network-troubleshooting.md#pre-commit-nodeenv-ssl-errors)
+
+# Checklist
+
+- [ ] All code passes lint, type, and security checks
+- [ ] All new ENV variables are documented in `agents/index.md`
+- [ ] `.env.example` matches the table in `agents/index.md`
+- [ ] OpenAPI/contract and migration checks pass
+- [ ] All API endpoints have docstrings and documentation
+- [ ] CORS and security headers validated
+- [ ] No secrets or sensitive data are present in commits
+- [ ] Codex did **not** introduce any direct commits to `main`
+- [ ] Documentation passes `bash scripts/check_docs.sh`
+- [ ] Are all Codex changes covered by tests and docs?
+- [ ] Coverage does not decrease (see CI summary)


### PR DESCRIPTION
## Summary
- document QA checklist in `docs/QA_CHECKLIST.md`
- implement `/qa_checklist` command for the Discord bot
- describe new command in the bot README
- update changelog

## Testing
- `npm run build --prefix bot`
- `npm test --prefix bot`
- `pytest -q`
- `bash scripts/check_docs.sh` *(fails: Markdownlint issues found)*

------
https://chatgpt.com/codex/tasks/task_e_686f46290bb48320852ad4274e735e8b