### PR TITLE
Add known error learning loop

### DIFF
--- a/.codex/known_errors.yaml
+++ b/.codex/known_errors.yaml
@@ -1,0 +1,9 @@
+- error_code: ERR001
+  error_message: "ModuleNotFoundError: No module named 'foo'"
+  solution: "pip install foo"
+  context: "Occurs when the optional 'foo' dependency is missing"
+  date_added: "2024-01-01"
+  resolved_by: "maintainers"
+  hits: 0
+  tags:
+    - python

--- a/.github/workflows/dev-orchestrator.yml
+++ b/.github/workflows/dev-orchestrator.yml
@@ -21,6 +21,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: ksivamuthu/actions-setup-gh-cli@v3
+      - name: Known errors learning loop
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pip install PyYAML
+          python scripts/known_errors_loop.py
       - name: Run dev orchestrator
         run: bash scripts/orchestrate-dev.sh
         env:

--- a/.github/workflows/prod-orchestrator.yml
+++ b/.github/workflows/prod-orchestrator.yml
@@ -21,6 +21,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: ksivamuthu/actions-setup-gh-cli@v3
+      - name: Known errors learning loop
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pip install PyYAML
+          python scripts/known_errors_loop.py
       - name: Run production orchestrator
         run: bash scripts/orchestrate-prod.sh
         env:

--- a/.github/workflows/review-known-errors.yml
+++ b/.github/workflows/review-known-errors.yml
@@ -1,0 +1,53 @@
+# ---
+# codex-agent:
+#   name: Agent.ReviewKnownErrors
+#   role: Audits known error entries and escalates outdated ones
+#   scope: .github/workflows/review-known-errors.yml
+#   triggers: Weekly schedule
+#   output: Issue when entries are outdated
+# ---
+name: Review Known Errors
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ksivamuthu/actions-setup-gh-cli@v3
+      - name: Install PyYAML
+        run: pip install PyYAML
+      - name: Check for outdated entries
+        id: check
+        run: |
+          python - <<'PY'
+          import datetime, json, yaml
+          from pathlib import Path
+          path = Path('.codex/known_errors.yaml')
+          data = yaml.safe_load(path.read_text()) or []
+          threshold = datetime.datetime.utcnow() - datetime.timedelta(days=30)
+          outdated = [e for e in data if datetime.datetime.fromisoformat(e['date_added']) < threshold and e.get('hits',0) == 0]
+          if outdated:
+              Path('outdated.json').write_text(json.dumps(outdated, indent=2))
+          PY
+          if [ -f outdated.json ]; then echo "has_outdated=true" >> "$GITHUB_OUTPUT"; else echo "has_outdated=false" >> "$GITHUB_OUTPUT"; fi
+      - name: Escalate outdated entries
+        if: steps.check.outputs.has_outdated == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          payload=$(python - <<'PY'
+          import json
+          from pathlib import Path
+          body = Path('outdated.json').read_text()
+          print(json.dumps({'title': 'Outdated known error entries', 'body': body}))
+          PY
+          )
+          gh workflow run notify.yml -f data="$payload"

--- a/.github/workflows/staging-orchestrator.yml
+++ b/.github/workflows/staging-orchestrator.yml
@@ -21,6 +21,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: ksivamuthu/actions-setup-gh-cli@v3
+      - name: Known errors learning loop
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pip install PyYAML
+          python scripts/known_errors_loop.py
       - name: Run staging orchestrator
         run: bash scripts/orchestrate-staging.sh
         env:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -808,3 +808,4 @@ All notable changes to this project will be recorded in this file.
 - Added a `fastapi` check to `scripts/check_dependencies.sh` so tests fail fast when runtime dependencies are missing.
 - `scripts/run_tests.sh` validates dependencies with `pip check` after installing dev requirements and again after installing the project.
 - Replaced custom GitHub CLI script with the `ksivamuthu/actions-setup-gh-cli` action and updated documentation.
+- Added known error learning loop and review workflow.

--- a/docs/KEKB.md
+++ b/docs/KEKB.md
@@ -1,0 +1,3 @@
+# Known Error Knowledge Base
+
+This file collects resolved issues and troubleshooting steps discovered during automated runs.

--- a/scripts/known_errors_loop.py
+++ b/scripts/known_errors_loop.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+"""Process error logs against the known error database."""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+
+import yaml
+
+KNOWN_ERRORS = Path(".codex/known_errors.yaml")
+ERROR_LOG = Path("error_log.txt")
+
+
+def load_errors() -> list[dict]:
+    if KNOWN_ERRORS.exists():
+        return yaml.safe_load(KNOWN_ERRORS.read_text()) or []
+    return []
+
+
+def save_errors(data: list[dict]) -> None:
+    with KNOWN_ERRORS.open("w", encoding="utf-8") as handle:
+        yaml.safe_dump(data, handle, sort_keys=False)
+
+
+def escalate(line: str) -> None:
+    """Create an issue for an unknown error via the notify workflow."""
+    gh = shutil.which("gh") or "gh"
+    payload = json.dumps({"title": "Unknown error detected", "body": line})
+    subprocess.run(
+        [gh, "workflow", "run", "notify.yml", "-f", f"data={payload}"],
+        check=False,
+    )
+
+
+def process_log(path: Path) -> None:
+    lines = path.read_text().splitlines() if path.exists() else []
+    if not lines:
+        return
+
+    entries = load_errors()
+    updated = False
+    now = datetime.utcnow().isoformat()
+
+    for line in lines:
+        matched = False
+        for entry in entries:
+            if entry.get("error_code") in line or entry.get("error_message") in line:
+                entry["hits"] = int(entry.get("hits", 0)) + 1
+                cmd = entry.get("solution", "")
+                if cmd:
+                    subprocess.run(cmd, shell=True, check=False)
+                matched = True
+                updated = True
+                break
+        if not matched:
+            escalate(line)
+        with ERROR_LOG.open("a", encoding="utf-8") as log:
+            log.write(f"{now} {line}\n")
+
+    if updated:
+        save_errors(entries)
+
+
+def main() -> None:
+    log_path = Path(sys.argv[1]) if len(sys.argv) > 1 else ERROR_LOG
+    process_log(log_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sync-issue-to-kekb.py
+++ b/scripts/sync-issue-to-kekb.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+"""Append resolved GitHub issues to the KEKB knowledge base."""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+KB_FILE = Path("docs/KEKB.md")
+
+
+def append_issue(issue_number: str) -> None:
+    gh = shutil.which("gh") or "gh"
+    out = subprocess.run(
+        [gh, "issue", "view", issue_number, "--json", "title,body,state"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    data = json.loads(out.stdout)
+    if data.get("state") != "closed":
+        print(f"Issue {issue_number} is not closed; skipping")
+        return
+
+    KB_FILE.touch(exist_ok=True)
+    with KB_FILE.open("a", encoding="utf-8") as handle:
+        handle.write(f"## {issue_number}: {data['title']}\n\n{data['body']}\n\n")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: sync-issue-to-kekb.py <issue-number>", file=sys.stderr)
+        sys.exit(1)
+    append_issue(sys.argv[1])


### PR DESCRIPTION
## Summary
- track known errors in `.codex/known_errors.yaml`
- add `scripts/known_errors_loop.py` and `scripts/sync-issue-to-kekb.py`
- audit known errors weekly in `review-known-errors.yml`
- run the learning loop from orchestrator workflows
- document knowledge base
- note changes in the changelog

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68772f4afa6c832082c0ed4678d1f248