### PR TITLE
Track CI failure issue across runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -414,6 +414,11 @@ jobs:
             - name: Run CI log audit
               if: always()
               run: python scripts/ci_log_audit.py ${{ runner.temp }}/_github_workflow/*/job.log > audit.md
+            - name: Download previous CI failure issue
+              if: always()
+              run: bash scripts/download_ci_failure_issue.sh
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             - name: Create or update CI failure issue
               if: always()
               id: ci_failure
@@ -423,20 +428,27 @@ jobs:
                   cat audit.md >> summary.md
                   gh_bin=$(which gh)
                   "$gh_bin" auth status 2>&1 | tee -a gh_cli.log
-                  search_query="label:ci-failure ${{ github.sha }} in:title,body"
-                  echo "Searching with: $search_query" | tee -a gh_cli.log
-                  set +e
-                  search_output=$($gh_bin issue list --state open --search "$search_query" 2>&1 | tee -a gh_cli.log)
-                  list_exit=${PIPESTATUS[0]}
-                  set -e
-                  ISSUE=$(echo "$search_output" | awk 'NR==1 {print $1}')
-                  echo "Search exit code: $list_exit" | tee -a gh_cli.log
-                  if [ "$list_exit" -eq 0 ] && [ -n "$ISSUE" ]; then
+                  ISSUE_FILE=ci_failure_issue.txt
+                  if [ -f "$ISSUE_FILE" ]; then
+                      ISSUE=$(cat "$ISSUE_FILE")
+                      echo "Using saved issue number $ISSUE" | tee -a gh_cli.log
                       "$gh_bin" issue comment "$ISSUE" --body-file summary.md 2>&1 | tee -a gh_cli.log
                   else
-                      echo "::warning::Issue search failed or returned no results" | tee -a gh_cli.log
-                      ISSUE_URL=$($gh_bin issue create --title "CI Failures for ${{ github.sha }}" --body-file summary.md --label ci-failure | tee -a gh_cli.log)
-                      ISSUE=$(echo "$ISSUE_URL" | grep -oE '[0-9]+$')
+                      search_query="label:ci-failure ${{ github.sha }} in:title,body"
+                      echo "Searching with: $search_query" | tee -a gh_cli.log
+                      set +e
+                      search_output=$($gh_bin issue list --state open --search "$search_query" 2>&1 | tee -a gh_cli.log)
+                      list_exit=${PIPESTATUS[0]}
+                      set -e
+                      ISSUE=$(echo "$search_output" | awk 'NR==1 {print $1}')
+                      echo "Search exit code: $list_exit" | tee -a gh_cli.log
+                      if [ "$list_exit" -eq 0 ] && [ -n "$ISSUE" ]; then
+                          "$gh_bin" issue comment "$ISSUE" --body-file summary.md 2>&1 | tee -a gh_cli.log
+                      else
+                          echo "::warning::Issue search failed or returned no results" | tee -a gh_cli.log
+                          ISSUE_URL=$($gh_bin issue create --title "CI Failures for ${{ github.sha }}" --body-file summary.md --label ci-failure | tee -a gh_cli.log)
+                          ISSUE=$(echo "$ISSUE_URL" | grep -oE '[0-9]+$')
+                      fi
                   fi
                   echo "issue-number=$ISSUE" >> "$GITHUB_OUTPUT"
               env:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be recorded in this file.
 ## [Unreleased]
 
 - fix(ci): correct YAML indentation in Verify gh version step
+- chore(ci): reuse saved ci-failure issue number across runs
 
 - Linked `docs/CHANGELOG.md` from `README.md` for easier navigation.
 - Mentioned `codex/agents/index.json` alongside `agents/index.md` and

--- a/docs/ci-failure-issues.md
+++ b/docs/ci-failure-issues.md
@@ -8,6 +8,7 @@ When the CI workflow fails, it opens or updates an issue titled `CI Failures for
 
 - `ci.yml` closes every open `ci-failure` issue whenever the pipeline succeeds using the built-in `GITHUB_TOKEN`.
 - The workflow uploads a `ci-logs` artifact with the full job log for download after each run.
+- The issue number is saved as a `ci-failure-issue` artifact so later runs update the same issue.
 
 ## Forked Pull Requests
 

--- a/scripts/download_ci_failure_issue.sh
+++ b/scripts/download_ci_failure_issue.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Download ci-failure issue number from the previous CI run if available
+set -euo pipefail
+
+if ! command -v gh >/dev/null 2>&1; then
+    echo "::error::GitHub CLI not installed" >&2
+    exit 1
+fi
+
+run_id=$(gh run list -w CI --json databaseId,headSha -L 10 \
+    --jq 'map(select(.headSha=="'"$GITHUB_SHA"'" && .databaseId != '"$GITHUB_RUN_ID"')) | .[0].databaseId' || true)
+
+if [ -n "${run_id:-}" ]; then
+    echo "Downloading ci-failure-issue artifact from run $run_id" >&2
+    gh run download "$run_id" --name ci-failure-issue --dir . || true
+fi


### PR DESCRIPTION
## Summary
- store CI failure issue numbers so each run can update the same issue
- document the new artifact

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68765d2128b88320ae2b6f2ef75b2055