### PR TITLE
Add TAGS compose templates

### DIFF
--- a/archive/docker-compose.tags.dev.yaml
+++ b/archive/docker-compose.tags.dev.yaml
@@ -1,0 +1,67 @@
+# Example TAGS development compose file. Copy to the repo root as
+# `docker-compose.tags.dev.yaml` and customize the service names,
+# images, and environment variables to match your deployment.
+x-app-base: &app-base
+  build: .
+
+x-node-base: &node-base
+  image: node:20
+  command: ["npm", "start"]
+
+x-db-base: &db-base
+  image: postgres:15
+  environment:
+    POSTGRES_USER: devuser
+    POSTGRES_PASSWORD: devpass
+    POSTGRES_DB: devdb
+  volumes:
+    - db_data:/var/lib/postgresql/data
+
+x-env-dev: &env-dev
+  env_file:
+    - .env.dev
+
+services:
+  auth:
+    <<: [*app-base, *env-dev]
+    command: ["devonboarder-auth"]
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8002/health"]
+      interval: 5s
+      timeout: 2s
+      retries: 10
+
+  bot:
+    build:
+      context: .
+      dockerfile: bot/Dockerfile.dev
+    env_file:
+      - .env.dev
+    volumes:
+      - ./docs:/docs
+
+  xp:
+    <<: [*app-base, *env-dev]
+    command: ["devonboarder-api"]
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8001/health"]
+      interval: 5s
+      timeout: 2s
+      retries: 10
+
+  frontend:
+    build:
+      context: .
+      dockerfile: frontend/Dockerfile.dev
+    env_file:
+      - .env.dev
+    ports:
+      - "3000:3000"
+
+  db:
+    <<: [*db-base, *env-dev]
+    ports:
+      - "5432:5432"
+
+volumes:
+  db_data:

--- a/archive/docker-compose.tags.prod.yaml
+++ b/archive/docker-compose.tags.prod.yaml
@@ -1,0 +1,60 @@
+# Example TAGS production compose file. Copy to the repo root as
+# `docker-compose.tags.prod.yaml` and customize the service names,
+# images, and environment variables to match your deployment.
+x-app-base: &app-base
+  build: .
+
+x-node-base: &node-base
+  image: node:20
+  command: ["npm", "start"]
+
+x-db-base: &db-base
+  image: postgres:15
+  environment:
+    POSTGRES_USER: devuser
+    POSTGRES_PASSWORD: devpass
+    POSTGRES_DB: devdb
+  volumes:
+    - db_data:/var/lib/postgresql/data
+
+x-env-prod: &env-prod
+  env_file:
+    - .env.prod
+
+services:
+  auth:
+    <<: [*app-base, *env-prod]
+    command: ["devonboarder-auth"]
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8002/health"]
+      interval: 5s
+      timeout: 2s
+      retries: 10
+
+  bot:
+    <<: [*node-base, *env-prod]
+    working_dir: /bot
+    volumes:
+      - ./bot:/bot
+      - ./docs:/docs
+
+  xp:
+    <<: [*app-base, *env-prod]
+    command: ["devonboarder-api"]
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8001/health"]
+      interval: 5s
+      timeout: 2s
+      retries: 10
+
+  frontend:
+    <<: [*node-base, *env-prod]
+    working_dir: /frontend
+    volumes:
+      - ./frontend:/frontend
+
+  db:
+    <<: [*db-base, *env-prod]
+
+volumes:
+  db_data:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -758,3 +758,5 @@ All notable changes to this project will be recorded in this file.
 - Updated `docs/ONBOARDING.md` to run `python -m diagnostics` once services are
   running and link to `docs/troubleshooting.md` for interpreting failures.
 - Clarified how to obtain the TAGS compose files in `docs/tags_integration.md`.
+- Added example TAGS compose templates under `archive/` and documented how to
+  customize them in `docs/tags_integration.md`.

--- a/docs/tags_integration.md
+++ b/docs/tags_integration.md
@@ -1,10 +1,17 @@
 # Integrating with TAGS
 
-The TAGS stack uses dedicated Compose files to coordinate each service. These
-files are not tracked in this repository because the configuration differs per
-deployment. Obtain the templates from the TAGS infrastructure repository or
-generate them locally by copying `archive/docker-compose.dev.yaml` and adjusting
-the service names. Start a local stack with:
+The TAGS stack uses dedicated Compose files to coordinate each service.
+Minimal templates are now provided under `archive/`:
+
+```
+archive/docker-compose.tags.dev.yaml
+archive/docker-compose.tags.prod.yaml
+```
+
+Copy the appropriate file to the repository root and update the service names,
+image tags and environment variables to match your deployment. If your team
+maintains a central infrastructure repository, replace the templates with those
+versions. Start a local stack with:
 
 ```bash
 docker compose -f docker-compose.tags.dev.yaml up


### PR DESCRIPTION
## Summary
- add example TAGS compose templates under `archive/`
- document how to customize them in `docs/tags_integration.md`
- note the new templates in the changelog

## Testing
- `bash scripts/run_tests.sh`
- `bash scripts/check_docs.sh`


------
https://chatgpt.com/codex/tasks/task_e_687462911038832080d56c14d17968dc