### PR TITLE
Add Python module checks to dependency script

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -779,3 +779,4 @@ All notable changes to this project will be recorded in this file.
   awk-based parsing so the commands work on older GitHub CLI versions.
 
 - Verified GitHub CLI version and piped issue author JSON to jq in `close-codex-issues.yml`.
+- Added `httpx`, `requests`, and `yaml` checks to `scripts/check_dependencies.sh` and now exit non-zero when any are missing.

--- a/scripts/check_dependencies.sh
+++ b/scripts/check_dependencies.sh
@@ -37,7 +37,12 @@ check_python_module() {
 
 check_python_module devonboarder "Run 'pip install -e .' before running the tests."
 check_python_module pytest "Run 'pip install -r requirements-dev.txt'."
+check_python_module httpx "Run 'pip install -e .' to install runtime deps."
+check_python_module requests "Run 'pip install -r requirements-dev.txt'."
+check_python_module yaml "Run 'pip install -r requirements-dev.txt'."
 
 if [ "$missing" -eq 0 ]; then
     echo "All optional dependencies installed ✅"
+else
+    exit 1
 fi


### PR DESCRIPTION
## Summary
- check httpx, requests and yaml in `scripts/check_dependencies.sh`
- exit non-zero when any optional deps missing
- document the extra checks in `docs/CHANGELOG.md`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687529e4f4ec8320a3296a1034f78b92