### PR TITLE
Update CI env var docs for orchestration bot keys

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -815,3 +815,4 @@ All notable changes to this project will be recorded in this file.
 - `scripts/run_tests.sh` validates dependencies with `pip check` after installing dev requirements and again after installing the project.
 - Replaced custom GitHub CLI script with the `ksivamuthu/actions-setup-gh-cli` action and updated documentation.
 - Added known error learning loop and review workflow.
+- Documented `DEV_ORCHESTRATION_BOT_KEY`, `STAGING_ORCHESTRATION_BOT_KEY`, and `PROD_ORCHESTRATION_BOT_KEY` in `docs/ci-env-vars.md`.

--- a/docs/ci-env-vars.md
+++ b/docs/ci-env-vars.md
@@ -15,6 +15,9 @@ values when running CI jobs locally or configuring new workflows.
 | `NPM_TOKEN` | GitHub Actions secret | `publish` (npm) | Authenticate `npm
   publish` when releasing packages | Not currently used but reserved for future
   publishing steps |
+| `DEV_ORCHESTRATION_BOT_KEY` | GitHub Actions secret | n/a | Secret token for the dev orchestrator workflow | Passed as `ORCHESTRATION_KEY` |
+| `STAGING_ORCHESTRATION_BOT_KEY` | GitHub Actions secret | n/a | Secret token for the staging orchestrator workflow | Passed as `ORCHESTRATION_KEY` |
+| `PROD_ORCHESTRATION_BOT_KEY` | GitHub Actions secret | n/a | Secret token for the production orchestrator workflow | Passed as `ORCHESTRATION_KEY` |
 | `VALE_VERSION` | Workflow `env` block or local environment | n/a | Choose the
   Vale linter version for docs checks | Defaults to `3.12.0` |
 | `TRIVY_VERSION` | Workflow `env` block | n/a | Selects the Trivy version for


### PR DESCRIPTION
## Summary
- document orchestration bot keys in `docs/ci-env-vars.md`
- note the additions in `docs/CHANGELOG.md`

## Testing
- `bash scripts/check_docs.sh`
- `bash scripts/run_tests.sh` *(fails: E501 line too long)*

------
https://chatgpt.com/codex/tasks/task_e_68780e0d1f3c832080c3b65354020a28