### PR TITLE
Update retro docs

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be recorded in this file.
 - docs(ci): outline CI enforcement tasks in `.codex/automation-tasks.md`
 - docs(pr-template): add Codex policy checklist bullet to PR templates
 - docs(retros): introduce retrospective framework and audit workflow
+- docs(retros): document `scripts/create-retro-file.sh` usage for new retrospectives
 
 - fix(ci): correct YAML indentation in Verify gh version step
 - chore(ci): reuse saved ci-failure issue number across runs

--- a/docs/README.md
+++ b/docs/README.md
@@ -190,6 +190,19 @@ Add yourself to [../ALPHA_TESTERS.md](../ALPHA_TESTERS.md) or
 [../FOUNDERS.md](../FOUNDERS.md) when you participate. These logs help us track
 who has contributed and when.
 
+## Retrospectives
+
+Run `scripts/create-retro-file.sh` whenever you start a new retrospective. It
+copies `docs/checklists/retrospective-template.md` into
+`docs/checklists/retros/` using today's date for the filename.
+
+```bash
+bash scripts/create-retro-file.sh
+```
+
+If a file with the same date already exists, the script prints an error and
+exits so duplicates are not created.
+
 ## Configuration Helpers
 
 - `.pre-commit-config.yaml` &ndash; run `pre-commit install` to set up git hooks that execute the linter and tests.


### PR DESCRIPTION
## Summary
- document how to generate new retrospective files in `docs/README.md`
- log the update in the changelog

## Testing
- `bash scripts/check_docs.sh`
- `pytest -q`
- `npm run coverage` in `bot`
- `npm run coverage` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6877158d900483208b8e97d140a6b1db