### PR TITLE
Add codex agent index and doc headers

### DIFF
--- a/agents/ai-mentor.md
+++ b/agents/ai-mentor.md
@@ -1,3 +1,12 @@
+---
+codex-agent:
+  name: Agent.AiMentor
+  role: Provides automated mentorship for contributors
+  scope: onboarding workflows
+  triggers: Contributor questions
+  output: Curated resources
+---
+
 # AI Mentor Agent
 
 **Status:** Planned.

--- a/agents/discord-integration.md
+++ b/agents/discord-integration.md
@@ -1,3 +1,12 @@
+---
+codex-agent:
+  name: Agent.DiscordIntegration
+  role: Handles Discord OAuth flows and role lookups
+  scope: auth service
+  triggers: User Discord login or role sync request
+  output: Discord role mapping
+---
+
 # Discord Integration Agent
 
 **Status:** Deferred – planned endpoints `/oauth` and `/roles` are not yet implemented.

--- a/agents/idme-verification.md
+++ b/agents/idme-verification.md
@@ -1,3 +1,12 @@
+---
+codex-agent:
+  name: Agent.IdmeVerification
+  role: Verifies users through ID.me
+  scope: user onboarding
+  triggers: ID.me OAuth token submission
+  output: Verification confirmation
+---
+
 # ID.me Verification Agent
 
 **Status:** Planned.

--- a/agents/llama2-agile-helper.md
+++ b/agents/llama2-agile-helper.md
@@ -1,3 +1,12 @@
+---
+codex-agent:
+  name: Agent.Llama2AgileHelper
+  role: Provides agile planning advice via Llama2
+  scope: sprint workflows
+  triggers: Developer questions or metrics updates
+  output: Backlog grooming tips
+---
+
 # Llama2 Agile Helper Agent
 **Status:** Active.
 

--- a/agents/ms-teams-integration.md
+++ b/agents/ms-teams-integration.md
@@ -1,3 +1,12 @@
+---
+codex-agent:
+  name: Agent.MsTeamsIntegration
+  role: Sends DevOnboarder updates to Microsoft Teams
+  scope: infrastructure notifications
+  triggers: Project events requiring team alerts
+  output: Teams channel messages
+---
+
 # MS Teams Integration Agent
 
 **Status:** Planned.

--- a/codex/agents/README.md
+++ b/codex/agents/README.md
@@ -1,0 +1,15 @@
+# Codex Agents
+
+This directory holds metadata about automation agents used in the DevOnboarder project.
+
+## index.json
+
+`index.json` contains an `agents` array. Each entry has these fields:
+
+- `name` – canonical agent identifier
+- `role` – short description of what the agent does
+- `path` – relative path to the agent documentation
+- `triggers` – conditions that activate the agent
+- `output` – artifact or result produced
+
+The data mirrors the `codex-agent` YAML headers inside documentation files under `agents/`.

--- a/codex/agents/index.json
+++ b/codex/agents/index.json
@@ -1,0 +1,39 @@
+{
+  "agents": [
+    {
+      "name": "Agent.DiscordIntegration",
+      "role": "Handles Discord OAuth flows and role lookups",
+      "path": "agents/discord-integration.md",
+      "triggers": "User Discord login or role sync request",
+      "output": "Discord role mapping"
+    },
+    {
+      "name": "Agent.AiMentor",
+      "role": "Provides automated mentorship for contributors",
+      "path": "agents/ai-mentor.md",
+      "triggers": "Contributor questions via chat or CLI",
+      "output": "Suggested resources and guidance"
+    },
+    {
+      "name": "Agent.MsTeamsIntegration",
+      "role": "Sends DevOnboarder updates to Microsoft Teams",
+      "path": "agents/ms-teams-integration.md",
+      "triggers": "Project events requiring team notifications",
+      "output": "Teams channel messages"
+    },
+    {
+      "name": "Agent.IdmeVerification",
+      "role": "Verifies users through ID.me",
+      "path": "agents/idme-verification.md",
+      "triggers": "User submits ID.me OAuth tokens",
+      "output": "Verification confirmation"
+    },
+    {
+      "name": "Agent.Llama2AgileHelper",
+      "role": "Provides agile planning advice via Llama2",
+      "path": "agents/llama2-agile-helper.md",
+      "triggers": "Developer questions or metrics updates",
+      "output": "Sprint summaries and grooming tips"
+    }
+  ]
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -713,6 +713,7 @@ All notable changes to this project will be recorded in this file.
 - Documented the Node.js 20 requirement in the bot and frontend READMEs and referenced `.nvmrc`.
 - Added `docs/service-status.md` summarizing core service health and linked it from the documentation overview.
 - Re-added `"milestone": "v0.5.0"` for `feedback-002` in `codex.tasks.json`.
+- Documented Codex agent index and YAML headers for agent docs.
 
 ## [0.1.0] - 2025-06-14
 


### PR DESCRIPTION
## Summary
- document active DevOnboarder agents in `codex/agents/index.json`
- explain the index format in `codex/agents/README.md`
- add `codex-agent` YAML headers to each agent document
- log changes in `docs/CHANGELOG.md`

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6874fb84602c8320b5d7fb802b3d7c82