### PR TITLE
chore(docs): automate env doc regeneration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,8 @@ jobs:
                 fi
             - name: Run Black
               run: black --check .
+            - name: Regenerate env docs
+              run: python scripts/regenerate_env_docs.py
             - name: Validate env docs
               run: python scripts/check_env_docs.py
             - name: Setup environment

--- a/agents/index.md
+++ b/agents/index.md
@@ -17,47 +17,45 @@ Use the [template](templates/agent-spec-template.md) when documenting a new agen
 
 The table below lists environment variables used across DevOnboarder agents. Keep `.env.example` in sync with this list.
 
-| Variable                     | Description                                |
-| ---------------------------- | ------------------------------------------ |
-| APP_ENV                      | Application mode (`development`, etc.)     |
-| DATABASE_URL                 | Postgres connection string                 |
-| TOKEN_EXPIRE_SECONDS         | JWT expiration in seconds                  |
-| TAGS_MODE                    | Expect TAGS services when `true`           |
-| CORS_ALLOW_ORIGINS           | Comma-separated list of allowed CORS origins |
-| IS_ALPHA_USER                | Enable alpha-only routes                   |
-| IS_FOUNDER                   | Enable founder-only routes                 |
-| ADMIN_SERVER_GUILD_ID        | Discord guild ID used for admin checks     |
-| OWNER_ROLE_ID                | Discord role for system owner              |
-| ADMINISTRATOR_ROLE_ID        | Discord role for administrators            |
-| MODERATOR_ROLE_ID            | Discord role for moderators                |
-| VERIFIED_USER_ROLE_ID        | Role granted to verified community members |
-| VERIFIED_MEMBER_ROLE_ID      | Alias role for verified members            |
-| GOVERNMENT_ROLE_ID           | Role for government employees              |
-| MILITARY_ROLE_ID             | Role for military members                  |
-| EDUCATION_ROLE_ID            | Role for school or university affiliation  |
-| DISCORD_CLIENT_ID            | Discord application client ID              |
-| DISCORD_CLIENT_SECRET        | Discord application client secret          |
-| DISCORD_REDIRECT_URI         | OAuth callback URL for Discord             |
-| DISCORD_API_TIMEOUT          | HTTP timeout in seconds for Discord API calls |
-| JWT_SECRET_KEY               | Secret key for JWT signing (required; service
-errors if empty or "secret" outside `development`) |
-| JWT_ALGORITHM                | Algorithm for JWT signing (default `HS256`) |
-| DISCORD_BOT_TOKEN            | Token for the Discord bot                  |
-| DISCORD_GUILD_IDS            | Guilds where the bot operates              |
-| BOT_JWT                      | JWT used by the bot for API calls          |
-| API_BASE_URL                 | XP API URL for the bot                     |
-| AUTH_URL                     | Auth service URL for Playwright tests      |
-| CHECK_HEADERS_URL            | Endpoint used by header checks (default `http://localhost:8002/api/user`) |
-| VITE_AUTH_URL                | Auth service URL for the frontend          |
-| VITE_API_URL                 | XP API URL for the frontend                |
-| VITE_FEEDBACK_URL            | Base URL for the feedback service          |
-| VITE_DISCORD_CLIENT_ID       | Discord client ID for the frontend         |
-| VITE_SESSION_REFRESH_INTERVAL| How often the frontend refreshes sessions  |
-| INIT_DB_ON_STARTUP           | Auto-run migrations when the auth service starts |
-| TEAMS_APP_ID                 | Azure app ID for the Teams integration      |
-| TEAMS_APP_PASSWORD           | Secret used to authenticate the Teams app   |
-| TEAMS_TENANT_ID              | Azure tenant hosting the Teams app          |
-| TEAMS_CHANNEL_ID_ONBOARD     | Teams channel ID for onboarding updates     |
-| LLAMA2_API_KEY               | API key for accessing the Llama2 service    |
-| LLAMA2_API_TIMEOUT           | HTTP timeout in seconds for Llama2 API calls |
-
+| Variable                      | Description |
+| ----------------------------- | ----------- |
+| ADMINISTRATOR_ROLE_ID         | Discord role for administrators |
+| ADMIN_SERVER_GUILD_ID         | Discord guild ID used for admin checks |
+| API_BASE_URL                  | XP API URL for the bot |
+| APP_ENV                       | Application mode (`development`, etc.) |
+| AUTH_URL                      | Auth service URL for Playwright tests |
+| BOT_JWT                       | JWT used by the bot for API calls |
+| CHECK_HEADERS_URL             | Endpoint used by header checks (default `http://localhost:8002/api/user`) |
+| CORS_ALLOW_ORIGINS            | Comma-separated list of allowed CORS origins |
+| DATABASE_URL                  | Postgres connection string |
+| DISCORD_API_TIMEOUT           | HTTP timeout in seconds for Discord API calls |
+| DISCORD_BOT_TOKEN             | Token for the Discord bot |
+| DISCORD_CLIENT_ID             | Discord application client ID |
+| DISCORD_CLIENT_SECRET         | Discord application client secret |
+| DISCORD_GUILD_IDS             | Guilds where the bot operates |
+| DISCORD_REDIRECT_URI          | OAuth callback URL for Discord |
+| EDUCATION_ROLE_ID             | Role for school or university affiliation |
+| GOVERNMENT_ROLE_ID            | Role for government employees |
+| INIT_DB_ON_STARTUP            | Auto-run migrations when the auth service starts |
+| IS_ALPHA_USER                 | Enable alpha-only routes |
+| IS_FOUNDER                    | Enable founder-only routes |
+| JWT_ALGORITHM                 | Algorithm for JWT signing (default `HS256`) |
+| JWT_SECRET_KEY                | Secret key for JWT signing (required; service errors if empty or "secret" outside `development`) |
+| LLAMA2_API_KEY                | API key for accessing the Llama2 service |
+| LLAMA2_API_TIMEOUT            | HTTP timeout in seconds for Llama2 API calls |
+| MILITARY_ROLE_ID              | Role for military members |
+| MODERATOR_ROLE_ID             | Discord role for moderators |
+| OWNER_ROLE_ID                 | Discord role for system owner |
+| TAGS_MODE                     | Expect TAGS services when `true` |
+| TEAMS_APP_ID                  | Azure app ID for the Teams integration |
+| TEAMS_APP_PASSWORD            | Secret used to authenticate the Teams app |
+| TEAMS_CHANNEL_ID_ONBOARD      | Teams channel ID for onboarding updates |
+| TEAMS_TENANT_ID               | Azure tenant hosting the Teams app |
+| TOKEN_EXPIRE_SECONDS          | JWT expiration in seconds |
+| VERIFIED_MEMBER_ROLE_ID       | Alias role for verified members |
+| VERIFIED_USER_ROLE_ID         | Role granted to verified community members |
+| VITE_API_URL                  | XP API URL for the frontend |
+| VITE_AUTH_URL                 | Auth service URL for the frontend |
+| VITE_DISCORD_CLIENT_ID        | Discord client ID for the frontend |
+| VITE_FEEDBACK_URL             | Base URL for the feedback service |
+| VITE_SESSION_REFRESH_INTERVAL | How often the frontend refreshes sessions |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be recorded in this file.
 - fix(ci): correct YAML indentation in Verify gh version step
 - chore(ci): reuse saved ci-failure issue number across runs
 
