### PR TITLE
Fix gh version indentation in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,12 +74,12 @@ jobs:
               run: which gh && gh --version
             - name: Verify gh version
               run: |
-                    ver=$(gh --version | head -n1 | awk '{print $3}')
-                  major=${ver%%.*}
-                  if [ "$major" -lt 2 ]; then
-                      echo "::error::GitHub CLI v2 or higher required" >&2
-                      exit 1
-                  fi
+                ver=$(gh --version | head -n1 | awk '{print $3}')
+                major=${ver%%.*}
+                if [ "$major" -lt 2 ]; then
+                echo "::error::GitHub CLI v2 or higher required" >&2
+                exit 1
+                fi
             - name: Set up Python
               uses: actions/setup-python@v4
               with:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be recorded in this file.
 
 ## [Unreleased]
 
+- fix(ci): correct YAML indentation in Verify gh version step
+
 - Linked `docs/CHANGELOG.md` from `README.md` for easier navigation.
 - Mentioned `codex/agents/index.json` alongside `agents/index.md` and
   documented the agent index requirement in `AGENTS.md`.


### PR DESCRIPTION
## Summary
- align indentation for `Verify gh version` step in `ci.yml`
- document the fix in the changelog

## Testing
- `yamllint -c .github/.yamllint-config .github/workflows/ci.yml`
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6875bb2a6e4c8320a1f495b1bd8565fc