### PR TITLE
Update issue closer workflow to validate gh version

### DIFF
--- a/.github/workflows/close-codex-issues.yml
+++ b/.github/workflows/close-codex-issues.yml
@@ -33,12 +33,20 @@ jobs:
         run: ./scripts/install_gh_cli.sh
       - name: Show gh version
         run: which gh && gh --version
+      - name: Verify gh version
+        run: |
+          ver=$(gh --version | head -n1 | awk '{print $3}')
+          major=${ver%%.*}
+          if [ "$major" -lt 2 ]; then
+            echo "::error::GitHub CLI v2 or higher required" >&2
+            exit 1
+          fi
       - name: Close referenced Codex issues
         run: |
           echo "${{ github.event.pull_request.body }}" | grep -oE 'Fixes #[0-9]+' | sed 's/Fixes #//' > issues.txt || true
           gh_bin=$(which gh)
           for ISSUE in $(cat issues.txt); do
-            AUTHOR=$($gh_bin api repos/${{ github.repository }}/issues/$ISSUE --jq '.user.login')
+            AUTHOR=$($gh_bin api repos/${{ github.repository }}/issues/$ISSUE | jq -r '.user.login')
             if [ "$AUTHOR" = "codex[bot]" ]; then
               $gh_bin issue comment "$ISSUE" --body "Closed via merge of #${{ github.event.pull_request.number }}."
               $gh_bin issue close "$ISSUE" --reason completed

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -777,3 +777,5 @@ All notable changes to this project will be recorded in this file.
   indentation of `GH_TOKEN` lines.
 - Replaced `--json` and `--jq` examples in `docs/ci-failure-issues.md` with
   awk-based parsing so the commands work on older GitHub CLI versions.
+
+- Verified GitHub CLI version and piped issue author JSON to jq in `close-codex-issues.yml`.


### PR DESCRIPTION
## Summary
- verify GitHub CLI version in `close-codex-issues.yml`
- pipe issue author JSON through `jq`
- document workflow tweaks in CHANGELOG

## Testing
- `bash scripts/run_tests.sh`
- `bash scripts/check_docs.sh`


------
https://chatgpt.com/codex/tasks/task_e_68751ee9b63c83208b66c29bf782c29b