### PR TITLE
Fix indentation in auto-fix workflow

### DIFF
--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -55,13 +55,13 @@ jobs:
           fi
           export SNIPPET="$snippet"
           patch=$(python - "$OPENAI_API_KEY" <<'PY'
-import sys, os, openai
-openai.api_key = sys.argv[1]
-log=open('yamllint.log').read()
-snippet=os.environ.get('SNIPPET','')
-prompt=f"yamllint output:\n{log}\n\nRelevant YAML snippet:\n{snippet}\nProvide a unified diff patch to fix these errors."
-resp=openai.chat.completions.create(model='gpt-4o', messages=[{'role':'user','content':prompt}])
-print(resp.choices[0].message.content)
+            import sys, os, openai
+            openai.api_key = sys.argv[1]
+            log=open('yamllint.log').read()
+            snippet=os.environ.get('SNIPPET','')
+            prompt=f"yamllint output:\n{log}\n\nRelevant YAML snippet:\n{snippet}\nProvide a unified diff patch to fix these errors."
+            resp=openai.chat.completions.create(model='gpt-4o', messages=[{'role':'user','content':prompt}])
+            print(resp.choices[0].message.content)
 PY
           )
           echo "$patch" > fix-ci-health.patch.diff
@@ -76,18 +76,18 @@ PY
           fi
           pip install openai
           suggestion=$(python - "$OPENAI_API_KEY" <<'PY'
-import sys, openai
-openai.api_key = sys.argv[1]
-with open('yamllint.log', 'r', encoding='utf-8') as f:
-    yamls = f.read()
-with open('ci-logs/pytest.log', 'r', encoding='utf-8') as f:
-    logs = f.read()
-prompt = f"""Yamllint output:\n{yamls}\n\nCI logs:\n{logs}\n\nFirst fix YAML syntax errors, then address remaining issues. Provide a git patch."""
-response = openai.chat.completions.create(
-    model='gpt-4o',
-    messages=[{'role':'user','content':prompt}]
-)
-print(response.choices[0].message.content)
+            import sys, openai
+            openai.api_key = sys.argv[1]
+            with open('yamllint.log', 'r', encoding='utf-8') as f:
+                yamls = f.read()
+            with open('ci-logs/pytest.log', 'r', encoding='utf-8') as f:
+                logs = f.read()
+            prompt = f"""Yamllint output:\n{yamls}\n\nCI logs:\n{logs}\n\nFirst fix YAML syntax errors, then address remaining issues. Provide a git patch."""
+            response = openai.chat.completions.create(
+                model='gpt-4o',
+                messages=[{'role':'user','content':prompt}]
+            )
+            print(response.choices[0].message.content)
 PY
           )
           echo "$suggestion" > patch.diff

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be recorded in this file.
   `document-start` and `truthy` and warning on lines over 200 characters.
 - Aligned yamllint invocation across scripts and CI with
   `yamllint -c .github/.yamllint-config .github/workflows/**/*.yml`.
+- Fixed indentation of Python blocks in `auto-fix.yml` to resolve YAML linting errors.
 
 - Improved `ci-monitor.yml` to detect additional rate-limit phrases and fall back
   to `${{ secrets.GITHUB_TOKEN }}` when `CI_ISSUE_TOKEN` is unavailable.


### PR DESCRIPTION
## Summary
- keep OpenAI blocks in `.github/workflows/auto-fix.yml` indented
- document the YAML lint fix in the changelog

## Testing
- `yamllint -c .github/.yamllint-config .github/workflows/**/*.yml` *(fails: invalid config option)*

------
https://chatgpt.com/codex/tasks/task_e_68731a9bc5408320995697078eab7486