### PR TITLE
Fix pip-audit step indent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,14 +125,14 @@ jobs:
               run: pip check
             - name: Python dependency audit
               run: |
-                  if ! pip-audit; then
-                      code=$?
-                      if [ "$code" -eq 1 ]; then
-                          exit 1
-                      else
-                          echo "pip-audit failed. See docs/offline-setup.md for offline instructions." >&2
-                      fi
+                if ! pip-audit; then
+                  code=$?
+                  if [ "$code" -eq 1 ]; then
+                    exit 1
+                  else
+                    echo "pip-audit failed. See docs/offline-setup.md for offline instructions." >&2
                   fi
+                fi
             - name: Run Black
               run: black --check .
             - name: Validate env docs

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be recorded in this file.
   `document-start` and `truthy` and warning on lines over 200 characters.
 - Aligned yamllint invocation across scripts and CI with
   `yamllint -c .github/.yamllint-config .github/workflows/**/*.yml`.
+- fix(ci): correct YAML indentation in `Python dependency audit` step
 - Fixed indentation of Python blocks in `auto-fix.yml` to resolve YAML linting errors.
 - Added `src/diagnostics.py` with a `python -m diagnostics` entry for package
   and service health checks. CI runs the script and uploads its log.


### PR DESCRIPTION
## Summary
- fix YAML indent for the `Python dependency audit` step in ci.yml
- note the fix in the changelog

## Testing
- `make test` *(fails: Package 'devonboarder' requires a different Python: 3.11.12 not in '>=3.12')*
- `yamllint .github/workflows/ci.yml` *(fails: line length errors and pre-existing syntax warnings)*

------
https://chatgpt.com/codex/tasks/task_e_687536dfaa7483208eacd97c6fe6f515