### PR TITLE
Add script for parsing retrospective action owners

### DIFF
--- a/.github/workflows/audit-retro-actions.yml
+++ b/.github/workflows/audit-retro-actions.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Check for unresolved action items
         id: check
         run: |
-          UNRESOLVED=$(grep -r "^\- \[ \]" docs/checklists/retros/*.md || true)
+          UNRESOLVED=$(python scripts/parse_retro_actions.py || true)
           if [ -n "$UNRESOLVED" ]; then
             echo "unresolved_actions=$UNRESOLVED" >> "$GITHUB_OUTPUT"
           else
@@ -20,7 +20,7 @@ jobs:
       - name: Create issue for unresolved actions
         if: steps.check.outputs.unresolved_actions != 'None'
         run: |
-          OWNERS=$(echo "${{ steps.check.outputs.unresolved_actions }}" | grep -oE "@[A-Za-z0-9_-]+" | sort -u | tr '\n' ' ')
+          OWNERS=$(python scripts/parse_retro_actions.py --owners || true)
           gh issue create \
             --title "Unresolved Retrospective Action Items" \
             --body "The following action items remain open:\n\n${{ steps.check.outputs.unresolved_actions }}\n\nCC: $OWNERS" \

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be recorded in this file.
 - chore(ci): reuse saved ci-failure issue number across runs
 - chore(ci): validate `.codex/bot-permissions.yaml` via new script
 - chore(ci): add permissions validation workflow
+- chore(scripts): parse retrospective actions via new Python utility
 
 - chore(codex): record bot secrets and permissions in `.codex/bot-permissions.yaml`
 

--- a/scripts/parse_retro_actions.py
+++ b/scripts/parse_retro_actions.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+"""Extract open retrospective action items and owners."""
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+ACTION_RE = re.compile(r"^\s*-\s*\[\s*\]\s*(.*)")
+USER_RE = re.compile(r"@[A-Za-z0-9_-]+")
+
+
+def parse_actions(directory: Path) -> list[str]:
+    """Return unresolved action item lines under ``directory``."""
+    actions: list[str] = []
+    for file in sorted(directory.glob("*.md")):
+        for line in file.read_text(encoding="utf-8").splitlines():
+            if ACTION_RE.match(line):
+                actions.append(f"{file}:{line}")
+    return actions
+
+
+def extract_usernames(actions: list[str]) -> list[str]:
+    """Return unique GitHub usernames mentioned in ``actions``."""
+    users = set()
+    for line in actions:
+        users.update(USER_RE.findall(line))
+    return sorted(users)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "path",
+        nargs="?",
+        default="docs/checklists/retros",
+        help="Directory containing retrospective files",
+    )
+    parser.add_argument(
+        "--owners",
+        action="store_true",
+        help="Print unique GitHub usernames instead of action lines",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print actions and owners for validation and exit",
+    )
+    args = parser.parse_args(argv)
+
+    actions = parse_actions(Path(args.path))
+    output = extract_usernames(actions) if args.owners else actions
+    if output:
+        print("\n".join(output))
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_parse_retro_actions.py
+++ b/tests/test_parse_retro_actions.py
@@ -1,0 +1,34 @@
+import importlib.util
+from pathlib import Path
+
+# Load the script as a module
+spec = importlib.util.spec_from_file_location(
+    "parse_retro_actions",
+    Path(__file__).resolve().parents[1] / "scripts" / "parse_retro_actions.py",
+)
+parse_retro_actions = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(parse_retro_actions)
+
+
+def test_parse_actions(tmp_path: Path) -> None:
+    retro_dir = tmp_path / "docs" / "checklists" / "retros"
+    retro_dir.mkdir(parents=True)
+    file = retro_dir / "2024-07-16.md"
+    file.write_text("- [ ] Task one @alice\n- [x] Done\n- [ ] Task two @bob")
+
+    actions = parse_retro_actions.parse_actions(retro_dir)
+    assert actions == [
+        f"{file}:- [ ] Task one @alice",
+        f"{file}:- [ ] Task two @bob",
+    ]
+    assert parse_retro_actions.extract_usernames(actions) == ["@alice", "@bob"]
+
+
+def test_cli_owners(tmp_path: Path, capsys) -> None:
+    retro_dir = tmp_path / "docs" / "checklists" / "retros"
+    retro_dir.mkdir(parents=True)
+    (retro_dir / "retro.md").write_text("- [ ] Example @user")
+
+    parse_retro_actions.main([str(retro_dir), "--owners"])
+    assert capsys.readouterr().out.strip() == "@user"
+


### PR DESCRIPTION
## Summary
- add `parse_retro_actions.py` to parse open action items
- test extracting usernames and CLI output
- use new script in `audit-retro-actions.yml`
- document the change in `docs/CHANGELOG.md`

## Testing
- `ruff check scripts/parse_retro_actions.py tests/test_parse_retro_actions.py`
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_687726c235288320bab504ad9f94ddff