### PR TITLE
Add tests for notification utilities

### DIFF
--- a/tests/test_known_errors_loop.py
+++ b/tests/test_known_errors_loop.py
@@ -1,0 +1,64 @@
+import importlib.util
+import subprocess
+from pathlib import Path
+
+import yaml
+
+
+def load_module(tmp_path: Path):
+    spec = importlib.util.spec_from_file_location(
+        "known_errors_loop",
+        Path(__file__).resolve().parents[1] / "scripts" / "known_errors_loop.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)  # type: ignore[attr-defined]
+    return module
+
+
+def setup_env(tmp_path: Path):
+    (tmp_path / ".codex").mkdir()
+    yaml.safe_dump(
+        [
+            {
+                "error_code": "ERR001",
+                "error_message": "ModuleNotFoundError: No module named 'foo'",
+                "hits": 0,
+            }
+        ],
+        (tmp_path / ".codex" / "known_errors.yaml").open("w", encoding="utf-8"),
+        sort_keys=False,
+    )
+
+
+def test_known_error_increments_hits(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    setup_env(tmp_path)
+    log = tmp_path / "log.txt"
+    log.write_text("ModuleNotFoundError: No module named 'foo'\n")
+    module = load_module(tmp_path)
+
+    module.process_log(log)
+
+    data = yaml.safe_load((tmp_path / ".codex" / "known_errors.yaml").read_text())
+    assert data[0]["hits"] == 1
+
+
+def test_unknown_error_triggers_notification(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    setup_env(tmp_path)
+    log = tmp_path / "log.txt"
+    log.write_text("something unexpected\n")
+
+    calls = []
+
+    def fake_run(cmd, *a, **kw):
+        calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    module = load_module(tmp_path)
+    module.process_log(log)
+
+    notify_calls = [c for c in calls if "notify.yml" in c]
+    assert notify_calls, "notify workflow not triggered"
+

--- a/tests/test_process_notifications.py
+++ b/tests/test_process_notifications.py
@@ -1,0 +1,42 @@
+import importlib.util
+import json
+import subprocess
+import shutil
+from pathlib import Path
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location(
+        "process_notifications",
+        Path(__file__).resolve().parents[1] / "scripts" / "process_notifications.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)  # type: ignore[attr-defined]
+    return module
+
+
+def test_process_notifications_adds_comment(tmp_path, monkeypatch):
+    data = {"title": "Alert", "body": "something happened"}
+    notify_file = tmp_path / "notify.json"
+    notify_file.write_text(json.dumps(data))
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(shutil, "which", lambda x: "gh")
+
+    calls = []
+
+    def fake_run(cmd, capture_output=False, text=False, check=True):
+        if "list" in cmd:
+            return subprocess.CompletedProcess(cmd, 0, stdout=json.dumps([{"number": 42, "title": "Operations Notifications"}]), stderr="")
+        if "comment" in cmd:
+            calls.append(cmd)
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+        raise AssertionError(f"Unexpected command: {cmd}")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    module = load_module()
+    module.main(str(notify_file))
+
+    assert calls
+    assert calls[0][3] == "42"
+

--- a/tests/test_sync_issue_to_kekb.py
+++ b/tests/test_sync_issue_to_kekb.py
@@ -1,0 +1,36 @@
+import importlib.util
+import json
+import subprocess
+from pathlib import Path
+
+
+def load_module(tmp_path: Path):
+    spec = importlib.util.spec_from_file_location(
+        "sync_issue_to_kekb",
+        Path(__file__).resolve().parents[1] / "scripts" / "sync-issue-to-kekb.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)  # type: ignore[attr-defined]
+    return module
+
+
+def test_append_closed_issue(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "docs").mkdir()
+
+    def fake_run(cmd, capture_output=False, text=False, check=True):
+        return subprocess.CompletedProcess(
+            cmd,
+            0,
+            stdout=json.dumps({"title": "Fix bug", "body": "details", "state": "closed"}),
+            stderr="",
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    module = load_module(tmp_path)
+    module.append_issue("123")
+
+    content = (tmp_path / "docs" / "KEKB.md").read_text()
+    assert "## 123: Fix bug" in content
+    assert "details" in content
+


### PR DESCRIPTION
## Summary
- test known_errors_loop increments hits and triggers notifications
- test process_notifications posts comments on the notification issue
- test sync-issue-to-kekb appends closed issues to the KEKB doc

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877ddb5d0608320a8ca3f4d18ffd957