### PR TITLE
Implement escalation scripts and bot permission checks

### DIFF
--- a/.github/workflows/ci-health.yml
+++ b/.github/workflows/ci-health.yml
@@ -106,6 +106,10 @@ jobs:
         run: |
           failures=$(grep -h "" results/result-*/result.txt | awk -F': ' '$2=="failure"{print $1}')
           echo "failures=$(printf '%s ' $failures | sed 's/ *$//')" >> "$GITHUB_OUTPUT"
+      - name: Install PyYAML
+        run: pip install PyYAML
+      - name: Verify bot permission
+        run: bash scripts/check-bot-permissions.sh orchestration_bot "issues: write"
       - name: Create issue for failures
         if: steps.summarize.outputs.failures != ''
         env:
@@ -116,7 +120,7 @@ jobs:
           for b in $FAILED; do
             echo "- $b" >> body.md
           done
-          gh issue create --title "CI health failures $(date -I)" --label ci-health --body-file body.md
+          bash scripts/notify-humans.sh "CI health failures $(date -I)" body.md
       - name: Summary if no failures
         if: steps.summarize.outputs.failures == ''
         run: echo "All scheduled CI runs passed" > /dev/null

--- a/.github/workflows/ci-monitor.yml
+++ b/.github/workflows/ci-monitor.yml
@@ -51,13 +51,16 @@ jobs:
           else
             echo "hit=false" >> "$GITHUB_OUTPUT"
           fi
