### PR TITLE
Add CI and Auto Fix badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # DevOnboarder
 ![Coverage](coverage.svg)
+[![CI](https://github.com/theangrygamershowproductions/DevOnboarder/actions/workflows/ci.yml/badge.svg)](https://github.com/theangrygamershowproductions/DevOnboarder/actions/workflows/ci.yml)
+[![Auto Fix](https://github.com/theangrygamershowproductions/DevOnboarder/actions/workflows/auto-fix.yml/badge.svg)](https://github.com/theangrygamershowproductions/DevOnboarder/actions/workflows/auto-fix.yml)
 
 
 DevOnboarder demonstrates a trunk‑based workflow with Docker‑based services for rapid onboarding.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -725,3 +725,4 @@ All notable changes to this project will be recorded in this file.
 - Linked the checklist from `docs/README.md` and the project README for onboarding reviews.
 - Created `assessment.md` issue template and referenced it from the merge checklist and README.
 - Updated engineer assessment checklist with Codex-compatible work items.
+- Added CI and Auto Fix badges to `README.md`.


### PR DESCRIPTION
## Summary
- show CI and Auto Fix workflow badges near the top of the README
- log the change in the changelog

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6872ddc231b083208c23f3441e11fc67