### PR TITLE
Add diagnostics script and CI step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,6 +203,15 @@ jobs:
                   fi
             - name: Wait for auth service
               run: bash scripts/wait_for_service.sh http://localhost:8002/health 30 2 auth
+            - name: Run diagnostics
+              run: python -m diagnostics > diagnostics.log
+            - name: Upload diagnostics
+              if: always()
+              uses: actions/upload-artifact@v4
+              with:
+                  name: diagnostics
+                  path: diagnostics.log
+                  retention-days: 7
             - name: Prepare test-results directory
               run: mkdir -p test-results
             - name: Run tests with coverage

--- a/README.md
+++ b/README.md
@@ -211,7 +211,9 @@ docker compose -f archive/docker-compose.prod.yaml --env-file .env.prod up -d
 4. Copy each `*.env.example` to `.env` inside its service directory.
 5. Build the containers with `make deps` and start them with `make up`.
 6. Apply database migrations using `bash scripts/run_migrations.sh`.
-7. Install the project **before** running tests. Use editable mode so `pytest` can import the `devonboarder` package:
+7. Run `python -m diagnostics` to verify required packages load, services are
+   healthy, and environment variables match the examples.
+8. Install the project **before** running tests. Use editable mode so `pytest` can import the `devonboarder` package:
 
    ```bash
    pip install -e .  # or `pip install -r requirements.txt` if present
@@ -226,11 +228,11 @@ docker compose -f archive/docker-compose.prod.yaml --env-file .env.prod up -d
    **Note:** both installs must finish before running `pytest` or the tests may
    fail with `ModuleNotFoundError`. See
    [tests/README.md](tests/README.md) for details.
-8. Run `./scripts/run_tests.sh` to install dependencies and execute all tests.
+9. Run `./scripts/run_tests.sh` to install dependencies and execute all tests.
    This wrapper prints helpful hints when packages are missing. See
    [docs/troubleshooting.md](docs/troubleshooting.md) if any failures occur.
-9. Install git hooks with `pre-commit install` so lint checks run automatically.
-10. The CI workflow enforces a minimum of **95% code coverage** for all projects
+10. Install git hooks with `pre-commit install` so lint checks run automatically.
+11. The CI workflow enforces a minimum of **95% code coverage** for all projects
    (frontend, bot, and backend). Pull requests will fail if any test suite drops
    below this threshold.
 

--- a/docs/Agents.md
+++ b/docs/Agents.md
@@ -194,6 +194,7 @@ Use a small loop in your workflow to wait for the auth service before running te
 - [x] Document each agent's purpose, key files, environment, and workflow.
 - [x] Update this file and the changelog when an agent changes.
 - [x] Ensure healthchecks pass for required services.
+- [x] Run `python -m diagnostics` to verify packages, service health, and env vars.
 
 ---
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this project will be recorded in this file.
 - Aligned yamllint invocation across scripts and CI with
   `yamllint -c .github/.yamllint-config .github/workflows/**/*.yml`.
 - Fixed indentation of Python blocks in `auto-fix.yml` to resolve YAML linting errors.
+- Added `src/diagnostics.py` with a `python -m diagnostics` entry for package
+  and service health checks. CI runs the script and uploads its log.
 
 - Improved `ci-monitor.yml` to detect additional rate-limit phrases and fall back
   to `${{ secrets.GITHUB_TOKEN }}` when `CI_ISSUE_TOKEN` is unavailable.

--- a/src/diagnostics.py
+++ b/src/diagnostics.py
@@ -1,0 +1,82 @@
+"""Basic diagnostics for the DevOnboarder stack."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import requests
+
+
+REQUIRED_PACKAGES = ["fastapi", "pytest"]
+SERVICE_VARS = {
+    "auth": ("AUTH_URL", "http://localhost:8002"),
+    "xp": ("API_BASE_URL", "http://localhost:8001"),
+    "feedback": ("VITE_FEEDBACK_URL", "http://localhost:8090"),
+}
+
+
+def check_packages() -> list[str]:
+    """Import required packages and return any failures."""
+    failures: list[str] = []
+    for pkg in REQUIRED_PACKAGES:
+        try:
+            importlib.import_module(pkg)
+            print(f"{pkg} imported")
+        except Exception as exc:  # pragma: no cover - fails printed
+            msg = f"Failed to import {pkg}: {exc}"
+            print(msg)
+            failures.append(msg)
+    return failures
+
+
+def check_health() -> dict[str, str]:
+    """Call each service's `/health` endpoint and return statuses."""
+    statuses: dict[str, str] = {}
+    for name, (env_var, default) in SERVICE_VARS.items():
+        base = os.getenv(env_var, default).rstrip("/")
+        url = f"{base}/health"
+        try:
+            resp = requests.get(url, timeout=5)
+            statuses[name] = f"{resp.status_code} {resp.reason}"
+        except requests.RequestException as exc:  # pragma: no cover - network fail
+            statuses[name] = f"error: {exc}"
+        print(f"{name}: {statuses[name]}")
+    return statuses
+
+
+def audit_env() -> dict[str, list[str]]:
+    """Run `scripts/audit_env_vars.sh` and return its summary."""
+    tmp = Path("env_audit.json")
+    env = os.environ.copy()
+    env["JSON_OUTPUT"] = str(tmp)
+    result = subprocess.run(
+        ["bash", "scripts/audit_env_vars.sh"],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    print(result.stdout)
+    if tmp.exists():
+        data = json.loads(tmp.read_text())
+        tmp.unlink()
+    else:  # pragma: no cover - script failure
+        data = {"missing": [], "extra": []}
+    print(f"Missing: {data.get('missing', [])}")
+    print(f"Extra: {data.get('extra', [])}")
+    return data
+
+
+def main() -> None:
+    """Run all diagnostic checks."""
+    check_packages()
+    check_health()
+    audit_env()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,70 @@
+import importlib
+import subprocess
+
+import diagnostics
+
+
+class StubResp:
+    def __init__(self, code: int):
+        self.status_code = code
+        self.reason = "OK"
+
+
+def test_check_packages_success(monkeypatch, capsys):
+    monkeypatch.setattr(importlib, "import_module", lambda name: None)
+    assert diagnostics.check_packages() == []
+    out = capsys.readouterr().out
+    assert "fastapi imported" in out
+    assert "pytest imported" in out
+
+
+def test_check_packages_failure(monkeypatch, capsys):
+    def fake_import(name: str):
+        if name == "pytest":
+            raise ImportError("boom")
+        return None
+
+    monkeypatch.setattr(importlib, "import_module", fake_import)
+    failures = diagnostics.check_packages()
+    assert failures == ["Failed to import pytest: boom"]
+    assert "Failed to import pytest" in capsys.readouterr().out
+
+
+def test_check_health(monkeypatch):
+    monkeypatch.setenv("AUTH_URL", "http://auth")
+    monkeypatch.setenv("API_BASE_URL", "http://xp")
+    monkeypatch.setenv("VITE_FEEDBACK_URL", "http://feedback")
+
+    def fake_get(url: str, timeout: int = 5):
+        return StubResp(200)
+
+    monkeypatch.setattr(diagnostics.requests, "get", fake_get)
+    statuses = diagnostics.check_health()
+    assert statuses == {"auth": "200 OK", "xp": "200 OK", "feedback": "200 OK"}
+
+
+def test_audit_env(monkeypatch, tmp_path, capsys):
+    tmp_json = tmp_path / "env_audit.json"
+
+    def fake_run(cmd, env=None, capture_output=True, text=True, check=False):
+        tmp_json.write_text('{"missing":["A"],"extra":["B"]}')
+        stdout = (
+            "Missing variables:\nA\n\nExtra variables:\nB\n\n"
+            '{"missing":["A"],"extra":["B"]}'
+        )
+        return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.chdir(tmp_path)
+    result = diagnostics.audit_env()
+    assert result == {"missing": ["A"], "extra": ["B"]}
+    out = capsys.readouterr().out
+    assert "Missing variables" in out
+
+
+def test_module_cli(monkeypatch, capsys):
+    monkeypatch.setattr(diagnostics, "check_packages", lambda: None)
+    monkeypatch.setattr(diagnostics, "check_health", lambda: None)
+    monkeypatch.setattr(diagnostics, "audit_env", lambda: None)
+    diagnostics.main()
+    assert capsys.readouterr().out == ""


### PR DESCRIPTION
## Summary
- add `src/diagnostics.py` module with package and health checks
- document running `python -m diagnostics`
- run diagnostics in CI and upload results
- add unit tests for diagnostics

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687322e690f083208f7003d9748b5e7a