### PR TITLE
DOCS: mention TAGS docs in onboarding

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -33,6 +33,9 @@ All notable changes to this project will be recorded in this file.
 - Added `docs/ecosystem.md` and `docs/tags_integration.md` describing the TAGS
   stack and integration steps. Linked them from both READMEs.
 
+- Linked TAGS stack docs from `docs/ONBOARDING.md` and mentioned `IS_ALPHA_USER`
+  and `IS_FOUNDER` for running in TAGS.
+
 - Added `LLAMA2_API_TIMEOUT` variable with default `10` and documented it.
 - Replaced the Node.js installation command to download the NodeSource script
   before running it, referencing the security policy.

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -10,6 +10,10 @@ Please review our [Code of Conduct](../CODE_OF_CONDUCT.md) before contributing.
   health, and environment variables. See
   [diagnostics-sample.log](diagnostics-sample.log) for a sample output and
   [troubleshooting.md](troubleshooting.md) for help interpreting failures.
+* Review [ecosystem.md](ecosystem.md) for how DevOnboarder fits into TAGS and
+  [tags_integration.md](tags_integration.md) for compose templates. Set
+  `IS_ALPHA_USER` or `IS_FOUNDER` in `.env.dev` when running within the TAGS
+  stack to expose early-access endpoints.
 
 ## Requesting a Codex QA Assessment
 


### PR DESCRIPTION
## Summary
- link `ecosystem.md` and `tags_integration.md` from onboarding docs
- advise setting `IS_ALPHA_USER` or `IS_FOUNDER` when running the TAGS stack
- document the change in the changelog

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68742927e12c8320993c9b46b38c4ae8