### PR TITLE
Unify yamllint invocation

### DIFF
--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Run yamllint
         run: |
           pip install yamllint
-          yamllint -c .github/.yamllint-config .github/workflows/**/*.yml > yamllint.log || true
+          yamllint -c .github/.yamllint-config .github/workflows/**/*.yml | tee yamllint.log || true
       - name: Download CI logs
         uses: actions/download-artifact@v4
         with:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be recorded in this file.
 - Linked `docs/CHANGELOG.md` from `README.md` for easier navigation.
 - Added `.github/.yamllint-config` to centralize workflow lint rules, disabling
   `document-start` and `truthy` and warning on lines over 200 characters.
+- Aligned yamllint invocation across scripts and CI with
+  `yamllint -c .github/.yamllint-config .github/workflows/**/*.yml`.
 
 - Improved `ci-monitor.yml` to detect additional rate-limit phrases and fall back
   to `${{ secrets.GITHUB_TOKEN }}` when `CI_ISSUE_TOKEN` is unavailable.

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
+shopt -s globstar
 
 # Aggregate validation checks documented in AGENTS.md and docs.
 


### PR DESCRIPTION
## Summary
- ensure `**` globstar expands in `validate.sh`
- pipe yamllint output through `tee` in auto-fix workflow
- document unified yamllint command

## Testing
- `bash scripts/validate.sh` *(fails: yamllint and markdownlint missing)*
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68730b60c83c8320a0ed9a23110d9c37