### PR TITLE
Add pip check to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,11 +121,13 @@ jobs:
                       echo "Pip install failed. See docs/offline-setup.md for offline instructions." >&2
                       exit 1
                   }
+            - name: Check Python dependencies
+              run: pip check
             - name: Python dependency audit
-              run: |
-                  if ! pip-audit; then
-                      code=$?
-                      if [ "$code" -eq 1 ]; then
+                run: |
+                    if ! pip-audit; then
+                        code=$?
+                        if [ "$code" -eq 1 ]; then
                           exit 1
                       else
                           echo "pip-audit failed. See docs/offline-setup.md for offline instructions." >&2


### PR DESCRIPTION
## Summary
- verify Python dependencies after installing development packages

## Testing
- `bash scripts/validate.sh`

------
https://chatgpt.com/codex/tasks/task_e_68752629832083208521044f472dd66f