### PR TITLE
Add bot permission validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,10 @@ jobs:
                     echo "pip-audit failed. See docs/offline-setup.md for offline instructions." >&2
                   fi
                 fi
+            - name: Install yamllint
+              run: pip install yamllint
+            - name: Validate bot permissions
+              run: bash scripts/validate-bot-permissions.sh
             - name: Run Black
               run: black --check .
             - name: Regenerate env docs

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be recorded in this file.
 
 - fix(ci): correct YAML indentation in Verify gh version step
 - chore(ci): reuse saved ci-failure issue number across runs
+- chore(ci): validate `.codex/bot-permissions.yaml` via new script
 
 - chore(codex): record bot secrets and permissions in `.codex/bot-permissions.yaml`
 

--- a/scripts/validate-bot-permissions.sh
+++ b/scripts/validate-bot-permissions.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FILE=".codex/bot-permissions.yaml"
+REQUIRED=("orchestration_bot")
+
+if [ ! -f "$FILE" ]; then
+  echo "$FILE not found" >&2
+  exit 1
+fi
+
+if ! command -v yamllint >/dev/null 2>&1; then
+  echo "yamllint not installed" >&2
+  exit 1
+fi
+
+yamllint -c .github/.yamllint-config "$FILE"
+
+missing=$(python - "$FILE" "${REQUIRED[@]}" <<'PY'
+import sys, yaml
+path = sys.argv[1]
+required = sys.argv[2:]
+data = yaml.safe_load(open(path)) or {}
+missing = [r for r in required if r not in data]
+print(",".join(missing))
+PY
+)
+
+if [ -n "$missing" ]; then
+  echo "Missing required bot entries: $missing" >&2
+  exit 1
+fi
+
+echo "Bot permissions file valid ✅"


### PR DESCRIPTION
## Summary
- validate `.codex/bot-permissions.yaml` with a new script
- run the script in CI before linting

## Testing
- `bash scripts/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_687690c5115083209348abb072ef623b