### PR TITLE
Add validate script

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,3 +59,7 @@ repos:
             entry: pytest --cov=src --cov-fail-under=95
             language: system
             enabled: false
+          - id: validate
+            name: Full validation suite
+            entry: bash scripts/validate.sh
+            language: system

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Aggregate validation checks documented in AGENTS.md and docs.
+
+# Verify required ignore entries exist
+bash "$(dirname "$0")/check_potato_ignore.sh"
+
+# Confirm required external domains are reachable
+bash "$(dirname "$0")/check_network_access.sh"
+
+# Lint documentation with markdownlint and Vale
+bash "$(dirname "$0")/check_docs.sh"
+
+# Ensure environment variable docs match .env examples
+python "$(dirname "$0")/check_env_docs.py"
+
+# Ensure API endpoints include docstrings
+python "$(dirname "$0")/check_docstrings.py" src/devonboarder
+
+# Confirm optional tools like Jest, Vitest and Vale are installed
+bash "$(dirname "$0")/check_dependencies.sh"
+
+# Run linters and test suites with coverage
+bash "$(dirname "$0")/run_tests.sh"


### PR DESCRIPTION
## Summary
- aggregate project checks in `scripts/validate.sh`
- run the validation script via a pre-commit hook

## Testing
- `bash scripts/validate.sh` *(fails: Markdownlint issues)*

------
https://chatgpt.com/codex/tasks/task_e_6872da4fa1a08320b546ca77369a69fd