### PR TITLE
Update CI monitor docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -260,9 +260,10 @@ See [doc-quality-onboarding.md](doc-quality-onboarding.md) for a step-by-step gu
 13. The `auto-fix.yml` workflow runs when CI fails. It downloads the `ci-logs` artifact,
     asks OpenAI for a YAML patch using `yamllint` output, applies it, then requests a
     broader fix and opens a pull request with `peter-evans/create-pull-request`.
-14. The `ci-monitor.yml` workflow scans CI logs for `rate limit`, `429 Too Many Requests`,
-    or `quota exceeded` messages and opens an issue using
-    `${{ secrets.CI_ISSUE_TOKEN || secrets.GITHUB_TOKEN }}` when a match is found.
+14. The `ci-monitor.yml` workflow scans CI logs for several rate-limit phrases.
+    It quotes the first match and opens an issue using
+    `${{ secrets.CI_ISSUE_TOKEN }}` or `${{ secrets.GITHUB_TOKEN }}` when that
+    secret isn’t set. See [ci-env-vars.md](ci-env-vars.md) for details.
 
 ## \U0001F6E1\uFE0F Coverage and Security
 


### PR DESCRIPTION
## Summary
- clarify the search phrases and token fallback for `ci-monitor.yml`

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6872fde16fbc83209885e8f7e7b17492