### PR TITLE
Update onboarding to run diagnostics

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -748,3 +748,5 @@ All notable changes to this project will be recorded in this file.
 - Added CI and Auto Fix badges to `README.md`.
 - Added `ci-monitor.yml` to open an issue when CI fails due to API rate limits and documented the secret in `docs/ci-env-vars.md`.
 - Updated docs/README local setup to run `python -m diagnostics` after bootstrap. The script checks package imports, service health, and environment variables.
+- Updated `docs/ONBOARDING.md` to run `python -m diagnostics` once services are
+  running and link to `docs/troubleshooting.md` for interpreting failures.

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -6,6 +6,10 @@ See the [Service Health Checks](README.md#service-health-checks) section for
 monitoring endpoints available locally and in production.
 Please review our [Code of Conduct](../CODE_OF_CONDUCT.md) before contributing.
 
+* After services start, run `python -m diagnostics` to verify packages, service
+  health, and environment variables. See
+  [troubleshooting.md](troubleshooting.md) for help interpreting failures.
+
 ## Requesting a Codex QA Assessment
 
 * **To trigger a full QA sweep:** Simply comment


### PR DESCRIPTION
## Summary
- note diagnostics step in docs/ONBOARDING
- link to troubleshooting guide for failures
- log change in CHANGELOG

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_687348e0d9f88320b71a5382ec384dce