### PR TITLE
Improve CI rate limit checks

### DIFF
--- a/.github/workflows/ci-monitor.yml
+++ b/.github/workflows/ci-monitor.yml
@@ -34,18 +34,21 @@ jobs:
       - name: Check for rate-limit error
         id: check
         run: |
-          if grep -q "rate limit" ci-logs/*.log; then
+          match=$(grep -iE 'rate limit|429 Too Many Requests|quota exceeded' -m1 ci-logs/*.log || true)
+          if [ -n "$match" ]; then
             echo "hit=true" >> "$GITHUB_OUTPUT"
+            echo "match=$match" >> "$GITHUB_OUTPUT"
+            echo "$match"
           else
             echo "hit=false" >> "$GITHUB_OUTPUT"
           fi
       - name: Open issue on rate-limit
         if: steps.check.outputs.hit == 'true'
         env:
-          GH_TOKEN: ${{ secrets.CI_ISSUE_TOKEN }}
+          GH_TOKEN: ${{ secrets.CI_ISSUE_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           gh issue create \
             --title "\ud83d\udea8 CI Rate Limit Exceeded" \
-            --body "Our CI run failed due to API rate limits. Logs: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --body "Our CI run failed due to API rate limits. Matched line: ${{ steps.check.outputs.match }}. Logs: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
             --label ci \
             --assignee "@me"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be recorded in this file.
 
 ## [Unreleased]
 
+- Improved `ci-monitor.yml` to detect additional rate-limit phrases and fall back
+  to `${{ secrets.GITHUB_TOKEN }}` when `CI_ISSUE_TOKEN` is unavailable.
+
 - Documented additional pre-PR checklist steps in `docs/sample-pr.md`.
 - Added `docs/codex-e2e-report.md` to track E2E run results and linked it from
   `docs/README.md`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -260,7 +260,9 @@ See [doc-quality-onboarding.md](doc-quality-onboarding.md) for a step-by-step gu
 13. The `auto-fix.yml` workflow runs when CI fails. It downloads the `ci-logs` artifact,
     asks OpenAI for a YAML patch using `yamllint` output, applies it, then requests a
     broader fix and opens a pull request with `peter-evans/create-pull-request`.
-14. The `ci-monitor.yml` workflow checks CI logs for rate-limit errors and opens an issue when detected using `${{ secrets.CI_ISSUE_TOKEN }}`.
+14. The `ci-monitor.yml` workflow scans CI logs for `rate limit`, `429 Too Many Requests`,
+    or `quota exceeded` messages and opens an issue using
+    `${{ secrets.CI_ISSUE_TOKEN || secrets.GITHUB_TOKEN }}` when a match is found.
 
 ## \U0001F6E1\uFE0F Coverage and Security
 


### PR DESCRIPTION
## Summary
- improve rate limit detection in `ci-monitor.yml`
- document new patterns and token fallback
- note improvement in changelog

## Testing
- `bash scripts/validate.sh` *(fails: markdownlint issues, missing yamllint)*
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6872fc5dc3c88320843455562636b532