### PR TITLE
Update CI matrix for Python 3.10, 3.11 and Node 18, 21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,8 +55,8 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                python-version: ["3.12"]
-                node-version: ["20"]
+                python-version: ["3.10", "3.11", "3.12"]
+                node-version: ["18", "20", "21"]
         timeout-minutes: 60
         env:
             VALE_VERSION: 3.12.0

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,6 +25,8 @@ All notable changes to this project will be recorded in this file.
 - Added `prompts/devonboarder_integration_task.md` and referenced it from
   `codex.tasks.json` so Codex can generate integration steps automatically.
 
+- CI matrix now tests Python 3.10, 3.11 and Node 18, 21.
+
 - Improved `ci-monitor.yml` to detect additional rate-limit phrases and fall back
   to `${{ secrets.GITHUB_TOKEN }}` when `CI_ISSUE_TOKEN` is unavailable.
 - Broadened `ci-monitor.yml` detection patterns, captures the matched log line,


### PR DESCRIPTION
## Summary
- test multiple Python and Node versions in `ci.yml`
- note new matrix versions in the changelog

## Testing
- `./scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68765a40a6048320ac5fd2eb70782dda