### PR TITLE
Improve QA checklist command

### DIFF
--- a/bot/src/commands/qa_checklist.ts
+++ b/bot/src/commands/qa_checklist.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder, ChatInputCommandInteraction } from 'discord.js';
-import { promises as fs } from 'fs';
+import { readFile } from 'fs/promises';
 import path from 'path';
 
 export const data = new SlashCommandBuilder()
@@ -8,6 +8,18 @@ export const data = new SlashCommandBuilder()
 
 export async function execute(interaction: ChatInputCommandInteraction) {
   const filePath = path.resolve(__dirname, '../../../docs/QA_CHECKLIST.md');
-  const text = await fs.readFile(filePath, 'utf8');
-  await interaction.reply(text);
+  try {
+    const text = await readFile(filePath, 'utf8');
+    const chunks = text.match(/([\s\S]{1,2000})/g) || [];
+    if (chunks.length === 0) {
+      await interaction.reply({ content: 'QA checklist is empty.', ephemeral: true });
+      return;
+    }
+    await interaction.reply({ content: chunks[0], ephemeral: true });
+    for (const chunk of chunks.slice(1)) {
+      await interaction.followUp({ content: chunk, ephemeral: true });
+    }
+  } catch {
+    await interaction.reply({ content: 'Unable to read QA checklist.', ephemeral: true });
+  }
 }

--- a/bot/tests/qa_checklist.test.ts
+++ b/bot/tests/qa_checklist.test.ts
@@ -1,21 +1,33 @@
 import { execute } from '../src/commands/qa_checklist';
-import { promises as fs } from 'fs';
+import { readFile } from 'fs/promises';
 
-jest.mock('fs', () => ({ promises: { readFile: jest.fn() } }));
+jest.mock('fs/promises', () => ({ readFile: jest.fn() }));
 
 const interaction = {
   reply: jest.fn(),
+  followUp: jest.fn(),
 } as any;
 
-const mockedReadFile = fs.readFile as jest.MockedFunction<typeof fs.readFile>;
+const mockedReadFile = readFile as jest.MockedFunction<typeof readFile>;
 
 beforeEach(() => {
+  mockedReadFile.mockReset();
   mockedReadFile.mockResolvedValue('list');
   interaction.reply.mockReset();
+  interaction.followUp.mockReset();
 });
 
 test('qa_checklist command replies with file contents', async () => {
   await execute(interaction);
   expect(mockedReadFile).toHaveBeenCalled();
-  expect(interaction.reply).toHaveBeenCalledWith('list');
+  expect(interaction.reply).toHaveBeenCalledWith({ content: 'list', ephemeral: true });
+  expect(interaction.followUp).not.toHaveBeenCalled();
+});
+
+test('qa_checklist command splits long content', async () => {
+  const long = 'a'.repeat(3000);
+  mockedReadFile.mockResolvedValueOnce(long);
+  await execute(interaction);
+  expect(interaction.reply).toHaveBeenCalledWith({ content: long.slice(0, 2000), ephemeral: true });
+  expect(interaction.followUp).toHaveBeenCalledWith({ content: long.slice(2000), ephemeral: true });
 });


### PR DESCRIPTION
## Summary
- chunk QA checklist output into ephemeral 2000-char messages
- handle file read errors
- test long QA checklist content

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686f6f953fa4832081f4328f3cd59858