### PR TITLE
Update run_tests dependency checks

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -780,3 +780,4 @@ All notable changes to this project will be recorded in this file.
 
 - Verified GitHub CLI version and piped issue author JSON to jq in `close-codex-issues.yml`.
 - Added `httpx`, `requests`, and `yaml` checks to `scripts/check_dependencies.sh` and now exit non-zero when any are missing.
+- `scripts/run_tests.sh` validates dependencies with `pip check` after installing dev requirements and again after installing the project.

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -4,10 +4,12 @@ set -euo pipefail
 # Always ensure development requirements are installed
 echo "Installing dev requirements..."
 pip install -r requirements-dev.txt
+pip check
 
 # Ensure runtime dependencies are installed
 if [ -f pyproject.toml ]; then
     pip install -e .
+    pip check
 fi
 
 ruff check .


### PR DESCRIPTION
## Summary
- validate Python dependencies after installing dev requirements and after editable installs
- log this change in the changelog

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68752df5c3a48320b818ae6b633c22c1