### PR TITLE
Add qa_checklist docs

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be recorded in this file.
 - Fixed ordered list formatting in `AGENTS.md` and updated outreach links.
 - Added `/qa_checklist` bot command and the QA checklist document.
 - Documented `/qa_checklist` usage in `docs/README.md`.
+- Documented `/qa_checklist` usage in `docs/discord/configuration.md`.
 
 - Added a Python shebang to `scripts/check_docstrings.py` and made the file executable.
 

--- a/docs/discord/configuration.md
+++ b/docs/discord/configuration.md
@@ -11,3 +11,10 @@ This guide explains how to configure the Discord server used by the project.
 
 With the Widget enabled, the marketing site and other tools can show who is
 online without requiring users to open Discord.
+
+## Using `/qa_checklist`
+
+Run the `/qa_checklist` command during onboarding to display the
+[QA checklist](../QA_CHECKLIST.md) directly inside Discord. The bot reads the
+document and replies in ephemeral messages so contributors can work through each
+step without leaving the server.

--- a/tests/test_qa_checklist.py
+++ b/tests/test_qa_checklist.py
@@ -1,8 +1,7 @@
+import asyncio
 import re
 from pathlib import Path
 from unittest.mock import AsyncMock
-
-import pytest
 
 
 class FakeInteraction:
@@ -23,16 +22,17 @@ async def send_checklist(interaction: FakeInteraction) -> None:
         await interaction.followUp(content=chunk, ephemeral=True)
 
 
-@pytest.mark.asyncio
-async def test_send_checklist_chunks(tmp_path):
+def test_send_checklist_chunks(tmp_path):
     interaction = FakeInteraction()
-    await send_checklist(interaction)
+    asyncio.run(send_checklist(interaction))
 
     file_path = Path(__file__).resolve().parents[1] / "docs" / "QA_CHECKLIST.md"
     text = file_path.read_text(encoding="utf-8")
     expected_chunks = re.findall(r"([\s\S]{1,2000})", text)
 
-    interaction.reply.assert_called_once_with(content=expected_chunks[0], ephemeral=True)
+    interaction.reply.assert_called_once_with(
+        content=expected_chunks[0], ephemeral=True
+    )
     follow_up_calls = interaction.followUp.call_args_list
     assert len(follow_up_calls) == max(0, len(expected_chunks) - 1)
     for call, chunk in zip(follow_up_calls, expected_chunks[1:]):


### PR DESCRIPTION
## Summary
- document `/qa_checklist` in Discord configuration docs
- note new documentation in the changelog
- adjust QA checklist test to avoid pytest-asyncio dependency

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68707f44ba20832097cb9c6a1342acdd