### PR TITLE
Add TAGS docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ Workflow documentation lives under the [docs/](docs/) directory. New contributor
     and open an issue with the
     [Engineer Assessment template](.github/ISSUE_TEMPLATE/assessment.md)
     during onboarding reviews to ensure new features meet the checklist.
+24. Read [docs/ecosystem.md](docs/ecosystem.md) for an overview of how the
+    services interact inside the TAGS stack.
+25. See [docs/tags_integration.md](docs/tags_integration.md) for TAGS setup
+    steps and feature flag usage.
 
 These files expand on the steps listed in the Quickstart section.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be recorded in this file.
 - Added `docs/codex-e2e-report.md` to track E2E run results and linked it from
   `docs/README.md`.
 
+- Added `docs/ecosystem.md` and `docs/tags_integration.md` describing the TAGS
+  stack and integration steps. Linked them from both READMEs.
+
 - Added `LLAMA2_API_TIMEOUT` variable with default `10` and documented it.
 - Replaced the Node.js installation command to download the NodeSource script
   before running it, referencing the security policy.

--- a/docs/README.md
+++ b/docs/README.md
@@ -136,6 +136,8 @@ platforms. Please report any issues you encounter on your operating system.
 - [Endpoint reference](endpoint-reference.md) &ndash; list of API routes and Discord command mappings.
 - [Environment variables](env.md) &ndash; explanation of `.env` settings and the role-based permission system.
 - [Agents overview](../agents/index.md) &ndash; service and integration specs.
+- [DevOnboarder in TAGS](ecosystem.md) &ndash; how the services fit together.
+- [TAGS integration guide](tags_integration.md) &ndash; compose files and feature flags.
 - [Feedback dashboard PRD](prd/feedback-dashboard.md) &ndash; objectives and features for the feedback tool.
 - [Founder's Circle onboarding](founders/README.md) &ndash; roles and perks for core supporters.
 - [Founders log](../FOUNDERS.md) &ndash; record core contributors and how they help.

--- a/docs/ecosystem.md
+++ b/docs/ecosystem.md
@@ -1,0 +1,19 @@
+# DevOnboarder and the TAGS Stack
+
+DevOnboarder is one of several services that make up the TAGS platform. The stack relies on
+Docker Compose to orchestrate each component. Shared authentication allows users to move
+between services seamlessly. The table below lists the default interfaces and ports.
+
+| Service                | Description                                    | Port |
+| ---------------------- | ---------------------------------------------- | ---- |
+| Auth Server            | Provides Discord OAuth and JWT issuance        | 8002 |
+| XP API                 | Tracks onboarding progress and experience      | 8001 |
+| Integration Service    | Handles Discord role syncing                   | 8081 |
+| DevOnboarder Server    | Greeting and status endpoints                  | 8000 |
+
+All services depend on the same Postgres database container exposed on port 5432. The auth
+service issues tokens consumed by the other agents. Each agent exposes a `/health` endpoint so
+Docker Compose can verify readiness.
+
+TAGS deployments typically run behind a reverse proxy. Local development exposes the ports
+directly on `localhost` as shown above.

--- a/docs/tags_integration.md
+++ b/docs/tags_integration.md
@@ -1,0 +1,23 @@
+# Integrating with TAGS
+
+The TAGS stack uses dedicated Compose files to coordinate each service. Start a local
+stack with:
+
+```bash
+docker compose -f docker-compose.tags.dev.yaml up
+```
+
+Production deployments rely on `docker-compose.tags.prod.yaml`. Both files extend the
+base `docker-compose.yml` and enable extra logging suitable for the TAGS environment.
+
+Feature flags control early access routes. Add the following settings to `.env.dev` when
+running against the TAGS stack:
+
+```
+IS_ALPHA_USER=true
+IS_FOUNDER=true
+```
+
+With these flags set, the API exposes the `/alpha` and `/founder` endpoints described in
+[docs/env.md](env.md). Use the TAGS Compose files to run a fully integrated environment
+with shared authentication across all services.


### PR DESCRIPTION
## Summary
- document service interfaces in `docs/ecosystem.md`
- add `docs/tags_integration.md` with compose references and feature flag notes
- link TAGS docs from main README and docs index
- log the addition in `docs/CHANGELOG.md`

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68727718abbc8320af21b9975695f619