### PR TITLE
Update CI failure issue tracking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -430,33 +430,28 @@ jobs:
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             - name: Create or update CI failure issue
-              if: always()
+              if: always() && github.event_name == 'pull_request'
               id: ci_failure
               run: |
                   set -euo pipefail
-                  printf '\n' >> summary.md
+                  printf '\n<!-- sha: %s -->\n' "$GITHUB_SHA" >> summary.md
                   cat audit.md >> summary.md
                   gh_bin=$(which gh)
                   "$gh_bin" auth status 2>&1 | tee -a gh_cli.log
                   ISSUE_FILE=ci_failure_issue.txt
+                  ISSUE_TITLE="CI Failure: PR #${{ github.event.pull_request.number }}"
                   if [ -f "$ISSUE_FILE" ]; then
                       ISSUE=$(cat "$ISSUE_FILE")
                       echo "Using saved issue number $ISSUE" | tee -a gh_cli.log
                       "$gh_bin" issue comment "$ISSUE" --body-file summary.md 2>&1 | tee -a gh_cli.log
                   else
-                      search_query="label:ci-failure ${{ github.sha }} in:title,body"
-                      echo "Searching with: $search_query" | tee -a gh_cli.log
-                      set +e
-                      search_output=$($gh_bin issue list --state open --search "$search_query" 2>&1 | tee -a gh_cli.log)
-                      list_exit=${PIPESTATUS[0]}
-                      set -e
+                      echo "Searching for existing issue" | tee -a gh_cli.log
+                      search_output=$($gh_bin issue list --label ci-failure --state open --search "$ISSUE_TITLE" 2>&1 | tee -a gh_cli.log)
                       ISSUE=$(echo "$search_output" | awk 'NR==1 {print $1}')
-                      echo "Search exit code: $list_exit" | tee -a gh_cli.log
-                      if [ "$list_exit" -eq 0 ] && [ -n "$ISSUE" ]; then
+                      if [ -n "$ISSUE" ]; then
                           "$gh_bin" issue comment "$ISSUE" --body-file summary.md 2>&1 | tee -a gh_cli.log
                       else
-                          echo "::warning::Issue search failed or returned no results" | tee -a gh_cli.log
-                          ISSUE_URL=$($gh_bin issue create --title "CI Failures for ${{ github.sha }}" --body-file summary.md --label ci-failure | tee -a gh_cli.log)
+                          ISSUE_URL=$($gh_bin issue create --title "$ISSUE_TITLE" --body-file summary.md --label ci-failure | tee -a gh_cli.log)
                           ISSUE=$(echo "$ISSUE_URL" | grep -oE '[0-9]+$')
                       fi
                   fi
@@ -464,10 +459,10 @@ jobs:
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             - name: Save CI failure issue number
-              if: failure()
+              if: failure() && github.event_name == 'pull_request'
               run: echo "${{ steps.ci_failure.outputs.issue-number }}" > ci_failure_issue.txt
             - name: Upload CI failure issue number
-              if: failure()
+              if: failure() && github.event_name == 'pull_request'
               uses: actions/upload-artifact@v4
               with:
                   name: ci-failure-issue

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be recorded in this file.
 
 - fix(ci): correct YAML indentation in Verify gh version step
 - chore(ci): reuse saved ci-failure issue number across runs
+- chore(ci): track CI failure issues by PR number and store the commit SHA in the issue body
 - chore(ci): validate `.codex/bot-permissions.yaml` via new script
 - chore(ci): add permissions validation workflow
 - chore(scripts): parse retrospective actions via new Python utility

--- a/docs/README.md
+++ b/docs/README.md
@@ -257,8 +257,9 @@ See [doc-quality-onboarding.md](doc-quality-onboarding.md) for a step-by-step gu
 3. Use the pull request template and ensure the checklist passes.
 4. Review [sample-pr.md](sample-pr.md) for an end-to-end example.
 5. See the Codex CI Monitoring Policy in [../AGENTS.md](../AGENTS.md) for how failed CI jobs automatically create tasks.
