### PR TITLE
Mount docs for bot runtime

### DIFF
--- a/bot/Dockerfile
+++ b/bot/Dockerfile
@@ -4,6 +4,8 @@ COPY package.json package-lock.json* ./
 RUN npm install
 COPY tsconfig.json ./
 COPY src ./src
+COPY ../docs /docs
+RUN ln -s /docs /usr/src/docs
 RUN npm run build
 RUN npm prune --production
 CMD ["node", "dist/main.js"]

--- a/bot/Dockerfile.dev
+++ b/bot/Dockerfile.dev
@@ -9,6 +9,8 @@ RUN npm ci
 
 # copy source, compile TS
 COPY bot/ .
+COPY docs /docs
+RUN ln -s /docs /usr/src/docs
 RUN npm run build
 
 # default command

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -34,6 +34,8 @@ services:
       dockerfile: bot/Dockerfile.dev
     env_file:
       - .env.dev
+    volumes:
+      - ./docs:/docs
 
   xp:
     <<: [*app-base, *env-dev]

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -33,6 +33,7 @@ services:
     working_dir: /bot
     volumes:
       - ./bot:/bot
+      - ./docs:/docs
 
   xp:
     <<: [*app-base, *env-prod]


### PR DESCRIPTION
## Summary
- copy `docs` into bot Docker images
- mount `./docs` in compose files so QA checklist loads at runtime

## Testing
- `./scripts/run_tests.sh`
- `node -e "const {readFile}=require('fs/promises');const path=require('path');readFile(path.resolve(__dirname,'./bot/dist/commands/../../../docs/QA_CHECKLIST.md'),'utf8').then(t=>console.log('First line:',t.split('\n')[0]))"`

------
https://chatgpt.com/codex/tasks/task_e_687005f80d988320bc555b8daf0c8cc6