### PR TITLE
Simplify CI failure cleanup docs

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -773,3 +773,5 @@ All notable changes to this project will be recorded in this file.
   path in `docs/tags_integration.md`.
 - Added a yamllint log upload step to `cleanup-ci-failure.yml` and corrected
   indentation of `GH_TOKEN` lines.
+- Replaced `--json` and `--jq` examples in `docs/ci-failure-issues.md` with
+  awk-based parsing so the commands work on older GitHub CLI versions.

--- a/docs/ci-failure-issues.md
+++ b/docs/ci-failure-issues.md
@@ -61,14 +61,12 @@ log artifact.
 
 ## Clearing Old Issues
 
-Past failures may leave old `ci-failure` issues open. You can close them in bulk with the GitHub CLI:
-
-> **Note**: These examples require GitHub CLI v2 or later for the `--json` and `--jq` flags.
-> Run `./scripts/install_gh_cli.sh` to install the CLI if it isn't already available.
+Past failures may leave old `ci-failure` issues open. You can close them in bulk with the GitHub CLI.
+Run `./scripts/install_gh_cli.sh` if the CLI isn't already available.
 
 ```bash
 export GH_TOKEN=your_personal_token
-for n in $(gh issue list --label ci-failure --state open --json number --jq '.[].number'); do
+for n in $(gh issue list --label ci-failure --state open | awk '{print $1}' | grep -Eo '[0-9]+'); do
   gh issue close "$n" --reason completed
   echo "Closed CI-failure issue #$n"
 done
@@ -90,7 +88,7 @@ jobs:
     steps:
       - name: Bulk close all open ci-failure issues
         run: |
-          for n in $(gh issue list --label ci-failure --state open --json number --jq '.[].number'); do
+          for n in $(gh issue list --label ci-failure --state open | awk '{print $1}' | grep -Eo '[0-9]+'); do
             gh issue close "$n" --reason completed
             echo "Closed CI-failure issue #$n"
           done


### PR DESCRIPTION
## Summary
- replace `--json`/`--jq` references in `docs/ci-failure-issues.md`
- parse issue numbers from plain `gh issue list` output
- note change in `docs/CHANGELOG.md`

## Testing
- `ruff check .`
- `pytest --cov=src --cov-fail-under=95`
- `bash scripts/check_docs.sh` *(fails: 426 markdownlint errors)*

------
https://chatgpt.com/codex/tasks/task_e_687515cee8848320b19543070452e0c2