### PR TITLE
Reference CI failure guide in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ Workflow documentation lives under the [docs/](docs/) directory. New contributor
 21. See [docs/network-exception-list.md](docs/network-exception-list.md)
     for required firewall domains. Run
     `scripts/show_network_exceptions.sh` to print them.
+22. See [docs/ci-failure-issues.md](docs/ci-failure-issues.md)
+    if CI automation fails to create or close `ci-failure` issues.
 
 These files expand on the steps listed in the Quickstart section.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -57,6 +57,8 @@ All notable changes to this project will be recorded in this file.
 - Fixed indentation in `cleanup-ci-failure.yml` so the closing step runs as a
   separate action and prints `Closed N ci-failure issues` on success.
 - Updated README star and issue links to point to the repository.
+- Mentioned `docs/ci-failure-issues.md` in the README for troubleshooting CI
+  automation.
 - CI now commits a coverage.svg badge using coverage-summary.md.
 
 - CI workflow caches Playwright browsers to reuse ~/.cache/ms-playwright.


### PR DESCRIPTION
## Summary
- link `docs/ci-failure-issues.md` from the documentation section of the README
- note this update in the changelog

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686f65ddbf648320a5308ff58f654f53