### PR TITLE
Add diagnostics log sample

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to this project will be recorded in this file.
 - Fixed indentation of Python blocks in `auto-fix.yml` to resolve YAML linting errors.
 - Added `src/diagnostics.py` with a `python -m diagnostics` entry for package
   and service health checks. CI runs the script and uploads its log.
+- Added `docs/diagnostics-sample.log` and referenced it from onboarding docs to
+  show expected output from `python -m diagnostics`.
 
 - Improved `ci-monitor.yml` to detect additional rate-limit phrases and fall back
   to `${{ secrets.GITHUB_TOKEN }}` when `CI_ISSUE_TOKEN` is unavailable.

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -8,6 +8,7 @@ Please review our [Code of Conduct](../CODE_OF_CONDUCT.md) before contributing.
 
 * After services start, run `python -m diagnostics` to verify packages, service
   health, and environment variables. See
+  [diagnostics-sample.log](diagnostics-sample.log) for a sample output and
   [troubleshooting.md](troubleshooting.md) for help interpreting failures.
 
 ## Requesting a Codex QA Assessment

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,7 +30,8 @@ check in CI. See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
    This launches the auth, bot, XP API, frontend, and Postgres services.
    The `frontend/` folder now hosts a React app built with Vite.
 6. Run `bash scripts/run_migrations.sh` to apply the initial database migration.
-7. Run `python -m diagnostics` to confirm required packages import, all services are healthy, and environment variables match the examples.
+7. Run `python -m diagnostics` to confirm required packages import, all services are healthy, and environment variables match the examples. See
+   [diagnostics-sample.log](diagnostics-sample.log) for the expected output.
 8. Alternatively, run `devonboarder-server` to start the app without Docker. Stop the server with Ctrl+C.
 9. Visit `http://localhost:8000` to see the greeting server.
 10. Run `devonboarder-api` to start the user API at `http://localhost:8001`.

--- a/docs/diagnostics-sample.log
+++ b/docs/diagnostics-sample.log
@@ -1,0 +1,24 @@
+fastapi imported
+pytest imported
+auth: 200 OK
+xp: 200 OK
+feedback: 200 OK
+Missing variables:
+
+
+Extra variables:
+JSON_OUTPUT
+LC_CTYPE
+PATH
+PWD
+PYENV_DIR
+PYENV_HOOK_PATH
+PYENV_ROOT
+PYENV_VERSION
+PYTHONPATH
+SHLVL
+_
+{"missing":[],"extra":["JSON_OUTPUT" ,"LC_CTYPE" ,"PATH" ,"PWD" ,"PYENV_DIR" ,"PYENV_HOOK_PATH" ,"PYENV_ROOT" ,"PYENV_VERSION" ,"PYTHONPATH" ,"SHLVL" ,"_"]}
+
+Missing: []
+Extra: ['JSON_OUTPUT', 'LC_CTYPE', 'PATH', 'PWD', 'PYENV_DIR', 'PYENV_HOOK_PATH', 'PYENV_ROOT', 'PYENV_VERSION', 'PYTHONPATH', 'SHLVL', '_']


### PR DESCRIPTION
## Summary
- show example output from `python -m diagnostics`
- link diagnostics sample log from onboarding docs
- document diagnostics log in changelog

## Testing
- `pre-commit run --files docs/README.md docs/ONBOARDING.md docs/diagnostics-sample.log` *(fails: CalledProcessError: command: ('/usr/bin/git', 'checkout', 'v3.6.2'))*
- `pytest -k '' -q` *(fails: sqlalchemy.exc.ArgumentError: Could not parse SQLAlchemy URL from given URL string)*

------
https://chatgpt.com/codex/tasks/task_e_68734c743bcc8320a900a226da6406ea