### PR TITLE
Add TAGS_MODE integration flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,9 @@ APP_ENV=development
 DATABASE_URL=postgresql://devuser:devpass@localhost:5432/devdb
 
 TOKEN_EXPIRE_SECONDS=3600
+# Enable when running within the TAGS stack so diagnostics
+# expect all services to be available
+TAGS_MODE=false
 
 # Feature flags
 IS_ALPHA_USER=false

--- a/agents/index.md
+++ b/agents/index.md
@@ -22,6 +22,7 @@ The table below lists environment variables used across DevOnboarder agents. Kee
 | APP_ENV                      | Application mode (`development`, etc.)     |
 | DATABASE_URL                 | Postgres connection string                 |
 | TOKEN_EXPIRE_SECONDS         | JWT expiration in seconds                  |
+| TAGS_MODE                    | Expect TAGS services when `true`           |
 | CORS_ALLOW_ORIGINS           | Comma-separated list of allowed CORS origins |
 | IS_ALPHA_USER                | Enable alpha-only routes                   |
 | IS_FOUNDER                   | Enable founder-only routes                 |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -37,6 +37,8 @@ All notable changes to this project will be recorded in this file.
 
 - Linked TAGS stack docs from `docs/ONBOARDING.md` and mentioned `IS_ALPHA_USER`
   and `IS_FOUNDER` for running in TAGS.
+- Added `TAGS_MODE` variable to `.env.example`, diagnostics, and integration docs
+  so TAGS deployments check all services.
 
 - Added `LLAMA2_API_TIMEOUT` variable with default `10` and documented it.
 - Replaced the Node.js installation command to download the NodeSource script

--- a/docs/env.md
+++ b/docs/env.md
@@ -12,6 +12,8 @@ when working with those packages directly.
 - `APP_ENV` &ndash; application mode such as `development` or `production`.
 - `DATABASE_URL` &ndash; Postgres connection string for the main database.
 - `TOKEN_EXPIRE_SECONDS` &ndash; lifetime of auth tokens in seconds (default `3600`).
+- `TAGS_MODE` &ndash; set to `true` when running within the TAGS stack so
+  diagnostics expect all services.
 - `CORS_ALLOW_ORIGINS` &ndash; comma-separated list of allowed CORS origins. Defaults to `*` in development.
 - `INIT_DB_ON_STARTUP` &ndash; run database migrations automatically when the auth service starts.
 

--- a/docs/tags_integration.md
+++ b/docs/tags_integration.md
@@ -26,9 +26,13 @@ Feature flags control early access routes. Add the following settings to `.env.d
 running against the TAGS stack:
 
 ```
+TAGS_MODE=true
 IS_ALPHA_USER=true
 IS_FOUNDER=true
 ```
+
+`TAGS_MODE` tells the diagnostics script to verify the XP API and
+feedback services in addition to the auth server.
 
 With these flags set, the API exposes the `/alpha` and `/founder` endpoints described in
 [docs/env.md](env.md). Use the TAGS Compose files to run a fully integrated environment

--- a/src/diagnostics.py
+++ b/src/diagnostics.py
@@ -12,6 +12,8 @@ import requests
 
 
 REQUIRED_PACKAGES = ["fastapi", "pytest"]
+
+# Base service mappings used for health checks
 SERVICE_VARS = {
     "auth": ("AUTH_URL", "http://localhost:8002"),
     "xp": ("API_BASE_URL", "http://localhost:8001"),
@@ -33,10 +35,17 @@ def check_packages() -> list[str]:
     return failures
 
 
+def _get_services() -> dict[str, tuple[str, str]]:
+    """Return service mapping based on TAGS_MODE flag."""
+    if os.getenv("TAGS_MODE", "false").lower() == "true":
+        return SERVICE_VARS
+    return {"auth": SERVICE_VARS["auth"]}
+
+
 def check_health() -> dict[str, str]:
     """Call each service's `/health` endpoint and return statuses."""
     statuses: dict[str, str] = {}
-    for name, (env_var, default) in SERVICE_VARS.items():
+    for name, (env_var, default) in _get_services().items():
         base = os.getenv(env_var, default).rstrip("/")
         url = f"{base}/health"
         try:

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -30,7 +30,19 @@ def test_check_packages_failure(monkeypatch, capsys):
     assert "Failed to import pytest" in capsys.readouterr().out
 
 
-def test_check_health(monkeypatch):
+def test_check_health_basic(monkeypatch):
+    monkeypatch.setenv("AUTH_URL", "http://auth")
+
+    def fake_get(url: str, timeout: int = 5):
+        return StubResp(200)
+
+    monkeypatch.setattr(diagnostics.requests, "get", fake_get)
+    statuses = diagnostics.check_health()
+    assert statuses == {"auth": "200 OK"}
+
+
+def test_check_health_tags_mode(monkeypatch):
+    monkeypatch.setenv("TAGS_MODE", "true")
     monkeypatch.setenv("AUTH_URL", "http://auth")
     monkeypatch.setenv("API_BASE_URL", "http://xp")
     monkeypatch.setenv("VITE_FEEDBACK_URL", "http://feedback")


### PR DESCRIPTION
## Summary
- add `TAGS_MODE=false` to `.env.example`
- document `TAGS_MODE` in environment docs and TAGS integration guide
- include `TAGS_MODE` in agent variable table
- update diagnostics to check additional services when `TAGS_MODE=true`
- test diagnostics behaviour with and without TAGS mode
- note new flag in the changelog

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_687469fb6f148320a0ba1093954e2842