### PR TITLE
Update Node.js setup instructions

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be recorded in this file.
 ## [Unreleased]
 
 - Added `LLAMA2_API_TIMEOUT` variable with default `10` and documented it.
+- Replaced the Node.js installation command to download the NodeSource script
+  before running it, referencing the security policy.
 
 - Added weekly `ci-health.yml` workflow that tests active branches and opens an issue on failures.
 

--- a/docs/ubuntu-setup.md
+++ b/docs/ubuntu-setup.md
@@ -17,10 +17,17 @@ sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plug
 ```
 
 ## Install Node.js 20
+Download the setup script first so it can be reviewed before execution.
 ```bash
-curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+curl -fsSL https://deb.nodesource.com/setup_20.x -o nodesource_setup.sh
+# Optional: inspect the script or verify it against the NodeSource repository
+sudo bash nodesource_setup.sh
+rm nodesource_setup.sh
 sudo apt-get install -y nodejs
 ```
+
+> **Security note:** The repository's policy forbids piping remote scripts
+> directly to `bash`. Always download scripts first so you can verify them.
 
 ## Install Python 3.12
 ```bash


### PR DESCRIPTION
## Summary
- download the NodeSource setup script instead of piping it to bash
- note the security policy

## Testing
- `bash scripts/check_docs.sh` *(fails: Markdownlint issues)*
- `bash scripts/run_tests.sh` *(fails: 1 test failed)*

------
https://chatgpt.com/codex/tasks/task_e_686f647767308320bc34aaf9311a19e7