### PR TITLE
Add auto fix workflow

### DIFF
--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -1,0 +1,65 @@
+name: Auto Fix
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
+
+jobs:
+  validate-yaml:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ibiqlik/action-yamllint@v3
+        with:
+          file_or_dir: ".github/workflows/**/*.yml"
+  fix:
+    needs: validate-yaml
+    if: github.event.workflow_run.conclusion == 'failure'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.workflow_run.head_sha }}
+      - name: Download CI logs
+        uses: actions/download-artifact@v4
+        with:
+          run-id: ${{ github.event.workflow_run.id }}
+          name: ci-logs
+          path: ci-logs
+      - name: Suggest fix with OpenAI
+        id: openai
+        run: |
+          if [ -z "${{ secrets.OPENAI_API_KEY }}" ]; then
+            echo "OPENAI_API_KEY not set" >&2
+            exit 1
+          fi
+          pip install openai
+          suggestion=$(python - "$OPENAI_API_KEY" <<'PY'
+import os, sys, openai
+openai.api_key = sys.argv[1]
+with open('ci-logs/pytest.log', 'r', encoding='utf-8') as f:
+    logs = f.read()
+response = openai.chat.completions.create(
+    model='gpt-4o',
+    messages=[{'role':'user','content':f'Suggest a git patch to fix these CI logs:\n{logs}'}]
+)
+print(response.choices[0].message.content)
+PY
+          )
+          echo "$suggestion" > patch.diff
+      - name: Apply patch
+        run: git apply patch.diff
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "chore(auto-fix): apply patch from OpenAI"
+          branch: auto-fix/${{ github.event.workflow_run.head_sha }}
+          title: "chore(auto-fix): propose fix for failed CI run"
+          body: |
+            Automated fix generated from CI logs of run `${{ github.event.workflow_run.id }}`.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,8 @@ All notable changes to this project will be recorded in this file.
   before running it, referencing the security policy.
 
 - Added weekly `ci-health.yml` workflow that tests active branches and opens an issue on failures.
+- Introduced `auto-fix.yml` workflow that downloads CI logs, asks OpenAI for a patch,
+  applies it on a new branch, and opens a pull request with `peter-evans/create-pull-request`.
 
 - Implemented feedback submission and analytics API.
 - Added a QA checklist bullet to the GitHub PR template.

--- a/docs/README.md
+++ b/docs/README.md
@@ -258,6 +258,9 @@ See [doc-quality-onboarding.md](doc-quality-onboarding.md) for a step-by-step gu
 
 11. A weekly job (`security-audit.yml`) runs dependency audits and uploads the report as an artifact.
 12. CODEOWNERS automatically requests reviews from the maintainer team.
+13. The `auto-fix.yml` workflow runs when CI fails. It downloads the `ci-logs` artifact,
+    asks OpenAI for a patch, applies the change on a new branch, and opens a pull request
+    with `peter-evans/create-pull-request`.
 
 ## \U0001F6E1\uFE0F Coverage and Security
 


### PR DESCRIPTION
## Summary
- add auto-fix.yml workflow triggered by failed CI runs
- document automated repairs in docs/README
- note new workflow in changelog

## Testing
- `ruff check .`
- `pytest --cov=src --cov-fail-under=95`
- `bash scripts/check_docs.sh` *(warnings only)*

------
https://chatgpt.com/codex/tasks/task_e_6872b787d3148320af3c18c08a2b034d