-6. When CI fails, an issue titled `CI Failures for <sha>` is opened or updated
-   with a summary of the failing tests and links to the artifacts.
+6. When CI fails on a pull request, an issue titled `CI Failure: PR #<number>`
+   is opened or updated with a summary of the failing tests. The commit SHA is
+   stored in the issue body as a comment for reference.
 7. The CI workflow uses the built-in `GITHUB_TOKEN` with `issues: write`
    permission. When the pipeline succeeds, it closes every open `ci-failure`
    issue.

--- a/docs/ci-failure-issues.md
+++ b/docs/ci-failure-issues.md
@@ -1,14 +1,12 @@
 # Managing CI Failure Issues
 
-When the CI workflow fails, it opens or updates an issue titled `CI Failures for
-<sha>` with a summary of the failing tests. The workflow closes all open
-`ci-failure` issues once any CI run succeeds.
+When the CI workflow fails, it opens or updates an issue titled `CI Failure: PR #<number>` with a summary of the failing tests. The commit SHA is stored as an HTML comment in the issue body for reference. The workflow closes all open `ci-failure` issues once any CI run succeeds.
 
 ## Automatic Cleanup
 
 - `ci.yml` closes every open `ci-failure` issue whenever the pipeline succeeds using the built-in `GITHUB_TOKEN`.
 - The workflow uploads a `ci-logs` artifact with the full job log for download after each run.
-- The issue number is saved as a `ci-failure-issue` artifact so later runs update the same issue.
+- The issue number is saved to `ci_failure_issue.txt` and uploaded as a `ci-failure-issue` artifact so later runs update the same issue.
 
 ## Forked Pull Requests
 

--- a/scripts/download_ci_failure_issue.sh
+++ b/scripts/download_ci_failure_issue.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # Download ci-failure issue number from the previous CI run if available
+# The artifact now stores the issue number in ci_failure_issue.txt
 set -euo pipefail
 
 if ! command -v gh >/dev/null 2>&1; then
@@ -13,4 +14,7 @@ run_id=$(gh run list -w CI --json databaseId,headSha -L 10 \
 if [ -n "${run_id:-}" ]; then
     echo "Downloading ci-failure-issue artifact from run $run_id" >&2
     gh run download "$run_id" --name ci-failure-issue --dir . || true
+    if [ -f ci-failure-issue.txt ]; then
+        mv ci-failure-issue.txt ci_failure_issue.txt
+    fi
 fi

--- a/tests/test_process_notifications.py
+++ b/tests/test_process_notifications.py
@@ -27,7 +27,14 @@ def test_process_notifications_adds_comment(tmp_path, monkeypatch):
 
     def fake_run(cmd, capture_output=False, text=False, check=True):
         if "list" in cmd:
-            return subprocess.CompletedProcess(cmd, 0, stdout=json.dumps([{"number": 42, "title": "Operations Notifications"}]), stderr="")
+            return subprocess.CompletedProcess(
+                cmd,
+                0,
+                stdout=json.dumps([
+                    {"number": 42, "title": "Operations Notifications"}
+                ]),
+                stderr="",
+            )
         if "comment" in cmd:
             calls.append(cmd)
             return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")

--- a/tests/test_sync_issue_to_kekb.py
+++ b/tests/test_sync_issue_to_kekb.py
@@ -22,7 +22,13 @@ def test_append_closed_issue(tmp_path, monkeypatch):
         return subprocess.CompletedProcess(
             cmd,
             0,
-            stdout=json.dumps({"title": "Fix bug", "body": "details", "state": "closed"}),
+            stdout=json.dumps(
+                {
+                    "title": "Fix bug",
+                    "body": "details",
+                    "state": "closed",
+                }
+            ),
             stderr="",
         )
 


### PR DESCRIPTION
## Summary
- save CI failure issues per PR number
- note new tracking in docs and changelog
- fix linting errors in tests

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_687867c9c5ac8320b083339f43d73020