### PR TITLE
Update automation policy with bot orchestration rules

### DIFF
--- a/.codex/automation-tasks.md
+++ b/.codex/automation-tasks.md
@@ -32,3 +32,11 @@ This document outlines the automation checks Codex uses to keep the CI workflow 
 - When lint errors occur, Codex attempts `ruff --fix` and `pre-commit run --files`.
 - If the build still fails, the bot opens a `ci-failure` issue with logs and summaries.
 - Subsequent successful runs automatically close these issues.
+
+## Bot Orchestration
+
+All project bots must obey the permissions listed in `.codex/bot-permissions.yaml`.
+Workflows call `scripts/check-bot-permissions.sh` to verify that each bot's
+secrets and scopes match the policy. Only the orchestrator bots are allowed to
+notify humans (for example by opening issues or sending alerts). All other bots
+operate quietly and record their results in CI logs or artifacts.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be recorded in this file.
 - Mentioned `codex/agents/index.json` alongside `agents/index.md` and
   documented the agent index requirement in `AGENTS.md`.
 - chore(scripts): add `check-bot-permissions.sh` and `notify-humans.sh`; orchestrator workflows use them
+- Documented bot orchestration policy referencing `.codex/bot-permissions.yaml`
 - Documented that the `validate-yaml` step always runs even when `[no-ci]` skips
   the test job and clarified the `[no-ci]` marker in `docs/ci-workflow.md`.
 - Added `.github/.yamllint-config` to centralize workflow lint rules, disabling


### PR DESCRIPTION
## Summary
- outline that bots must follow `.codex/bot-permissions.yaml`
- clarify that only orchestrator bots may notify maintainers

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6876a435ef208320957ac1a31496f034