### PR TITLE
Add docs for orchestration agents

### DIFF
--- a/agents/ci-helper-agent.md
+++ b/agents/ci-helper-agent.md
@@ -1,0 +1,24 @@
+---
+codex-agent:
+  name: Agent.CIHelperAgent
+  role: Assists with CI troubleshooting and guidance
+  scope: CI workflows
+  triggers: Failed jobs or developer requests
+  output: Diagnostic notes
+---
+
+# CI Helper Agent
+
+**Status:** Planned.
+
+**Purpose:** Provides tips when CI jobs fail, pointing maintainers to logs and common resolutions.
+
+**Inputs:** CI failure events or manual invocation.
+
+**Outputs:** Summarized diagnostics and next steps.
+
+**Environment:** None defined yet.
+
+**Workflow:** Monitors workflow results and surfaces troubleshooting information.
+
+**Notification:** Route alerts through `.github/workflows/notify.yml`.

--- a/agents/dev-orchestrator.md
+++ b/agents/dev-orchestrator.md
@@ -1,0 +1,24 @@
+---
+codex-agent:
+  name: Agent.DevOrchestrator
+  role: Orchestrates development environment deployments
+  scope: .github/workflows/dev-orchestrator.yml
+  triggers: Push to dev or manual dispatch
+  output: Deployment job logs
+---
+
+# Dev Orchestrator Agent
+
+**Status:** Active.
+
+**Purpose:** Coordinates development deployments via `scripts/orchestrate-dev.sh`.
+
+**Inputs:** GitHub workflow dispatch or push to `dev`.
+
+**Outputs:** Logs confirming the orchestration request.
+
+**Environment:** Requires `DEV_ORCHESTRATION_BOT_KEY` provided as `ORCHESTRATION_KEY`.
+
+**Workflow:** The workflow calls `scripts/orchestrate-dev.sh`, which POSTs to the orchestration service.
+
+**Notification:** Route alerts through `.github/workflows/notify.yml`.

--- a/agents/diagnostics-bot.md
+++ b/agents/diagnostics-bot.md
@@ -1,0 +1,24 @@
+---
+codex-agent:
+  name: Agent.DiagnosticsBot
+  role: Collects environment diagnostics and system health info
+  scope: local and CI diagnostics
+  triggers: Invocation of `python -m diagnostics`
+  output: System check report
+---
+
+# Diagnostics Bot
+
+**Status:** Active.
+
+**Purpose:** Runs health checks and verifies environment variables using the diagnostics module.
+
+**Inputs:** Developer invocation via the command line.
+
+**Outputs:** Summary of system readiness and detected problems.
+
+**Environment:** Reads variables used by the diagnostics scripts.
+
+**Workflow:** Executes diagnostics and prints results. Alerts route through the notify workflow when issues arise.
+
+**Notification:** Route alerts through `.github/workflows/notify.yml`.

--- a/agents/index.md
+++ b/agents/index.md
@@ -11,6 +11,12 @@ how it fits into the workflow.
 - [ID.me Verification](idme-verification.md)
 - [AI Mentor](ai-mentor.md)
 - [Llama2 Agile Helper](llama2-agile-helper.md)
+- [Prod Orchestrator](prod-orchestrator.md)
+- [Dev Orchestrator](dev-orchestrator.md)
+- [Staging Orchestrator](staging-orchestrator.md)
+- [Onboarding Agent](onboarding-agent.md)
+- [CI Helper Agent](ci-helper-agent.md)
+- [Diagnostics Bot](diagnostics-bot.md)
 
 Use the [template](templates/agent-spec-template.md) when documenting a new agent.
 ## Required Environment Variables

--- a/agents/onboarding-agent.md
+++ b/agents/onboarding-agent.md
@@ -1,0 +1,24 @@
+---
+codex-agent:
+  name: Agent.OnboardingAgent
+  role: Guides new contributors through the onboarding checklist
+  scope: docs/ONBOARDING.md
+  triggers: Contributor requests or scheduled reminders
+  output: Onboarding guidance
+---
+
+# Onboarding Agent
+
+**Status:** Planned.
+
+**Purpose:** Helps new contributors complete project onboarding steps.
+
+**Inputs:** Developer questions or periodic automation.
+
+**Outputs:** Reminders and onboarding checklist progress updates.
+
+**Environment:** None defined yet.
+
+**Workflow:** Responds to requests and reviews onboarding tasks, notifying via workflow when actions are required.
+
+**Notification:** Route alerts through `.github/workflows/notify.yml`.

