### PR TITLE
Add TAGS integration prompt

### DIFF
--- a/codex.tasks.json
+++ b/codex.tasks.json
@@ -32,6 +32,15 @@
             "status": "planned",
             "milestone": "v0.5.1"
         }
+        ,
+        {
+            "id": "integration-002",
+            "title": "DevOnboarder TAGS integration checklist",
+            "module": "tags_integration",
+            "description": "QA steps for adding DevOnboarder to TAGS. See prompts/devonboarder_integration_task.md",
+            "status": "planned",
+            "milestone": "v0.5.2"
+        }
     ],
     "completedTasks": [
         {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable changes to this project will be recorded in this file.
   and service health checks. CI runs the script and uploads its log.
 - Added `docs/diagnostics-sample.log` and referenced it from onboarding docs to
   show expected output from `python -m diagnostics`.
+- Added `prompts/devonboarder_integration_task.md` and referenced it from
+  `codex.tasks.json` so Codex can generate integration steps automatically.
 
 - Improved `ci-monitor.yml` to detect additional rate-limit phrases and fall back
   to `${{ secrets.GITHUB_TOKEN }}` when `CI_ISSUE_TOKEN` is unavailable.

--- a/prompts/devonboarder_integration_task.md
+++ b/prompts/devonboarder_integration_task.md
@@ -1,0 +1,30 @@
+# DevOnboarder TAGS Integration Task
+
+Follow these steps when adding DevOnboarder to the TAGS stack. They mirror the docs under `docs/tags_integration.md` but are condensed for Codex to generate QA tasks.
+
+## Key environment variables
+
+- `IS_ALPHA_USER=true`
+- `IS_FOUNDER=true`
+- `AUTH_URL` – base URL for the auth service
+- `API_BASE_URL` – base URL for the XP API
+- `CHECK_HEADERS_URL` – endpoint checked by `scripts/check_headers.py`
+- `VITE_AUTH_URL` and `VITE_API_URL` – frontend URLs
+
+## Compose commands
+
+```bash
+docker compose -f docker-compose.tags.dev.yaml --env-file .env.dev up -d
+# To stop
+docker compose -f docker-compose.tags.dev.yaml down
+```
+
+## Diagnostics
+
+After the stack is running, run:
+
+```bash
+python -m diagnostics
+```
+
+Check container status with `docker compose ps` and view logs with `docker compose logs <service>` if diagnostics report failures.


### PR DESCRIPTION
## Summary
- document DevOnboarder steps for TAGS integration
- list compose commands and diagnostics usage
- reference the new prompt from codex.tasks.json
- document the update in the changelog

## Testing
- `scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68742a9932188320b7dee39b6c8bd630