### PR TITLE
Add dependency checks to test script

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -4,10 +4,12 @@ set -euo pipefail
 # Always ensure development requirements are installed
 echo "Installing dev requirements..."
 pip install -r requirements-dev.txt
+pip check
 
 # Ensure runtime dependencies are installed
 if [ -f pyproject.toml ]; then
     pip install -e .
+    pip check
 fi
 
 ruff check .


### PR DESCRIPTION
## Summary
- verify Python dependencies after installing development packages
- verify runtime dependencies after installing the package

## Testing
- `scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68752b81056483208e1a38158b2543c9