### PR TITLE
Add fastapi dependency check

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -791,5 +791,6 @@ All notable changes to this project will be recorded in this file.
 
 - Verified GitHub CLI version and piped issue author JSON to jq in `close-codex-issues.yml`.
 - Added `httpx`, `requests`, and `yaml` checks to `scripts/check_dependencies.sh` and now exit non-zero when any are missing.
+- Added a `fastapi` check to `scripts/check_dependencies.sh` so tests fail fast when runtime dependencies are missing.
 - `scripts/run_tests.sh` validates dependencies with `pip check` after installing dev requirements and again after installing the project.
 - Replaced custom GitHub CLI script with the `ksivamuthu/actions-setup-gh-cli` action and updated documentation.

--- a/scripts/check_dependencies.sh
+++ b/scripts/check_dependencies.sh
@@ -38,6 +38,7 @@ check_python_module() {
 check_python_module devonboarder "Run 'pip install -e .' before running the tests."
 check_python_module pytest "Run 'pip install -r requirements-dev.txt'."
 check_python_module httpx "Run 'pip install -e .' to install runtime deps."
+check_python_module fastapi "Run 'pip install -e .' to install runtime deps."
 check_python_module requests "Run 'pip install -r requirements-dev.txt'."
 check_python_module yaml "Run 'pip install -r requirements-dev.txt'."
 


### PR DESCRIPTION
## Summary
- ensure FastAPI is installed via `scripts/check_dependencies.sh`
- document the new check in the changelog

## Testing
- `pytest tests/test_auth_service.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68768d37ed1c83209fe4681050c207b2