### PR TITLE
Limit CI to Python 3.12 and Node 20

### DIFF
--- a/.codex/automation-tasks.md
+++ b/.codex/automation-tasks.md
@@ -4,8 +4,8 @@ This document outlines the automation checks Codex uses to keep the CI workflow 
 
 ## Language Versions
 
-- The main workflow tests Python **3.10**, **3.11** and **3.12**.
-- Node.js **18**, **20** and **21** are also validated.
+- The main workflow tests Python **3.12** only.
+- Node.js **20** is also validated.
 - `scripts/check_versions.sh` verifies the versions match the ones used locally.
 
 ## Workflow Linting

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,8 +55,8 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                python-version: ["3.10", "3.11", "3.12"]
-                node-version: ["18", "20", "21"]
+                python-version: ["3.12"]
+                node-version: ["20"]
         timeout-minutes: 60
         env:
             VALE_VERSION: 3.12.0

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,7 +30,7 @@ All notable changes to this project will be recorded in this file.
 - Added `prompts/devonboarder_integration_task.md` and referenced it from
   `codex.tasks.json` so Codex can generate integration steps automatically.
 
-- CI matrix now tests Python 3.10, 3.11 and Node 18, 21.
+- CI matrix now tests only Python 3.12 and Node 20.
 
 - Improved `ci-monitor.yml` to detect additional rate-limit phrases and fall back
   to `${{ secrets.GITHUB_TOKEN }}` when `CI_ISSUE_TOKEN` is unavailable.


### PR DESCRIPTION
## Summary
- drop Python 3.10 and 3.11 from CI
- drop Node 18 and 21 from CI
- document the version change in automation tasks and changelog

## Testing
- `pre-commit run --files .github/workflows/ci.yml .codex/automation-tasks.md docs/CHANGELOG.md` *(fails: could not clone hooks)*
- `pytest -q` *(fails: ModuleNotFoundError: fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_687689f578348320844c6aa392550d19