### PR TITLE
Clarify TAGS compose file instructions

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -752,3 +752,4 @@ All notable changes to this project will be recorded in this file.
 - Updated docs/README local setup to run `python -m diagnostics` after bootstrap. The script checks package imports, service health, and environment variables.
 - Updated `docs/ONBOARDING.md` to run `python -m diagnostics` once services are
   running and link to `docs/troubleshooting.md` for interpreting failures.
+- Clarified how to obtain the TAGS compose files in `docs/tags_integration.md`.

--- a/docs/tags_integration.md
+++ b/docs/tags_integration.md
@@ -1,14 +1,19 @@
 # Integrating with TAGS
 
-The TAGS stack uses dedicated Compose files to coordinate each service. Start a local
-stack with:
+The TAGS stack uses dedicated Compose files to coordinate each service. These
+files are not tracked in this repository because the configuration differs per
+deployment. Obtain the templates from the TAGS infrastructure repository or
+generate them locally by copying `archive/docker-compose.dev.yaml` and adjusting
+the service names. Start a local stack with:
 
 ```bash
 docker compose -f docker-compose.tags.dev.yaml up
 ```
 
-Production deployments rely on `docker-compose.tags.prod.yaml`. Both files extend the
-base `docker-compose.yml` and enable extra logging suitable for the TAGS environment.
+Production deployments rely on `docker-compose.tags.prod.yaml`. Both files
+extend the base `docker-compose.yml` and enable extra logging suitable for the
+TAGS environment.
+
 
 Feature flags control early access routes. Add the following settings to `.env.dev` when
 running against the TAGS stack:


### PR DESCRIPTION
## Summary
- explain where to source the TAGS compose files
- document the new instructions in the changelog

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6873e6bb9c7c8320a7afdbe43b03d2e5