### PR TITLE
Update dashboard metadata to YAML front matter

### DIFF
--- a/Codex_Contributor_Dashboard.md
+++ b/Codex_Contributor_Dashboard.md
@@ -1,15 +1,19 @@
-{
-  "project": "DevOnboarder",
-  "module": "Codex Integration",
-  "phase": "MVP",
-  "tags": ["dashboard", "codex", "contributors", "roadmap", "automation"],
-  "version": "v1.0.0",
-  "author": "Chad Reesey",
-  "email": "reesey275@thenagrygamershow.com",
-  "updated": "21 June 2025 08:25 (EST)",
-  "description": "Dashboard summarizing Codex task progress and module status for contributors."
-}
-
+---
+project: DevOnboarder
+module: Codex Integration
+phase: MVP
+tags:
+  - dashboard
+  - codex
+  - contributors
+  - roadmap
+  - automation
+version: v1.0.0
+author: Chad Reesey
+email: reesey275@thenagrygamershow.com
+updated: "21 June 2025 08:25 (EST)"
+description: Dashboard summarizing Codex task progress and module status for contributors.
+---
 # 🧩 Codex Contributor Dashboard – MVP
 
 This dashboard provides a live snapshot of module status and responsibilities.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to this project will be recorded in this file.
 - Added `LLAMA2_API_TIMEOUT` variable with default `10` and documented it.
 - Replaced the Node.js installation command to download the NodeSource script
   before running it, referencing the security policy.
+- Replaced the JSON block in `Codex_Contributor_Dashboard.md` with YAML front
+  matter and validated the file using `yamllint`.
 
 - Added weekly `ci-health.yml` workflow that tests active branches and opens an issue on failures.
 - Introduced `auto-fix.yml` workflow that downloads CI logs, asks OpenAI for a patch,


### PR DESCRIPTION
## Summary
- swap JSON metadata block in `Codex_Contributor_Dashboard.md` with YAML front matter
- log this change in `CHANGELOG`

## Testing
- `ruff check .`
- `pytest --cov=src --cov-fail-under=95`
- `bash scripts/check_docs.sh`
- `yamllint` on the new YAML front matter

------
https://chatgpt.com/codex/tasks/task_e_6872d6072e3883208db94f9529cc2d17