### PR TITLE
chore(ci): centralize yamllint config

### DIFF
--- a/.github/.yamllint-config
+++ b/.github/.yamllint-config
@@ -1,0 +1,9 @@
+extends: default
+rules:
+  document-start:
+    enable: false
+  truthy:
+    enable: false
+  line-length:
+    max: 200
+    level: warning

--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: ibiqlik/action-yamllint@v3
         with:
           file_or_dir: ".github/workflows/**/*.yml"
+          config_file: .github/.yamllint-config
   fix:
     needs: validate-yaml
     if: github.event.workflow_run.conclusion == 'failure'
@@ -29,7 +30,7 @@ jobs:
       - name: Run yamllint
         run: |
           pip install yamllint
-          yamllint .github/workflows/**/*.yml > yamllint.log || true
+          yamllint -c .github/.yamllint-config .github/workflows/**/*.yml > yamllint.log || true
       - name: Download CI logs
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/ci-health.yml
+++ b/.github/workflows/ci-health.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: ibiqlik/action-yamllint@v3
         with:
           file_or_dir: ".github/workflows/**/*.yml"
+          config_file: .github/.yamllint-config
   branches:
     needs: validate-yaml
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-monitor.yml
+++ b/.github/workflows/ci-monitor.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: ibiqlik/action-yamllint@v3
         with:
           file_or_dir: ".github/workflows/**/*.yml"
+          config_file: .github/.yamllint-config
   report-rate-limit:
     needs: validate-yaml
     if: github.event.workflow_run.conclusion == 'failure'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
             - uses: ibiqlik/action-yamllint@v3
               with:
                   file_or_dir: ".github/workflows/**/*.yml"
+                  config_file: .github/.yamllint-config
     filter:
         needs: validate-yaml
         runs-on: ubuntu-latest

--- a/.github/workflows/cleanup-ci-failure.yml
+++ b/.github/workflows/cleanup-ci-failure.yml
@@ -9,6 +9,7 @@ jobs:
             - uses: ibiqlik/action-yamllint@v3
               with:
                   file_or_dir: ".github/workflows/**/*.yml"
+                  config_file: .github/.yamllint-config
     cleanup:
         needs: validate-yaml
         runs-on: ubuntu-latest

--- a/.github/workflows/close-codex-issues.yml
+++ b/.github/workflows/close-codex-issues.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: ibiqlik/action-yamllint@v3
         with:
           file_or_dir: ".github/workflows/**/*.yml"
+          config_file: .github/.yamllint-config
   close:
     needs: validate-yaml
     if: github.event.pull_request.merged == true

--- a/.github/workflows/env-doc-alignment.yml
+++ b/.github/workflows/env-doc-alignment.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: ibiqlik/action-yamllint@v3
         with:
           file_or_dir: ".github/workflows/**/*.yml"
+          config_file: .github/.yamllint-config
   audit:
     needs: validate-yaml
     if: github.event.workflow_run.conclusion == 'failure'

--- a/.github/workflows/secrets-alignment.yml
+++ b/.github/workflows/secrets-alignment.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: ibiqlik/action-yamllint@v3
         with:
           file_or_dir: ".github/workflows/**/*.yml"
+          config_file: .github/.yamllint-config
   audit:
     needs: validate-yaml
     if: github.event_name == 'schedule' || github.event.workflow_run.conclusion == 'failure'

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -16,6 +16,7 @@ jobs:
       - uses: ibiqlik/action-yamllint@v3
         with:
           file_or_dir: ".github/workflows/**/*.yml"
+          config_file: .github/.yamllint-config
   audit:
     needs: validate-yaml
     runs-on: ubuntu-latest

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be recorded in this file.
 ## [Unreleased]
 
 - Linked `docs/CHANGELOG.md` from `README.md` for easier navigation.
+- Added `.github/.yamllint-config` to centralize workflow lint rules, disabling
+  `document-start` and `truthy` and warning on lines over 200 characters.
 
 - Improved `ci-monitor.yml` to detect additional rate-limit phrases and fall back
   to `${{ secrets.GITHUB_TOKEN }}` when `CI_ISSUE_TOKEN` is unavailable.

--- a/docs/README.md
+++ b/docs/README.md
@@ -264,6 +264,8 @@ See [doc-quality-onboarding.md](doc-quality-onboarding.md) for a step-by-step gu
     It quotes the first match and opens an issue using
     `${{ secrets.CI_ISSUE_TOKEN }}` or `${{ secrets.GITHUB_TOKEN }}` when that
     secret isn’t set. See [ci-env-vars.md](ci-env-vars.md) for details.
+15. Workflows share `.github/.yamllint-config` to disable `document-start` and
+    `truthy` checks while warning on lines over 200 characters.
 
 ## \U0001F6E1\uFE0F Coverage and Security
 

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -24,7 +24,7 @@ bash "$(dirname "$0")/check_docs.sh"
 
 # Lint GitHub Actions workflows
 if command -v yamllint >/dev/null 2>&1; then
-  yamllint .github/workflows/**/*.yml
+  yamllint -c .github/.yamllint-config .github/workflows/**/*.yml
 else
   echo "::warning::yamllint not installed; skipping workflow lint"
 fi


### PR DESCRIPTION
## Summary
- add .github/.yamllint-config
- reference the config in validation script and workflows
- document yamllint rules
- note centralized lint config in changelog

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6873080a71008320bc8921916baa712e