+      - name: Install PyYAML
+        if: steps.check.outputs.hit == 'true'
+        run: pip install PyYAML
+      - name: Verify bot permission
+        if: steps.check.outputs.hit == 'true'
+        run: bash scripts/check-bot-permissions.sh orchestration_bot "issues: write"
       - name: Open issue on rate-limit
         if: steps.check.outputs.hit == 'true'
         env:
           GH_TOKEN: ${{ secrets.CI_ISSUE_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
-          gh issue create \
-            --title "\ud83d\udea8 CI Rate Limit Exceeded" \
-            --body "Our CI run failed due to API rate limits. Matched line: ${{ steps.check.outputs.match }}. Logs: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
-            --label ci \
-            --assignee "@me"
+          printf '%s\n' "Our CI run failed due to API rate limits. Matched line: ${{ steps.check.outputs.match }}. Logs: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" > body.md
+          bash scripts/notify-humans.sh "\ud83d\udea8 CI Rate Limit Exceeded" body.md

--- a/.github/workflows/cleanup-ci-failure.yml
+++ b/.github/workflows/cleanup-ci-failure.yml
@@ -46,6 +46,10 @@ jobs:
                   echo "::error::GitHub CLI v2 or higher required" >&2
                   exit 1
                 fi
+            - name: Install PyYAML
+              run: pip install PyYAML
+            - name: Verify bot permission
+              run: bash scripts/check-bot-permissions.sh orchestration_bot "issues: write"
             - name: Debug token and permissions
               run: |
                 gh auth status
@@ -70,9 +74,8 @@ jobs:
                 done
                 if [ "$failed" -ne 0 ]; then
                   echo "::error::Cleanup failed"
-                  "$gh_bin" issue create --title "Cleanup CI failure issues failed" \
-                    --body "Automatic cleanup could not close one or more ci-failure issues." \
-                    --label ci-failure || true
+                  printf '%s\n' "Automatic cleanup could not close one or more ci-failure issues." > body.md
+                  bash scripts/notify-humans.sh "Cleanup CI failure issues failed" body.md || true
                   exit 1
                 fi
                 echo "Closed $closed ci-failure issues"

--- a/.github/workflows/close-codex-issues.yml
+++ b/.github/workflows/close-codex-issues.yml
@@ -33,17 +33,21 @@ jobs:
         uses: ksivamuthu/actions-setup-gh-cli@v3
       - name: Show gh version
         run: which gh && gh --version
-      - name: Verify gh version
-        run: |
-          ver=$(gh --version | head -n1 | awk '{print $3}')
-          major=${ver%%.*}
-          if [ "$major" -lt 2 ]; then
-            echo "::error::GitHub CLI v2 or higher required" >&2
-            exit 1
-          fi
-      - name: Close referenced Codex issues
-        run: |
-          echo "${{ github.event.pull_request.body }}" | grep -oE 'Fixes #[0-9]+' | sed 's/Fixes #//' > issues.txt || true
+        - name: Verify gh version
+          run: |
+            ver=$(gh --version | head -n1 | awk '{print $3}')
+            major=${ver%%.*}
+            if [ "$major" -lt 2 ]; then
+              echo "::error::GitHub CLI v2 or higher required" >&2
+              exit 1
+            fi
+        - name: Install PyYAML
+          run: pip install PyYAML
+        - name: Verify bot permission
+          run: bash scripts/check-bot-permissions.sh orchestration_bot "issues: write"
+        - name: Close referenced Codex issues
+          run: |
+            echo "${{ github.event.pull_request.body }}" | grep -oE 'Fixes #[0-9]+' | sed 's/Fixes #//' > issues.txt || true
           gh_bin=$(which gh)
           for ISSUE in $(cat issues.txt); do
             AUTHOR=$($gh_bin api repos/${{ github.repository }}/issues/$ISSUE | jq -r '.user.login')

--- a/.github/workflows/env-doc-alignment.yml
+++ b/.github/workflows/env-doc-alignment.yml
@@ -51,6 +51,12 @@ jobs:
         run: |
           missing=$(awk '/^Variables missing from agents\/index.md:/{flag=1;next}/^$/{flag=0}flag' env_docs.log | tr '\n' ',' | sed 's/,$//')
           echo "missing=$missing" >> "$GITHUB_OUTPUT"
+      - name: Install PyYAML
+        if: steps.check.outputs.success == 'false'
+        run: pip install PyYAML
+      - name: Verify bot permission
+        if: steps.check.outputs.success == 'false'
+        run: bash scripts/check-bot-permissions.sh orchestration_bot "issues: write"
       - name: Create issue
         if: steps.check.outputs.success == 'false'
         run: |
@@ -60,6 +66,6 @@ jobs:
 
             - [ ] I manually reviewed the variables against [agents/index.md](../../agents/index.md)
           BODY
-          gh issue create --title "Secrets misaligned in docs for ${{ github.event.workflow_run.head_sha || github.sha }}" --label ops --template "secret-alignment.md" --body-file body.md
+          bash scripts/notify-humans.sh "Secrets misaligned in docs for ${{ github.event.workflow_run.head_sha || github.sha }}" body.md
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/secrets-alignment.yml
+++ b/.github/workflows/secrets-alignment.yml
@@ -55,6 +55,12 @@ jobs:
           extras=$(awk '/^Extra variables:/{flag=1;next}flag' env_audit.log | grep -v -E '^(PATH|PWD|SHLVL|_)$' | tr '\n' ',' | sed 's/,$//')
           echo "missing=$missing" >> "$GITHUB_OUTPUT"
           echo "extras=$extras" >> "$GITHUB_OUTPUT"
+      - name: Install PyYAML
+        if: steps.vars.outputs.missing != '' || steps.vars.outputs.extras != ''
+        run: pip install PyYAML
+      - name: Verify bot permission
+        if: steps.vars.outputs.missing != '' || steps.vars.outputs.extras != ''
+        run: bash scripts/check-bot-permissions.sh orchestration_bot "issues: write"
       - name: Create issue
         if: steps.vars.outputs.missing != '' || steps.vars.outputs.extras != ''
         run: |
@@ -67,6 +73,6 @@ jobs:
 
             - [ ] I manually reviewed the variables against [agents/index.md](../../agents/index.md)
           BODY
-          gh issue create --title "Secrets misaligned in CI for ${{ github.event.workflow_run.head_sha || github.sha }}" --label ops --template "secret-alignment.md" --body-file body.md
+          bash scripts/notify-humans.sh "Secrets misaligned in CI for ${{ github.event.workflow_run.head_sha || github.sha }}" body.md
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be recorded in this file.
 - Linked `docs/CHANGELOG.md` from `README.md` for easier navigation.
 - Mentioned `codex/agents/index.json` alongside `agents/index.md` and
   documented the agent index requirement in `AGENTS.md`.
+- chore(scripts): add `check-bot-permissions.sh` and `notify-humans.sh`; orchestrator workflows use them
 - Documented that the `validate-yaml` step always runs even when `[no-ci]` skips
   the test job and clarified the `[no-ci]` marker in `docs/ci-workflow.md`.
 - Added `.github/.yamllint-config` to centralize workflow lint rules, disabling

--- a/scripts/check-bot-permissions.sh
+++ b/scripts/check-bot-permissions.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: check-bot-permissions.sh <bot> <permission>
+# Verifies <bot> is allowed the given <permission> according to .codex/bot-permissions.yaml
+
+BOT="${1:-}"
+PERM="${2:-}"
+FILE=".codex/bot-permissions.yaml"
+
+if [ -z "$BOT" ] || [ -z "$PERM" ]; then
+  echo "Usage: $0 <bot> <permission>" >&2
+  exit 1
+fi
+
+if [ ! -f "$FILE" ]; then
+  echo "$FILE not found" >&2
+  exit 1
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "python3 not installed" >&2
+  exit 1
+fi
+
+has_perm=$(python3 - "$FILE" "$BOT" "$PERM" <<'PY'
+import sys, yaml
+path, bot, perm = sys.argv[1:]
+data = yaml.safe_load(open(path)) or {}
+perms = data.get(bot, {}).get('permissions', [])
+print('true' if perm in perms else 'false')
+PY
+)
+
+if [ "$has_perm" != "true" ]; then
+  echo "Bot '$BOT' is not authorized for '$PERM'" >&2
+  exit 1
+fi
+
+echo "Bot '$BOT' authorized for '$PERM'"

--- a/scripts/notify-humans.sh
+++ b/scripts/notify-humans.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Create an issue or comment to escalate an event.
+# Usage: notify-humans.sh <title> <body-file> [issue-number]
+# Requires GH_TOKEN environment variable and the gh CLI.
+
+TITLE="${1:-}"
+BODY_FILE="${2:-}"
+ISSUE="${3:-}"
+
+if [ -z "$TITLE" ] || [ -z "$BODY_FILE" ]; then
+  echo "Usage: $0 <title> <body-file> [issue-number]" >&2
+  exit 1
+fi
+
+if [ ! -f "$BODY_FILE" ]; then
+  echo "Body file '$BODY_FILE' not found" >&2
+  exit 1
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "GitHub CLI not installed" >&2
+  exit 1
+fi
+
+if [ -n "$ISSUE" ]; then
+  gh issue comment "$ISSUE" --body-file "$BODY_FILE"
+else
+  gh issue create --title "$TITLE" --body-file "$BODY_FILE" --label ops
+fi
+
+echo "Notification sent"


### PR DESCRIPTION
## Summary
- add `check-bot-permissions.sh` to confirm an agent's allowed actions
- add `notify-humans.sh` for issue escalation from workflows
- use the new scripts in orchestrator workflows
- document the new scripts in the changelog

## Testing
- `bash scripts/validate.sh` *(fails: markdownlint warnings, missing Vale)*

------
https://chatgpt.com/codex/tasks/task_e_6876a23280988320909ca2e7c8fff1a4