### PR TITLE
Add extended validation checks

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,9 @@ All notable changes to this project will be recorded in this file.
 - Added `LLAMA2_API_TIMEOUT` variable with default `10` and documented it.
 - Replaced the Node.js installation command to download the NodeSource script
   before running it, referencing the security policy.
+- Enhanced `scripts/validate.sh` to enforce `.tool-versions`, lint workflows and
+  Markdown files, validate front matter with `ajv`, and list unused Docker
+  artifacts.
 - Replaced the JSON block in `Codex_Contributor_Dashboard.md` with YAML front
   matter and validated the file using `yamllint`.
 

--- a/schema/frontmatter.schema.json
+++ b/schema/frontmatter.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Documentation frontmatter schema",
+  "type": "object",
+  "properties": {
+    "title": {"type": "string"},
+    "version": {"type": "string"},
+    "author": {"type": "string"},
+    "created": {"type": "string", "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"},
+    "date_created": {"type": "string", "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"}
+  },
+  "required": ["title", "version"],
+  "additionalProperties": false
+}

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -9,8 +9,51 @@ bash "$(dirname "$0")/check_potato_ignore.sh"
 # Confirm required external domains are reachable
 bash "$(dirname "$0")/check_network_access.sh"
 
+# Verify .tool-versions usage
+if [ ! -f .tool-versions ]; then
+  echo ".tool-versions file is required" >&2
+  exit 1
+fi
+if [ -f .python-version ] || [ -f .nvmrc ]; then
+  echo "Remove .python-version and .nvmrc; use .tool-versions" >&2
+  exit 1
+fi
+
 # Lint documentation with markdownlint and Vale
 bash "$(dirname "$0")/check_docs.sh"
+
+# Lint GitHub Actions workflows
+if command -v yamllint >/dev/null 2>&1; then
+  yamllint .github/workflows/**/*.yml
+else
+  echo "::warning::yamllint not installed; skipping workflow lint"
+fi
+
+# Lint Markdown files
+if command -v markdownlint >/dev/null 2>&1; then
+  markdownlint 'docs/**/*.md' '*.md'
+else
+  echo "::warning::markdownlint not installed; skipping Markdown lint"
+fi
+
+# Validate frontmatter schema
+for md in $(git ls-files 'docs/**/*.md' '*.md'); do
+  if [ "$(head -n1 "$md")" = "---" ]; then
+    tmp=$(mktemp)
+    sed -n '/^---$/,/^---$/p' "$md" | sed '1d;$d' |
+      python - <<'EOF' "$tmp"
+import sys, yaml, json
+data = yaml.safe_load(sys.stdin.read() or "{}")
+json.dump(data, open(sys.argv[1], 'w'))
+EOF
+    if ! npx -y ajv-cli validate -s schema/frontmatter.schema.json -d "$tmp" >/dev/null; then
+      echo "Frontmatter validation failed for $md" >&2
+      rm "$tmp"
+      exit 1
+    fi
+    rm "$tmp"
+  fi
+done
 
 # Ensure environment variable docs match .env examples
 python "$(dirname "$0")/check_env_docs.py"
@@ -20,6 +63,12 @@ python "$(dirname "$0")/check_docstrings.py" src/devonboarder
 
 # Confirm optional tools like Jest, Vitest and Vale are installed
 bash "$(dirname "$0")/check_dependencies.sh"
+
+# Print unreferenced Docker artifacts
+unused=$(git ls-files | grep -E 'Dockerfile|docker-compose\.' | grep -v '^docker-compose.ci.yaml$' || true)
+if [ -n "$unused" ]; then
+  echo "Unreferenced Docker files:" && echo "$unused"
+fi
 
 # Run linters and test suites with coverage
 bash "$(dirname "$0")/run_tests.sh"


### PR DESCRIPTION
## Summary
- extend `scripts/validate.sh` with workflow linting, markdownlint, frontmatter validation and Dockerfile listing
- require `.tool-versions` and ensure `.python-version`/`.nvmrc` are absent
- add `schema/frontmatter.schema.json`
- note validation enhancements in the changelog

## Testing
- `pre-commit run --files scripts/validate.sh docs/CHANGELOG.md schema/frontmatter.schema.json` *(fails: CalledProcessError)*
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6872e4414d5c8320a4ac069727561e51