### PR TITLE
Add shellcheck linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,10 @@ jobs:
               with:
                   fetch-depth: 0
                   ref: ${{ github.head_ref }}
+            - name: Install shellcheck
+              run: pip install shellcheck-py
+            - name: Lint shell scripts
+              run: shellcheck scripts/*.sh
             - name: Lint commit messages
               run: bash scripts/check_commit_messages.sh
             - name: Install GitHub CLI

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,11 @@ repos:
       hooks:
           - id: trailing-whitespace
           - id: end-of-file-fixer
+    - repo: https://github.com/shellcheck-py/shellcheck-py
+      rev: v0.10.0.1
+      hooks:
+          - id: shellcheck
+            files: ^scripts/.*\.sh$
     - repo: https://github.com/codespell-project/codespell
       rev: v2.4.1
       hooks:

--- a/docs/QA_CHECKLIST.md
+++ b/docs/QA_CHECKLIST.md
@@ -6,6 +6,7 @@ Use this checklist alongside the [git guidelines](git-guidelines.md) and the [pu
 - [ ] Lint, type, and security checks succeed
 - [ ] Commit messages follow our conventions
 - [ ] Pre-commit hooks are installed and run
+- [ ] Shell scripts pass `shellcheck`
 
 ## CI/CD & Test Coverage
 - [ ] All test suites pass

--- a/docs/README.md
+++ b/docs/README.md
@@ -76,18 +76,20 @@ check in CI. See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
 
     Then set `LANGUAGETOOL_URL=http://localhost:8010/v2`.
 
-19. Run `bash scripts/check_dependencies.sh` to verify Jest, Vitest, and Vale are installed.
+19. Lint shell scripts with `shellcheck scripts/*.sh`.
 
-20. CI posts a coverage summary on pull requests. Run
+20. Run `bash scripts/check_dependencies.sh` to verify Jest, Vitest, and Vale are installed.
+
+21. CI posts a coverage summary on pull requests. Run
     `python scripts/post_coverage_comment.py` to generate the table locally.
-21. Append the coverage numbers to a Markdown file with
+22. Append the coverage numbers to a Markdown file with
     `bash scripts/append_coverage_summary.sh`. Set the following
     environment variables before running the script:
     `COVERED_LINES`, `TOTAL_LINES`, `COVERAGE_PERCENT`,
     `COVERED_BRANCHES`, `TOTAL_BRANCHES`, and `BRANCH_PERCENT`.
     Pass an optional output filename as the first argument
     (defaults to `summary.md`).
-22. Install the GitHub CLI from <https://cli.github.com/> if you plan to run
+23. Install the GitHub CLI from <https://cli.github.com/> if you plan to run
     scripts that use `gh` locally.
 
 The compose files define common service settings using YAML anchors. Each

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,3 +10,4 @@ language-tool-python==2.9.4  # LTS as of 2025-06
 pip-audit==2.9.0  # LTS as of 2025-06
 mypy==1.16.1  # LTS as of 2025-06
 bandit==1.8.6  # LTS as of 2025-06
+shellcheck-py==0.10.0.1


### PR DESCRIPTION
## Summary
- run `shellcheck` in CI before other shell scripts
- include `shellcheck-py` in dev requirements
- lint shell scripts in pre-commit
- document shell script linting requirement

## Testing
- `pytest -q`
- `pre-commit run --files .github/workflows/ci.yml .pre-commit-config.yaml docs/README.md docs/QA_CHECKLIST.md requirements-dev.txt` *(fails: pathspec 'v3.6.2' did not match any file)*

------
https://chatgpt.com/codex/tasks/task_e_687809ae0d948320832d98f6512e345c