### PR TITLE
Add QA checklist reference to templates

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,6 +3,7 @@
 ## Documentation & QA Checklist
 
 Refer to [doc-quality-onboarding.md](../docs/doc-quality-onboarding.md) for setup instructions.
+Review [docs/QA_CHECKLIST.md](../docs/QA_CHECKLIST.md) for manual QA steps.
 
 - [ ] All Python and JS dependencies installed (`pip install -r requirements-dev.txt`, `npm ci` if needed)
 - [ ] Vale is installed locally (`vale --version`)

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -25,6 +25,7 @@ bash scripts/check_docs.sh
 ## Documentation & QA Checklist
 
 - Refer to [doc-quality-onboarding.md](doc-quality-onboarding.md) for setup steps.
+- Review [docs/QA_CHECKLIST.md](QA_CHECKLIST.md) for manual QA tasks.
 
 - [ ] All Python and JS dependencies installed (`pip install -e .` or
       `pip install -r requirements.txt`, then `pip install -r requirements-dev.txt`; `npm ci` if needed)


### PR DESCRIPTION
## Summary
- reference `docs/QA_CHECKLIST.md` under the Documentation & QA Checklist section in both pull request templates

## Testing
- `bash scripts/check_docs.sh` *(fails: unable to download Vale)*
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_687123940bb4832090108109a18ca5e2