### PR TITLE
Document TAGS compose file location

### DIFF
--- a/docker-compose.tags.dev.yaml
+++ b/docker-compose.tags.dev.yaml
@@ -1,0 +1,67 @@
+# Example TAGS development compose file. Copy to the repo root as
+# `docker-compose.tags.dev.yaml` and customize the service names,
+# images, and environment variables to match your deployment.
+x-app-base: &app-base
+  build: .
+
+x-node-base: &node-base
+  image: node:20
+  command: ["npm", "start"]
+
+x-db-base: &db-base
+  image: postgres:15
+  environment:
+    POSTGRES_USER: devuser
+    POSTGRES_PASSWORD: devpass
+    POSTGRES_DB: devdb
+  volumes:
+    - db_data:/var/lib/postgresql/data
+
+x-env-dev: &env-dev
+  env_file:
+    - .env.dev
+
+services:
+  auth:
+    <<: [*app-base, *env-dev]
+    command: ["devonboarder-auth"]
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8002/health"]
+      interval: 5s
+      timeout: 2s
+      retries: 10
+
+  bot:
+    build:
+      context: .
+      dockerfile: bot/Dockerfile.dev
+    env_file:
+      - .env.dev
+    volumes:
+      - ./docs:/docs
+
+  xp:
+    <<: [*app-base, *env-dev]
+    command: ["devonboarder-api"]
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8001/health"]
+      interval: 5s
+      timeout: 2s
+      retries: 10
+
+  frontend:
+    build:
+      context: .
+      dockerfile: frontend/Dockerfile.dev
+    env_file:
+      - .env.dev
+    ports:
+      - "3000:3000"
+
+  db:
+    <<: [*db-base, *env-dev]
+    ports:
+      - "5432:5432"
+
+volumes:
+  db_data:

--- a/docker-compose.tags.prod.yaml
+++ b/docker-compose.tags.prod.yaml
@@ -1,0 +1,60 @@
+# Example TAGS production compose file. Copy to the repo root as
+# `docker-compose.tags.prod.yaml` and customize the service names,
+# images, and environment variables to match your deployment.
+x-app-base: &app-base
+  build: .
+
+x-node-base: &node-base
+  image: node:20
+  command: ["npm", "start"]
+
+x-db-base: &db-base
+  image: postgres:15
+  environment:
+    POSTGRES_USER: devuser
+    POSTGRES_PASSWORD: devpass
+    POSTGRES_DB: devdb
+  volumes:
+    - db_data:/var/lib/postgresql/data
+
+x-env-prod: &env-prod
+  env_file:
+    - .env.prod
+
+services:
+  auth:
+    <<: [*app-base, *env-prod]
+    command: ["devonboarder-auth"]
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8002/health"]
+      interval: 5s
+      timeout: 2s
+      retries: 10
+
+  bot:
+    <<: [*node-base, *env-prod]
+    working_dir: /bot
+    volumes:
+      - ./bot:/bot
+      - ./docs:/docs
+
+  xp:
+    <<: [*app-base, *env-prod]
+    command: ["devonboarder-api"]
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8001/health"]
+      interval: 5s
+      timeout: 2s
+      retries: 10
+
+  frontend:
+    <<: [*node-base, *env-prod]
+    working_dir: /frontend
+    volumes:
+      - ./frontend:/frontend
+
+  db:
+    <<: [*db-base, *env-prod]
+
+volumes:
+  db_data:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -765,3 +765,5 @@ All notable changes to this project will be recorded in this file.
 - Clarified how to obtain the TAGS compose files in `docs/tags_integration.md`.
 - Added example TAGS compose templates under `archive/` and documented how to
   customize them in `docs/tags_integration.md`.
+- Copied the TAGS compose templates to the repository root and clarified the
+  path in `docs/tags_integration.md`.

--- a/docs/tags_integration.md
+++ b/docs/tags_integration.md
@@ -1,15 +1,15 @@
 # Integrating with TAGS
 
 The TAGS stack uses dedicated Compose files to coordinate each service.
-Minimal templates are now provided under `archive/`:
+Templates are tracked in the repository root and under `archive/`:
 
 ```
-archive/docker-compose.tags.dev.yaml
-archive/docker-compose.tags.prod.yaml
+docker-compose.tags.dev.yaml    # or archive/docker-compose.tags.dev.yaml
+docker-compose.tags.prod.yaml   # or archive/docker-compose.tags.prod.yaml
 ```
-
-Copy the appropriate file to the repository root and update the service names,
-image tags and environment variables to match your deployment. If your team
+Copies of these templates are provided in the repository root. If they are
+missing, copy them from `archive/` and update the service names, image tags and
+environment variables to match your deployment. If your team
 maintains a central infrastructure repository, replace the templates with those
 versions. Start a local stack with:
 


### PR DESCRIPTION
## Summary
- add docker-compose.tags.dev.yaml and docker-compose.tags.prod.yaml to project root
- document path to these files in the TAGS integration guide
- note compose file addition in the changelog

## Testing
- `bash scripts/run_tests.sh`
- `bash scripts/check_docs.sh`


------
https://chatgpt.com/codex/tasks/task_e_68747dafe2208320948b1f8b1928bee3