### PR TITLE
Add ORCHESTRATOR_URL environment variable

### DIFF
--- a/.github/workflows/dev-orchestrator.yml
+++ b/.github/workflows/dev-orchestrator.yml
@@ -32,3 +32,4 @@ jobs:
         run: bash scripts/orchestrate-dev.sh
         env:
           ORCHESTRATION_KEY: ${{ secrets.DEV_ORCHESTRATION_BOT_KEY }}
+          ORCHESTRATOR_URL: https://orchestrator.example.com

--- a/.github/workflows/prod-orchestrator.yml
+++ b/.github/workflows/prod-orchestrator.yml
@@ -32,3 +32,4 @@ jobs:
         run: bash scripts/orchestrate-prod.sh
         env:
           ORCHESTRATION_KEY: ${{ secrets.PROD_ORCHESTRATION_BOT_KEY }}
+          ORCHESTRATOR_URL: https://orchestrator.example.com

--- a/.github/workflows/staging-orchestrator.yml
+++ b/.github/workflows/staging-orchestrator.yml
@@ -32,3 +32,4 @@ jobs:
         run: bash scripts/orchestrate-staging.sh
         env:
           ORCHESTRATION_KEY: ${{ secrets.STAGING_ORCHESTRATION_BOT_KEY }}
+          ORCHESTRATOR_URL: https://orchestrator.example.com

--- a/agents/dev-orchestrator.md
+++ b/agents/dev-orchestrator.md
@@ -17,7 +17,7 @@ codex-agent:
 
 **Outputs:** Logs confirming the orchestration request.
 
-**Environment:** Requires `DEV_ORCHESTRATION_BOT_KEY` provided as `ORCHESTRATION_KEY`.
+**Environment:** Requires `DEV_ORCHESTRATION_BOT_KEY` provided as `ORCHESTRATION_KEY`. Optionally set `ORCHESTRATOR_URL` (default `https://orchestrator.example.com`).
 
 **Workflow:** The workflow calls `scripts/orchestrate-dev.sh`, which POSTs to the orchestration service.
 

--- a/agents/prod-orchestrator.md
+++ b/agents/prod-orchestrator.md
@@ -17,7 +17,7 @@ codex-agent:
 
 **Outputs:** Logs confirming the orchestration request.
 
-**Environment:** Requires `PROD_ORCHESTRATION_BOT_KEY` provided as `ORCHESTRATION_KEY`.
+**Environment:** Requires `PROD_ORCHESTRATION_BOT_KEY` provided as `ORCHESTRATION_KEY`. Optionally set `ORCHESTRATOR_URL` (default `https://orchestrator.example.com`).
 
 **Workflow:** The workflow calls `scripts/orchestrate-prod.sh`, which POSTs to the orchestration service.
 

--- a/agents/staging-orchestrator.md
+++ b/agents/staging-orchestrator.md
@@ -17,7 +17,7 @@ codex-agent:
 
 **Outputs:** Logs confirming the orchestration request.
 
-**Environment:** Requires `STAGING_ORCHESTRATION_BOT_KEY` provided as `ORCHESTRATION_KEY`.
+**Environment:** Requires `STAGING_ORCHESTRATION_BOT_KEY` provided as `ORCHESTRATION_KEY`. Optionally set `ORCHESTRATOR_URL` (default `https://orchestrator.example.com`).
 
 **Workflow:** The workflow calls `scripts/orchestrate-staging.sh`, which POSTs to the orchestration service.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be recorded in this file.
 - chore(docs): regenerate env variable docs from `.env.example` via new script
   and run it in CI before validation
 - chore(ci): add prod, staging, and dev orchestrator workflows
+- feat(orchestration): parameterize orchestrator scripts with `ORCHESTRATOR_URL`
 
 - Linked `docs/CHANGELOG.md` from `README.md` for easier navigation.
 - Mentioned `codex/agents/index.json` alongside `agents/index.md` and

--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -17,6 +17,12 @@ Each bot uses a dedicated token stored in GitHub Actions secrets. The
 `check-bot-permissions.sh` script verifies that permissions match the policy
 before workflows run.
 
+## Orchestrator URL
+
+The orchestration scripts reference an `ORCHESTRATOR_URL` environment variable.
+Workflows set this variable when invoking the scripts. If not provided, the
+scripts default to `https://orchestrator.example.com`.
+
 ## API Key Management
 
 1. Store each bot token as a separate secret in GitHub.

--- a/scripts/orchestrate-dev.sh
+++ b/scripts/orchestrate-dev.sh
@@ -6,8 +6,11 @@ if [ -z "${ORCHESTRATION_KEY:-}" ]; then
   exit 1
 fi
 
+# Base URL for the orchestration service
+ORCHESTRATOR_URL=${ORCHESTRATOR_URL:-https://orchestrator.example.com}
+
 echo "Triggering development orchestration..."
 
-curl -fsSL -X POST "https://orchestrator.example.com/dev" \
+curl -fsSL -X POST "$ORCHESTRATOR_URL/dev" \
   -H "Authorization: Bearer $ORCHESTRATION_KEY" \
   -d '{}' || echo "Orchestration request failed or skipped."

--- a/scripts/orchestrate-prod.sh
+++ b/scripts/orchestrate-prod.sh
@@ -6,8 +6,11 @@ if [ -z "${ORCHESTRATION_KEY:-}" ]; then
   exit 1
 fi
 
+# Base URL for the orchestration service
+ORCHESTRATOR_URL=${ORCHESTRATOR_URL:-https://orchestrator.example.com}
+
 echo "Triggering production orchestration..."
 
-curl -fsSL -X POST "https://orchestrator.example.com/prod" \
+curl -fsSL -X POST "$ORCHESTRATOR_URL/prod" \
   -H "Authorization: Bearer $ORCHESTRATION_KEY" \
   -d '{}' || echo "Orchestration request failed or skipped."

--- a/scripts/orchestrate-staging.sh
+++ b/scripts/orchestrate-staging.sh
@@ -6,8 +6,11 @@ if [ -z "${ORCHESTRATION_KEY:-}" ]; then
   exit 1
 fi
 
+# Base URL for the orchestration service
+ORCHESTRATOR_URL=${ORCHESTRATOR_URL:-https://orchestrator.example.com}
+
 echo "Triggering staging orchestration..."
 
-curl -fsSL -X POST "https://orchestrator.example.com/staging" \
+curl -fsSL -X POST "$ORCHESTRATOR_URL/staging" \
   -H "Authorization: Bearer $ORCHESTRATION_KEY" \
   -d '{}' || echo "Orchestration request failed or skipped."


### PR DESCRIPTION
## Summary
- default orchestrator URL in orchestrate scripts
- allow workflows to pass `ORCHESTRATOR_URL`
- document the new variable

## Testing
- `pre-commit run --files .github/workflows/dev-orchestrator.yml .github/workflows/prod-orchestrator.yml .github/workflows/staging-orchestrator.yml agents/dev-orchestrator.md agents/prod-orchestrator.md agents/staging-orchestrator.md docs/CHANGELOG.md docs/orchestration.md scripts/orchestrate-dev.sh scripts/orchestrate-prod.sh scripts/orchestrate-staging.sh`
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_687806e420588320aa974cf6c48ac560