### PR TITLE
Fix YAML workflow linting

### DIFF
--- a/.github/.yamllint-config
+++ b/.github/.yamllint-config
@@ -1,9 +1,7 @@
 extends: default
 rules:
-  document-start:
-    enable: false
-  truthy:
-    enable: false
+  document-start: disable
+  truthy: disable
   line-length:
     max: 200
     level: warning

--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -62,7 +62,7 @@ jobs:
             prompt=f"yamllint output:\n{log}\n\nRelevant YAML snippet:\n{snippet}\nProvide a unified diff patch to fix these errors."
             resp=openai.chat.completions.create(model='gpt-4o', messages=[{'role':'user','content':prompt}])
             print(resp.choices[0].message.content)
-PY
+            PY
           )
           echo "$patch" > fix-ci-health.patch.diff
       - name: Apply YAML patch
@@ -88,7 +88,7 @@ PY
                 messages=[{'role':'user','content':prompt}]
             )
             print(response.choices[0].message.content)
-PY
+            PY
           )
           echo "$suggestion" > patch.diff
       - name: Apply patch

--- a/.github/workflows/ci-health.yml
+++ b/.github/workflows/ci-health.yml
@@ -74,7 +74,7 @@ jobs:
         run: bash scripts/run_tests.sh
       - name: Record result
         if: always()
-        run: echo "${{ matrix.branch }}: ${{ job.status }}" > result.txt
+        run: "echo \"${{ matrix.branch }}: ${{ job.status }}\" > result.txt"
       - name: Upload result
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -403,22 +403,22 @@ jobs:
                   set -euo pipefail
                   printf '\n' >> summary.md
                   cat audit.md >> summary.md
-                gh_bin=$(which gh)
-                "$gh_bin" auth status 2>&1 | tee -a gh_cli.log
-                search_query="label:ci-failure ${{ github.sha }} in:title,body"
-                echo "Searching with: $search_query" | tee -a gh_cli.log
-                set +e
-                search_output=$($gh_bin issue list --state open --search "$search_query" --json number --jq '.[0].number' 2>&1 | tee -a gh_cli.log)
-                list_exit=$?
-                set -e
-                echo "Search exit code: $list_exit" | tee -a gh_cli.log
-                if [ "$list_exit" -eq 0 ] && [ -n "$search_output" ]; then
-                    ISSUE="$search_output"
-                    "$gh_bin" issue comment "$ISSUE" --body-file summary.md 2>&1 | tee -a gh_cli.log
-                else
-                    echo "::warning::Issue search failed or returned no results" | tee -a gh_cli.log
-                    ISSUE=$($gh_bin issue create --title "CI Failures for ${{ github.sha }}" --body-file summary.md --label ci-failure --json number --jq '.number' | tee -a gh_cli.log)
-                fi
+                  gh_bin=$(which gh)
+                  "$gh_bin" auth status 2>&1 | tee -a gh_cli.log
+                  search_query="label:ci-failure ${{ github.sha }} in:title,body"
+                  echo "Searching with: $search_query" | tee -a gh_cli.log
+                  set +e
+                  search_output=$($gh_bin issue list --state open --search "$search_query" --json number --jq '.[0].number' 2>&1 | tee -a gh_cli.log)
+                  list_exit=$?
+                  set -e
+                  echo "Search exit code: $list_exit" | tee -a gh_cli.log
+                  if [ "$list_exit" -eq 0 ] && [ -n "$search_output" ]; then
+                      ISSUE="$search_output"
+                      "$gh_bin" issue comment "$ISSUE" --body-file summary.md 2>&1 | tee -a gh_cli.log
+                  else
+                      echo "::warning::Issue search failed or returned no results" | tee -a gh_cli.log
+                      ISSUE=$($gh_bin issue create --title "CI Failures for ${{ github.sha }}" --body-file summary.md --label ci-failure --json number --jq '.number' | tee -a gh_cli.log)
+                  fi
                   echo "issue-number=$ISSUE" >> "$GITHUB_OUTPUT"
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/env-doc-alignment.yml
+++ b/.github/workflows/env-doc-alignment.yml
@@ -47,11 +47,11 @@ jobs:
         if: steps.check.outputs.success == 'false'
         run: |
           cat > body.md <<'BODY'
-## Missing variables
-${{ steps.vars.outputs.missing }}
+            ## Missing variables
+            ${{ steps.vars.outputs.missing }}
 
-- [ ] I manually reviewed the variables against [agents/index.md](../../agents/index.md)
-BODY
+            - [ ] I manually reviewed the variables against [agents/index.md](../../agents/index.md)
+          BODY
           gh issue create --title "Secrets misaligned in docs for ${{ github.event.workflow_run.head_sha || github.sha }}" --label ops --template "secret-alignment.md" --body-file body.md
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/secrets-alignment.yml
+++ b/.github/workflows/secrets-alignment.yml
@@ -51,14 +51,14 @@ jobs:
         if: steps.vars.outputs.missing != '' || steps.vars.outputs.extras != ''
         run: |
           cat > body.md <<'BODY'
-## Missing variables
-${{ steps.vars.outputs.missing }}
+            ## Missing variables
+            ${{ steps.vars.outputs.missing }}
 
-## Extra variables
-${{ steps.vars.outputs.extras }}
+            ## Extra variables
+            ${{ steps.vars.outputs.extras }}
 
-- [ ] I manually reviewed the variables against [agents/index.md](../../agents/index.md)
-BODY
+            - [ ] I manually reviewed the variables against [agents/index.md](../../agents/index.md)
+          BODY
           gh issue create --title "Secrets misaligned in CI for ${{ github.event.workflow_run.head_sha || github.sha }}" --label ops --template "secret-alignment.md" --body-file body.md
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- align indentation within workflow scripts
- fix inline command quoting in CI health job
- disable yamllint rules using supported syntax

## Testing
- `bash scripts/run_tests.sh`
- `yamllint -c .github/.yamllint-config .github/workflows/ci.yml`
- `yamllint -c .github/.yamllint-config .github/workflows/auto-fix.yml`
- `yamllint -c .github/.yamllint-config .github/workflows/ci-health.yml`
- `yamllint -c .github/.yamllint-config .github/workflows/env-doc-alignment.yml`
- `yamllint -c .github/.yamllint-config .github/workflows/secrets-alignment.yml`


------
https://chatgpt.com/codex/tasks/task_e_6874784be8788320840079868bcf8098