### PR TITLE
Add agent policy doc and checklist references

### DIFF
--- a/.codex/Agents.md
+++ b/.codex/Agents.md
@@ -1,0 +1,13 @@
+# Codex Agent Policy
+
+All documentation under `agents/` must start with a `codex-agent` YAML header. This header defines the agent name, its role, and other metadata used by automation. Each agent file must also appear in `codex/agents/index.json` so Codex can map roles during orchestration.
+
+All agents send human‑facing messages through the centralized `notify.yml` workflow. Trigger it with:
+
+```bash
+gh workflow run notify.yml -f data=<json>
+```
+
+The workflow aggregates notifications via `scripts/process_notifications.py` and posts them to a single issue instead of sending disparate emails.
+
+See [../agents/index.md](../agents/index.md) for the full list of agents and sample YAML headers.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,3 +19,6 @@ The hook prevents bad commit messages from reaching CI. See
 [docs/git-guidelines.md](docs/git-guidelines.md) for style rules and
 [docs/README.md](docs/README.md) for environment setup tips.
 See [docs/dependencies.md](docs/dependencies.md) for the Dependabot update workflow.
+
+See [.codex/Agents.md](.codex/Agents.md) for agent YAML guidelines and notification rules.
+Refer to [docs/checklists/continuous-improvement.md](docs/checklists/continuous-improvement.md) during each retrospective.

--- a/README.md
+++ b/README.md
@@ -98,27 +98,30 @@ Workflow documentation lives under the [docs/](docs/) directory. New contributor
 17. Browse the [agents overview](agents/index.md) for individual service specs.
     Codex reads the machine‑readable list in `codex/agents/index.json` to
     coordinate automation across these agents.
-18. Keep the sentinel word `Potato` and the file `Potato.md` listed in `.gitignore`,
+18. Review [.codex/Agents.md](.codex/Agents.md) for agent YAML header requirements and centralized notifications.
+19. Keep the sentinel word `Potato` and the file `Potato.md` listed in `.gitignore`,
     `.dockerignore`, and `.codespell-ignore`.
     See [AGENTS.md](AGENTS.md) for the full policy. Both pre-commit and CI run `scripts/check_potato_ignore.sh`
     to confirm the entries exist. Do not remove them without approval.
-19. Review the [builder ethics dossier](docs/builder_ethics_dossier.md)
+20. Review the [builder ethics dossier](docs/builder_ethics_dossier.md)
     outlining contributor ethics and a simple template.
-20. Prefix a commit message with `[no-ci]` to skip the CI workflow on direct pushes. Pull requests always run CI. See
+21. Prefix a commit message with `[no-ci]` to skip the CI workflow on direct pushes. Pull requests always run CI. See
     [AGENTS.md](AGENTS.md) for details.
-21. See [docs/network-exception-list.md](docs/network-exception-list.md)
+22. See [docs/network-exception-list.md](docs/network-exception-list.md)
     for required firewall domains. Run
     `scripts/show_network_exceptions.sh` to print them.
-22. See [docs/ci-failure-issues.md](docs/ci-failure-issues.md)
+23. See [docs/ci-failure-issues.md](docs/ci-failure-issues.md)
     if CI automation fails to create or close `ci-failure` issues.
-23. Review [docs/assessments/engineer_assessment_work_items.md](docs/assessments/engineer_assessment_work_items.md)
+24. Review [docs/assessments/engineer_assessment_work_items.md](docs/assessments/engineer_assessment_work_items.md)
     and open an issue with the
     [Engineer Assessment template](.github/ISSUE_TEMPLATE/assessment.md)
     during onboarding reviews to ensure new features meet the checklist.
-24. Read [docs/ecosystem.md](docs/ecosystem.md) for an overview of how the
+25. Read [docs/ecosystem.md](docs/ecosystem.md) for an overview of how the
     services interact inside the TAGS stack.
-25. See [docs/tags_integration.md](docs/tags_integration.md) for TAGS setup
+26. See [docs/tags_integration.md](docs/tags_integration.md) for TAGS setup
     steps and feature flag usage.
+
+27. Review [docs/checklists/continuous-improvement.md](docs/checklists/continuous-improvement.md) for periodic retrospective tasks.
 
 These files expand on the steps listed in the Quickstart section.
 

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -14,6 +14,8 @@ Please review our [Code of Conduct](../CODE_OF_CONDUCT.md) before contributing.
   [tags_integration.md](tags_integration.md) for compose templates. Set
   `IS_ALPHA_USER` or `IS_FOUNDER` in `.env.dev` when running within the TAGS
   stack to expose early-access endpoints.
+* See [../.codex/Agents.md](../.codex/Agents.md) for agent documentation requirements and notification rules.
+* Review [checklists/continuous-improvement.md](checklists/continuous-improvement.md) during retrospectives.
 
 ## Requesting a Codex QA Assessment
 


### PR DESCRIPTION
## Summary
- document YAML headers and notify.yml usage in `.codex/Agents.md`
- reference the new policy in README, CONTRIBUTING, and onboarding guide
- mention the continuous-improvement checklist in docs

## Testing
- `scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6877d433e4a883208a1fe15f92247a1d