### PR TITLE
Add CI Bot agent spec

### DIFF
--- a/agents/ci-bot.md
+++ b/agents/ci-bot.md
@@ -1,0 +1,28 @@
+---
+codex-agent:
+  name: Agent.CIBot
+  role: Manages CI failure issues
+  scope: CI workflows
+  triggers: Failed CI runs and nightly cleanup
+  output: Open or closed ci-failure issues
+---
+
+# CI Bot
+
+**Status:** Active.
+
+**Purpose:** Automatically open, update, and close issues labeled `ci-failure` when CI jobs fail or succeed.
+
+**Inputs:** Completed CI workflow runs and scheduled cleanup tasks.
+
+**Outputs:** GitHub issues summarizing failing steps or confirmation that prior issues were closed.
+
+**Environment:** Uses `${{ secrets.CI_BOT_TOKEN }}` for authentication.
+
+**Permissions:** Requires `issues: write` to manage failure issues.
+
+**Workflow:** The workflow calls the bot after each run. It uses the token to create or update the failure issue. When builds succeed, the bot closes any open issues. A nightly cleanup job ensures stale issues are removed.
+
+**Escalation:** If issue automation fails repeatedly, notify maintainers via `.github/workflows/notify.yml` to review logs and rotate the token.
+
+**Notification:** Route alerts through `.github/workflows/notify.yml`.

--- a/agents/index.md
+++ b/agents/index.md
@@ -16,6 +16,7 @@ how it fits into the workflow.
 - [Staging Orchestrator](staging-orchestrator.md)
 - [Onboarding Agent](onboarding-agent.md)
 - [CI Helper Agent](ci-helper-agent.md)
+- [CI Bot](ci-bot.md)
 - [Diagnostics Bot](diagnostics-bot.md)
 
 Use the [template](templates/agent-spec-template.md) when documenting a new agent.

--- a/codex/agents/index.json
+++ b/codex/agents/index.json
@@ -134,6 +134,13 @@
       "output": "Diagnostic notes"
     },
     {
+      "name": "Agent.CIBot",
+      "role": "Manages CI failure issues",
+      "path": "agents/ci-bot.md",
+      "triggers": "Failed CI runs and nightly cleanup",
+      "output": "CI failure issues"
+    },
+    {
       "name": "Agent.DiagnosticsBot",
       "role": "Collects environment diagnostics and system health info",
       "path": "agents/diagnostics-bot.md",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -817,3 +817,4 @@ All notable changes to this project will be recorded in this file.
 - Replaced custom GitHub CLI script with the `ksivamuthu/actions-setup-gh-cli` action and updated documentation.
 - Added known error learning loop and review workflow.
 - Documented `DEV_ORCHESTRATION_BOT_KEY`, `STAGING_ORCHESTRATION_BOT_KEY`, and `PROD_ORCHESTRATION_BOT_KEY` in `docs/ci-env-vars.md`.
+- Added CI Bot agent documentation and updated agent index.


### PR DESCRIPTION
## Summary
- document CI Bot agent for handling CI failure issues
- list the new agent in the docs
- update Codex agent index

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_687914434174832091c21fa846b00b02