### PR TITLE
Add engineer assessment issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/assessment.md
+++ b/.github/ISSUE_TEMPLATE/assessment.md
@@ -1,0 +1,59 @@
+---
+name: Engineer Assessment
+about: Checklist for evaluating new features or services
+title: "[Assessment]"
+labels: ["onboarding"]
+---
+
+Use this issue to track an engineering assessment. Check off each item as it is completed.
+
+### Summary
+- [ ] Code Quality
+- [ ] Testing
+- [ ] Documentation
+- [ ] Roadmap Alignment
+- [ ] Community Engagement
+- [ ] Operational Readiness
+- [ ] Automation
+- [ ] Adoption
+
+### Code Quality
+- [ ] Linting passes for all modules
+- [ ] Complex logic is refactored for clarity
+- [ ] Peer review feedback is addressed
+
+### Testing
+- [ ] Unit tests cover new code paths
+- [ ] Integration tests are updated
+- [ ] Edge cases are documented
+
+### Documentation
+- [ ] Public API references are updated
+- [ ] README or user guides reflect changes
+- [ ] Inline comments explain tricky sections
+
+### Roadmap Alignment
+- [ ] Feature mapped to the correct milestone
+- [ ] Dependencies are tracked
+- [ ] Stakeholders notified about schedule
+
+### Community Engagement
+- [ ] Announce changes in Discord or forums
+- [ ] Respond to contributor questions
+- [ ] Update community docs
+
+### Operational Readiness
+- [ ] Monitoring and alerting configured
+- [ ] Logging meets project standards
+- [ ] Runbooks updated for new workflows
+
+### Automation
+- [ ] CI pipeline updated for new jobs
+- [ ] Deployment scripts tested end-to-end
+- [ ] Auto-merge rules verified
+
+### Adoption
+- [ ] Beta testers onboarded
+- [ ] Training materials prepared
+- [ ] Gather and review early feedback
+

--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ Workflow documentation lives under the [docs/](docs/) directory. New contributor
 22. See [docs/ci-failure-issues.md](docs/ci-failure-issues.md)
     if CI automation fails to create or close `ci-failure` issues.
 23. Review [docs/assessments/engineer_assessment_work_items.md](docs/assessments/engineer_assessment_work_items.md)
+    and open an issue with the
+    [Engineer Assessment template](.github/ISSUE_TEMPLATE/assessment.md)
     during onboarding reviews to ensure new features meet the checklist.
 
 These files expand on the steps listed in the Quickstart section.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -709,3 +709,4 @@ All notable changes to this project will be recorded in this file.
 - Added CI failure issue troubleshooting guide to `AGENTS.md` and a typedoc docs build script.
 - Added engineer assessment work items checklist in `docs/assessments/engineer_assessment_work_items.md`.
 - Linked the checklist from `docs/README.md` and the project README for onboarding reviews.
+- Created `assessment.md` issue template and referenced it from the merge checklist and README.

--- a/docs/merge-checklist.md
+++ b/docs/merge-checklist.md
@@ -11,6 +11,7 @@ Reviewers must verify the following before merging a pull request:
 - [ ] Run `make openapi` if API routes changed to update `openapi.json`.
 - [ ] The pull request contains a completed reviewer sign-off section.
 - [ ] Secret variable issues use the [Secret Alignment template](../.github/ISSUE_TEMPLATE/secret-alignment.md).
+- [ ] Assessment reviews use the [Engineer Assessment template](../.github/ISSUE_TEMPLATE/assessment.md).
 
 After merging large documentation updates, run `bash scripts/check_docs.sh`
 locally to ensure the main branch remains lint-free.


### PR DESCRIPTION
## Summary
- add `.github/ISSUE_TEMPLATE/assessment.md`
- link the template from README and merge checklist
- note the new template in CHANGELOG

## Testing
- `bash scripts/run_tests.sh`
- `bash scripts/check_docs.sh` *(warnings expected)*

------
https://chatgpt.com/codex/tasks/task_e_687135f4e75c8320aabb2347be17e857