+- chore(docs): regenerate env variable docs from `.env.example` via new script
+  and run it in CI before validation
+
 - Linked `docs/CHANGELOG.md` from `README.md` for easier navigation.
 - Mentioned `codex/agents/index.json` alongside `agents/index.md` and
   documented the agent index requirement in `AGENTS.md`.

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -1,0 +1,12 @@
+# Environment Maintenance
+
+Use `scripts/regenerate_env_docs.py` whenever you update any `.env.example` file.
+The script parses the example files and rewrites the environment variable table
+in `agents/index.md`.
+
+```bash
+python scripts/regenerate_env_docs.py
+```
+
+CI runs this command automatically before validating the docs, but running it
+locally ensures the documentation stays current.

--- a/scripts/regenerate_env_docs.py
+++ b/scripts/regenerate_env_docs.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Regenerate env variable docs from `.env.example` files."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+DOC_PATH = Path("agents/index.md")
+ENV_FILES = [
+    Path(".env.example"),
+    Path("frontend/src/.env.example"),
+    Path("bot/.env.example"),
+    Path("auth/.env.example"),
+]
+
+
+def read_env_vars(paths: list[Path]) -> set[str]:
+    pattern = re.compile(r"^([A-Za-z_][A-Za-z0-9_]*)=")
+    vars: set[str] = set()
+    for p in paths:
+        if not p.exists():
+            continue
+        with p.open("r", encoding="utf-8") as f:
+            for line in f:
+                m = pattern.match(line)
+                if m:
+                    vars.add(m.group(1))
+    return vars
+
+
+def read_doc_table(path: Path) -> dict[str, str]:
+    pattern = re.compile(r"^\|\s*([A-Za-z0-9_]+)\s*\|\s*(.*?)\s*\|$")
+    table: dict[str, str] = {}
+    lines = path.read_text().splitlines()
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        if line.startswith("|") and not line.rstrip().endswith("|"):
+            j = i
+            parts = [line.rstrip()]
+            while j + 1 < len(lines) and not lines[j + 1].rstrip().endswith("|"):
+                j += 1
+                parts.append(lines[j].rstrip())
+            if j + 1 < len(lines):
+                j += 1
+                parts.append(lines[j].rstrip())
+            line = " ".join(parts)
+            i = j
+        m = pattern.match(line)
+        if m and m.group(1) != "Variable":
+            table[m.group(1)] = m.group(2)
+        i += 1
+    return table
+
+
+def build_table(vars: set[str], existing: dict[str, str]) -> list[str]:
+    width = max(len("Variable"), *(len(v) for v in vars))
+    header = f"| {'Variable'.ljust(width)} | Description |"
+    separator = f"| {'-' * width} | ----------- |"
+    lines = [header, separator]
+    for var in sorted(vars):
+        desc = existing.get(var, "")
+        lines.append(f"| {var.ljust(width)} | {desc} |")
+    return lines
+
+
+def replace_table(doc_lines: list[str], table_lines: list[str]) -> list[str]:
+    start = None
+    for i, line in enumerate(doc_lines):
+        if line.strip() == "## Required Environment Variables":
+            start = i
+            break
+    if start is None:
+        raise RuntimeError("Section header not found")
+
+    # copy lines up to end of header and any explanatory text
+    result = doc_lines[: start + 1]
+    i = start + 1
+    while i < len(doc_lines) and not doc_lines[i].startswith("|"):
+        result.append(doc_lines[i])
+        i += 1
+
+    # find end of current table
+    end = i
+    while end < len(doc_lines) and doc_lines[end].startswith("|"):
+        end += 1
+    # skip to next section header
+    while end < len(doc_lines) and not doc_lines[end].startswith("## "):
+        end += 1
+
+    result.extend(table_lines)
+    result.extend(doc_lines[end:])
+    return result
+
+
+def main() -> None:
+    env_vars = read_env_vars(ENV_FILES)
+    doc_lines = DOC_PATH.read_text().splitlines()
+    existing = read_doc_table(DOC_PATH)
+    table_lines = build_table(env_vars, existing)
+    new_content = replace_table(doc_lines, table_lines)
+    DOC_PATH.write_text("\n".join(new_content) + "\n")
+    print(f"Updated {DOC_PATH} with {len(env_vars)} variables")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- script to rebuild environment variable table from `.env.example`
- call script in CI before validation
- document how to run the script

## Testing
- `bash scripts/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_687660539aec8320a90cbec64ffdca19