### PR TITLE
Add bot permissions config

### DIFF
--- a/.codex/bot-permissions.yaml
+++ b/.codex/bot-permissions.yaml
@@ -1,0 +1,30 @@
+# Mapping of bots to repository secrets and GitHub permissions.
+# Ensure the referenced secrets exist in repository settings.
+
+onboarding_agent:
+  secret: ONBOARDING_AGENT_KEY
+  permissions:
+    - issues: write
+    - pull_requests: write
+    - contents: read
+
+ci_helper_agent:
+  secret: CI_HELPER_AGENT_KEY
+  permissions:
+    - actions: read
+    - pull_requests: write
+    - checks: write
+
+diagnostics_bot:
+  secret: DIAGNOSTICS_BOT_KEY
+  permissions:
+    - actions: read
+    - issues: write
+    - repository: read
+
+orchestration_bot:
+  secret: ORCHESTRATION_BOT_KEY
+  permissions:
+    - workflows: write
+    - deployments: read
+    - repository: read

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,8 @@ test-results/
 
 # Local/Codex caches
 .codex/
+!.codex/
+!.codex/bot-permissions.yaml
 .vscode-integrations/
 logs/
 .env.dev

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be recorded in this file.
 - fix(ci): correct YAML indentation in Verify gh version step
 - chore(ci): reuse saved ci-failure issue number across runs
 
+- chore(codex): record bot secrets and permissions in `.codex/bot-permissions.yaml`
+
 - chore(docs): regenerate env variable docs from `.env.example` via new script
   and run it in CI before validation
 


### PR DESCRIPTION
## Summary
- map automation bots to secrets and permissions in `.codex/bot-permissions.yaml`
- track the file in git and update ignore rules
- record the change in `docs/CHANGELOG.md`

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68768e38b03c83208132eebbb65d9439