### PR TITLE
Add notification aggregator workflow

### DIFF
--- a/.github/workflows/ci-health.yml
+++ b/.github/workflows/ci-health.yml
@@ -120,7 +120,8 @@ jobs:
           for b in $FAILED; do
             echo "- $b" >> body.md
           done
-          bash scripts/notify-humans.sh "CI health failures $(date -I)" body.md
+          jq -Rs --arg title "CI health failures $(date -I)" '{title:$title,body:.}' body.md > notify.json
+          gh workflow run notify.yml -f data="$(cat notify.json)"
       - name: Summary if no failures
         if: steps.summarize.outputs.failures == ''
         run: echo "All scheduled CI runs passed" > /dev/null

--- a/.github/workflows/ci-monitor.yml
+++ b/.github/workflows/ci-monitor.yml
@@ -63,4 +63,5 @@ jobs:
           GH_TOKEN: ${{ secrets.CI_ISSUE_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           printf '%s\n' "Our CI run failed due to API rate limits. Matched line: ${{ steps.check.outputs.match }}. Logs: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" > body.md
-          bash scripts/notify-humans.sh "\ud83d\udea8 CI Rate Limit Exceeded" body.md
+          jq -Rs --arg title "\ud83d\udea8 CI Rate Limit Exceeded" '{title:$title,body:.}' body.md > notify.json
+          gh workflow run notify.yml -f data="$(cat notify.json)"

--- a/.github/workflows/cleanup-ci-failure.yml
+++ b/.github/workflows/cleanup-ci-failure.yml
@@ -75,7 +75,8 @@ jobs:
                 if [ "$failed" -ne 0 ]; then
                   echo "::error::Cleanup failed"
                   printf '%s\n' "Automatic cleanup could not close one or more ci-failure issues." > body.md
-                  bash scripts/notify-humans.sh "Cleanup CI failure issues failed" body.md || true
+                  jq -Rs --arg title "Cleanup CI failure issues failed" '{title:$title,body:.}' body.md > notify.json
+                  gh workflow run notify.yml -f data="$(cat notify.json)" || true
                   exit 1
                 fi
                 echo "Closed $closed ci-failure issues"

--- a/.github/workflows/env-doc-alignment.yml
+++ b/.github/workflows/env-doc-alignment.yml
@@ -66,6 +66,7 @@ jobs:
 
             - [ ] I manually reviewed the variables against [agents/index.md](../../agents/index.md)
           BODY
-          bash scripts/notify-humans.sh "Secrets misaligned in docs for ${{ github.event.workflow_run.head_sha || github.sha }}" body.md
+          jq -Rs --arg title "Secrets misaligned in docs for ${{ github.event.workflow_run.head_sha || github.sha }}" '{title:$title,body:.}' body.md > notify.json
+          gh workflow run notify.yml -f data="$(cat notify.json)"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -1,0 +1,49 @@
+# ---
+# codex-agent:
+#   name: Agent.Notify
+#   role: Aggregates human notifications from other workflows
+#   scope: .github/workflows/notify.yml
+#   triggers: Manual dispatch
+#   output: Comment on operations issue
+# ---
+name: Notify
+
+on:
+  workflow_dispatch:
+    inputs:
+      data:
+        description: JSON payload with title and body
+        required: true
+
+permissions:
+  issues: write
+
+jobs:
+  validate-yaml:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ibiqlik/action-yamllint@v3
+        with:
+          file_or_dir: ".github/workflows/**/*.yml"
+          config_file: .github/.yamllint-config
+  process:
+    needs: validate-yaml
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install GitHub CLI
+        uses: ksivamuthu/actions-setup-gh-cli@v3
+      - name: Show gh version
+        run: which gh && gh --version
+      - name: Install PyYAML
+        run: pip install PyYAML
+      - name: Verify bot permission
+        run: bash scripts/check-bot-permissions.sh orchestration_bot "issues: write"
+      - name: Process notification
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PAYLOAD: ${{ inputs.data }}
+        run: |
+          echo "$PAYLOAD" > notify.json
+          python scripts/process_notifications.py notify.json

--- a/.github/workflows/secrets-alignment.yml
+++ b/.github/workflows/secrets-alignment.yml
@@ -73,6 +73,7 @@ jobs:
 
             - [ ] I manually reviewed the variables against [agents/index.md](../../agents/index.md)
           BODY
-          bash scripts/notify-humans.sh "Secrets misaligned in CI for ${{ github.event.workflow_run.head_sha || github.sha }}" body.md
+          jq -Rs --arg title "Secrets misaligned in CI for ${{ github.event.workflow_run.head_sha || github.sha }}" '{title:$title,body:.}' body.md > notify.json
+          gh workflow run notify.yml -f data="$(cat notify.json)"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,6 +110,13 @@ The workflow also skips its test job when a push only modifies documentation or
 Markdown files. It uses `dorny/paths-filter` to set `steps.filter.outputs.code`
 to `false` in that case.
 
+## Notification Aggregation Policy
+
+All agents must send human notifications through the `notify.yml` workflow. Use
+`gh workflow run notify.yml -f data=<json>` instead of calling
+`scripts/notify-humans.sh` directly. The workflow aggregates messages via
+`scripts/process_notifications.py` and posts them to a single issue.
+
 ## \U0001F512 Security Note
 
 CI/CD scripts must not fetch and execute remote code via `curl | sh`. Tools like

--- a/agents/templates/agent-spec-template.md
+++ b/agents/templates/agent-spec-template.md
@@ -9,3 +9,5 @@
 **Environment:** <Relevant variables or configuration.>
 
 **Workflow:** <Step-by-step outline of how the agent operates.>
+
+**Notification:** Route alerts through `.github/workflows/notify.yml`.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be recorded in this file.
 - Mentioned `codex/agents/index.json` alongside `agents/index.md` and
   documented the agent index requirement in `AGENTS.md`.
 - chore(scripts): add `check-bot-permissions.sh` and `notify-humans.sh`; orchestrator workflows use them
+- chore(ci): add `notify.yml` workflow and replace `notify-humans.sh` calls
 - Documented bot orchestration policy referencing `.codex/bot-permissions.yaml`
 - Added `docs/orchestration.md` covering multi-bot setup, API key rotation and escalation steps.
 - Documented that the `validate-yaml` step always runs even when `[no-ci]` skips

--- a/scripts/process_notifications.py
+++ b/scripts/process_notifications.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+"""Aggregate human notifications into a single issue."""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from typing import Any
+
+
+def find_issue(gh: str) -> str:
+    """Return the issue number for the aggregator issue, creating it if needed."""
+    list_cmd = [
+        gh,
+        "issue",
+        "list",
+        "--label",
+        "ops",
+        "--state",
+        "open",
+        "--json",
+        "number,title",
+    ]
+    result = subprocess.run(list_cmd, capture_output=True, text=True, check=True)
+    for item in json.loads(result.stdout):
+        if item.get("title") == "Operations Notifications":
+            return str(item["number"])
+
+    create_cmd = [
+        gh,
+        "issue",
+        "create",
+        "--title",
+        "Operations Notifications",
+        "--body",
+        "Aggregated notifications",
+        "--label",
+        "ops",
+    ]
+    out = subprocess.run(create_cmd, capture_output=True, text=True, check=True)
+    url = out.stdout.strip().splitlines()[-1]
+    return url.rsplit("/", 1)[-1]
+
+
+def main(path: str) -> None:
+    with open(path, "r", encoding="utf-8") as handle:
+        data: dict[str, Any] = json.load(handle)
+
+    gh = shutil.which("gh") or "gh"
+    issue = find_issue(gh)
+    body = f"### {data.get('title', 'No title')}\n\n{data.get('body', '')}"
+    subprocess.run([gh, "issue", "comment", issue, "--body", body], check=True)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1] if len(sys.argv) > 1 else "notify.json")


### PR DESCRIPTION
## Summary
- aggregate notifications through new notify.yml workflow
- add process_notifications.py script to comment on an aggregated issue
- route existing workflows through notify.yml instead of notify-humans.sh
- document notification policy in AGENTS and agent template
- note notify workflow in CHANGELOG

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6876b8d310748320af0c5d4432b49056