### PR TITLE
Update CI documentation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be recorded in this file.
 ## [Unreleased]
 
 - Linked `docs/CHANGELOG.md` from `README.md` for easier navigation.
+- Documented that the `validate-yaml` step always runs even when `[no-ci]` skips
+  the test job and clarified the `[no-ci]` marker in `docs/ci-workflow.md`.
 - Added `.github/.yamllint-config` to centralize workflow lint rules, disabling
   `document-start` and `truthy` and warning on lines over 200 characters.
 - Aligned yamllint invocation across scripts and CI with

--- a/docs/ci-workflow.md
+++ b/docs/ci-workflow.md
@@ -16,6 +16,17 @@ The workflow runs `dorny/paths-filter` before other jobs. When the filter
 detects that only files under `docs/` or Markdown files were modified, the
 remaining jobs do not run. This keeps documentation-only pull requests fast.
 
+## Minimal Checks
+
+A `validate-yaml` job always runs first and lints the workflow files with
+`ibiqlik/action-yamllint`. This step executes even when the documentation filter
+skips the heavier test job or when a commit message contains `[no-ci]`.
+
+## Skipping the Test Job
+
+Pushes can opt out of the main test job by including `[no-ci]` anywhere in the
+commit message. Pull requests ignore this marker and run the full workflow.
+
 ## Caching
 
 The job caches several directories to speed up subsequent runs:


### PR DESCRIPTION
## Summary
- clarify `[no-ci]` filter behavior and document always-running YAML lint

## Testing
- `bash scripts/run_tests.sh` *(fails: Cannot read properties of undefined (reading 'then'))*

------
https://chatgpt.com/codex/tasks/task_e_68747bae58dc83209b629047fe74cb94