### PR TITLE
Add YAML linting to workflows

### DIFF
--- a/.github/workflows/ci-health.yml
+++ b/.github/workflows/ci-health.yml
@@ -10,7 +10,15 @@ permissions:
   issues: write
 
 jobs:
+  validate-yaml:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ibiqlik/action-yamllint@v3
+        with:
+          file_or_dir: ".github/workflows/**/*.yml"
   branches:
+    needs: validate-yaml
     runs-on: ubuntu-latest
     outputs:
       list: ${{ steps.set.outputs.list }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,15 @@ permissions:
     issues: write
 
 jobs:
+    validate-yaml:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v3
+            - uses: ibiqlik/action-yamllint@v3
+              with:
+                  file_or_dir: ".github/workflows/**/*.yml"
     filter:
+        needs: validate-yaml
         runs-on: ubuntu-latest
         outputs:
             code: ${{ steps.filter.outputs.code }}

--- a/.github/workflows/cleanup-ci-failure.yml
+++ b/.github/workflows/cleanup-ci-failure.yml
@@ -2,7 +2,15 @@ on:
     schedule:
         - cron: "0 0 * * *"
 jobs:
+    validate-yaml:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v3
+            - uses: ibiqlik/action-yamllint@v3
+              with:
+                  file_or_dir: ".github/workflows/**/*.yml"
     cleanup:
+        needs: validate-yaml
         runs-on: ubuntu-latest
         permissions:
             issues: write

--- a/.github/workflows/close-codex-issues.yml
+++ b/.github/workflows/close-codex-issues.yml
@@ -8,7 +8,15 @@ permissions:
   issues: write
 
 jobs:
+  validate-yaml:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ibiqlik/action-yamllint@v3
+        with:
+          file_or_dir: ".github/workflows/**/*.yml"
   close:
+    needs: validate-yaml
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/env-doc-alignment.yml
+++ b/.github/workflows/env-doc-alignment.yml
@@ -11,7 +11,15 @@ permissions:
   issues: write
 
 jobs:
+  validate-yaml:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ibiqlik/action-yamllint@v3
+        with:
+          file_or_dir: ".github/workflows/**/*.yml"
   audit:
+    needs: validate-yaml
     if: github.event.workflow_run.conclusion == 'failure'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/secrets-alignment.yml
+++ b/.github/workflows/secrets-alignment.yml
@@ -13,7 +13,15 @@ permissions:
   issues: write
 
 jobs:
+  validate-yaml:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ibiqlik/action-yamllint@v3
+        with:
+          file_or_dir: ".github/workflows/**/*.yml"
   audit:
+    needs: validate-yaml
     if: github.event_name == 'schedule' || github.event.workflow_run.conclusion == 'failure'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -9,7 +9,15 @@ permissions:
   contents: read
 
 jobs:
+  validate-yaml:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ibiqlik/action-yamllint@v3
+        with:
+          file_or_dir: ".github/workflows/**/*.yml"
   audit:
+    needs: validate-yaml
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Summary
- enforce YAML validation before running jobs in GitHub Actions

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_687288d6e0548320aff237234b36ec83