### PR TITLE
Add permissions validation workflow

### DIFF
--- a/.github/workflows/validate-permissions.yml
+++ b/.github/workflows/validate-permissions.yml
@@ -1,0 +1,54 @@
+# ---
+# codex-agent:
+#   name: Agent.ValidatePermissions
+#   role: Lints workflow files and bot permissions
+#   scope: .github/workflows/validate-permissions.yml
+#   triggers: Push and pull_request events
+#   output: CI logs
+# ---
+name: Validate Permissions
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-yaml:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ibiqlik/action-yamllint@v3
+        with:
+          file_or_dir: ".github/workflows/**/*.yml"
+          config_file: .github/.yamllint-config
+  check:
+    needs: validate-yaml
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install yamllint
+        run: pip install yamllint
+      - name: Lint bot permissions
+        run: bash scripts/lint-bot-permissions.sh
+      - name: Verify agent docs exist
+        run: |
+          test -f agents/index.md
+          test -f agents/templates/Agent.md
+      - name: Check for disallowed commands
+        run: |
+          if grep -R "gh issue" .github/workflows | grep -v validate-permissions.yml; then
+            echo "Direct gh issue command found" >&2
+            exit 1
+          fi
+          if grep -R "notify-humans.sh" .github/workflows; then
+            echo "External notification script used" >&2
+            exit 1
+          fi
+          if grep -R "hooks.slack.com" .github/workflows; then
+            echo "Direct Slack notification found" >&2
+            exit 1
+          fi
+

--- a/agents/templates/Agent.md
+++ b/agents/templates/Agent.md
@@ -1,0 +1,13 @@
+---
+codex-agent:
+  name: Agent.Template
+  role: Template for documenting new agents
+  scope: agents/templates/Agent.md
+  triggers: n/a
+  output: Agent documentation template
+---
+
+# Agent Documentation Template
+
+Use this file as a starting point when creating new agent documentation.
+Provide a brief description, inputs, outputs and environment requirements.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be recorded in this file.
 - fix(ci): correct YAML indentation in Verify gh version step
 - chore(ci): reuse saved ci-failure issue number across runs
 - chore(ci): validate `.codex/bot-permissions.yaml` via new script
+- chore(ci): add permissions validation workflow
 
 - chore(codex): record bot secrets and permissions in `.codex/bot-permissions.yaml`
 

--- a/scripts/lint-bot-permissions.sh
+++ b/scripts/lint-bot-permissions.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FILE=".codex/bot-permissions.yaml"
+
+if [ ! -f "$FILE" ]; then
+  echo "$FILE not found" >&2
+  exit 1
+fi
+
+if ! command -v yamllint >/dev/null 2>&1; then
+  echo "yamllint not installed" >&2
+  exit 1
+fi
+
+yamllint -c .github/.yamllint-config "$FILE"
+
+echo "Bot permissions lint passed"


### PR DESCRIPTION
## Summary
- create `validate-permissions.yml` to lint YAML and enforce workflow policies
- add `lint-bot-permissions.sh` script
- add missing agent template
- document new workflow in changelog

## Testing
- `bash scripts/validate.sh`
- `bash scripts/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_6876c01b2c24832094de54e9cfb2d1c4