### PR TITLE
Add multi-bot orchestration guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ This repository follows the DevOnboarder protocol. Key points:
 - Maintainer merge checklist: `docs/merge-checklist.md`.
 - Project changelog: `docs/CHANGELOG.md`.
 - Offline setup instructions: `docs/offline-setup.md`.
+- Multi-bot orchestration guide: `docs/orchestration.md`.
 
 1. **Development Environment**
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be recorded in this file.
   documented the agent index requirement in `AGENTS.md`.
 - chore(scripts): add `check-bot-permissions.sh` and `notify-humans.sh`; orchestrator workflows use them
 - Documented bot orchestration policy referencing `.codex/bot-permissions.yaml`
+- Added `docs/orchestration.md` covering multi-bot setup, API key rotation and escalation steps.
 - Documented that the `validate-yaml` step always runs even when `[no-ci]` skips
   the test job and clarified the `[no-ci]` marker in `docs/ci-workflow.md`.
 - Added `.github/.yamllint-config` to centralize workflow lint rules, disabling

--- a/docs/README.md
+++ b/docs/README.md
@@ -139,6 +139,7 @@ platforms. Please report any issues you encounter on your operating system.
 - [Environment variables](env.md) &ndash; explanation of `.env` settings and the role-based permission system.
 - [Agents overview](../agents/index.md) &ndash; service and integration specs.
   Codex also reads `codex/agents/index.json` to map these agents for automation.
+- [Multi-bot orchestration](orchestration.md) – token management and escalation paths.
 - [DevOnboarder in TAGS](ecosystem.md) &ndash; how the services fit together.
 - [TAGS integration guide](tags_integration.md) &ndash; compose files and feature flags.
 - [Feedback dashboard PRD](prd/feedback-dashboard.md) &ndash; objectives and features for the feedback tool.

--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -1,0 +1,42 @@
+# Multi-Bot Orchestration Guide
+
+This document explains how the Discord bot, Codex automation, and other
+service accounts coordinate within DevOnboarder. It also covers API key
+management and how to escalate problems when automation fails.
+
+## Multi-Bot Setup
+
+Several bots operate together:
+
+- **Codex** – monitors CI jobs, opens issues, and proposes YAML fixes.
+- **Discord bot** – provides slash commands and onboarding checks.
+- **Orchestrator workflows** – scheduled jobs that manage bot permissions
+  using `.codex/bot-permissions.yaml`.
+
+Each bot uses a dedicated token stored in GitHub Actions secrets. The
+`check-bot-permissions.sh` script verifies that permissions match the policy
+before workflows run.
+
+## API Key Management
+
+1. Store each bot token as a separate secret in GitHub.
+2. Limit the scopes to only the required operations (issue write, pull
+   requests, etc.).
+3. Rotate tokens every quarter and record the rotation date in
+   `docs/governance/bot_access_governance.md`.
+4. Reference tokens in workflows via `${{ secrets.<TOKEN_NAME> }}` so they are
+   not hard coded in repository files.
+
+## Escalation Paths
+
+If automation breaks or a bot is unresponsive:
+
+1. Check workflow run logs for errors and consult
+   `docs/troubleshooting.md` for common fixes.
+2. If the issue persists, mention @project-maintainers in the failing pull
+   request or issue.
+3. For credential problems, escalate to the security team listed in
+   `docs/governance/bot_access_governance.md`.
+4. Document the incident in `docs/CHANGELOG.md` if manual recovery steps were
+   required.
+


### PR DESCRIPTION
## Summary
- document multi-bot orchestration and escalation paths
- reference the new guide from AGENTS and docs/README
- log the addition in CHANGELOG

## Testing
- `bash scripts/check_docs.sh`
- `bash scripts/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_6876a6a745048320be3e4a014f03eb38