--- a/agents/prod-orchestrator.md
+++ b/agents/prod-orchestrator.md
@@ -1,0 +1,24 @@
+---
+codex-agent:
+  name: Agent.ProdOrchestrator
+  role: Orchestrates production environment deployments
+  scope: .github/workflows/prod-orchestrator.yml
+  triggers: Push to main or manual dispatch
+  output: Deployment job logs
+---
+
+# Prod Orchestrator Agent
+
+**Status:** Active.
+
+**Purpose:** Coordinates production deployments via `scripts/orchestrate-prod.sh`.
+
+**Inputs:** GitHub workflow dispatch or push to `main`.
+
+**Outputs:** Logs confirming the orchestration request.
+
+**Environment:** Requires `PROD_ORCHESTRATION_BOT_KEY` provided as `ORCHESTRATION_KEY`.
+
+**Workflow:** The workflow calls `scripts/orchestrate-prod.sh`, which POSTs to the orchestration service.
+
+**Notification:** Route alerts through `.github/workflows/notify.yml`.

--- a/agents/staging-orchestrator.md
+++ b/agents/staging-orchestrator.md
@@ -1,0 +1,24 @@
+---
+codex-agent:
+  name: Agent.StagingOrchestrator
+  role: Orchestrates staging environment deployments
+  scope: .github/workflows/staging-orchestrator.yml
+  triggers: Push to staging or manual dispatch
+  output: Deployment job logs
+---
+
+# Staging Orchestrator Agent
+
+**Status:** Active.
+
+**Purpose:** Coordinates staging deployments via `scripts/orchestrate-staging.sh`.
+
+**Inputs:** GitHub workflow dispatch or push to `staging`.
+
+**Outputs:** Logs confirming the orchestration request.
+
+**Environment:** Requires `STAGING_ORCHESTRATION_BOT_KEY` provided as `ORCHESTRATION_KEY`.
+
+**Workflow:** The workflow calls `scripts/orchestrate-staging.sh`, which POSTs to the orchestration service.
+
+**Notification:** Route alerts through `.github/workflows/notify.yml`.

--- a/codex/agents/index.json
+++ b/codex/agents/index.json
@@ -97,6 +97,48 @@
       "path": ".github/workflows/security-audit.yml",
       "triggers": "Scheduled or manual run",
       "output": "Uploaded security audit report"
+    },
+    {
+      "name": "Agent.ProdOrchestrator",
+      "role": "Orchestrates production environment deployments",
+      "path": "agents/prod-orchestrator.md",
+      "triggers": "Push to main or manual dispatch",
+      "output": "Deployment job logs"
+    },
+    {
+      "name": "Agent.DevOrchestrator",
+      "role": "Orchestrates development environment deployments",
+      "path": "agents/dev-orchestrator.md",
+      "triggers": "Push to dev or manual dispatch",
+      "output": "Deployment job logs"
+    },
+    {
+      "name": "Agent.StagingOrchestrator",
+      "role": "Orchestrates staging environment deployments",
+      "path": "agents/staging-orchestrator.md",
+      "triggers": "Push to staging or manual dispatch",
+      "output": "Deployment job logs"
+    },
+    {
+      "name": "Agent.OnboardingAgent",
+      "role": "Guides new contributors through the onboarding checklist",
+      "path": "agents/onboarding-agent.md",
+      "triggers": "Contributor requests or scheduled reminders",
+      "output": "Onboarding guidance"
+    },
+    {
+      "name": "Agent.CIHelperAgent",
+      "role": "Assists with CI troubleshooting and guidance",
+      "path": "agents/ci-helper-agent.md",
+      "triggers": "Failed jobs or developer requests",
+      "output": "Diagnostic notes"
+    },
+    {
+      "name": "Agent.DiagnosticsBot",
+      "role": "Collects environment diagnostics and system health info",
+      "path": "agents/diagnostics-bot.md",
+      "triggers": "Invocation of `python -m diagnostics`",
+      "output": "System check report"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- document CI helper and diagnostics agents
- add orchestrator agent docs
- list all new agents in codex index files

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6876bc0028188320860f1d54a8dbf01c