### PR TITLE
Update CI workflows for CI Bot token

### DIFF
--- a/.github/workflows/ci-health.yml
+++ b/.github/workflows/ci-health.yml
@@ -113,8 +113,9 @@ jobs:
       - name: Create issue for failures
         if: steps.summarize.outputs.failures != ''
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.CI_BOT_TOKEN || secrets.GITHUB_TOKEN }}
           FAILED: ${{ steps.summarize.outputs.failures }}
+          CI_BOT_USERNAME: ${{ vars.CI_BOT_USERNAME }}
         run: |
           echo "CI checks failed for the following branches:" > body.md
           for b in $FAILED; do

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -376,12 +376,12 @@ jobs:
                   gh_bin=$(which gh)
                   "$gh_bin" pr comment ${{ github.event.pull_request.number }} --body-file coverage-summary.md
               env:
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GH_TOKEN: ${{ secrets.CI_BOT_TOKEN || secrets.GITHUB_TOKEN }}
             - name: Update coverage badge
               run: python scripts/update_coverage_badge.py coverage-summary.md coverage.svg
             - name: Commit coverage badge
               env:
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GH_TOKEN: ${{ secrets.CI_BOT_TOKEN || secrets.GITHUB_TOKEN }}
               run: |
                   git config user.name "${{ github.actor }}"
                   git config user.email "${{ github.actor }}@users.noreply.github.com"
@@ -417,7 +417,7 @@ jobs:
                   gh_bin=$(which gh)
                   "$gh_bin" pr edit ${{ github.event.pull_request.number }} --add-label "🚧 Codex"
               env:
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GH_TOKEN: ${{ secrets.CI_BOT_TOKEN || secrets.GITHUB_TOKEN }}
             - name: Summarize CI failures
               if: always()
               run: python scripts/summarize_ci_failures.py
@@ -428,7 +428,7 @@ jobs:
               if: always()
               run: bash scripts/download_ci_failure_issue.sh
               env:
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GH_TOKEN: ${{ secrets.CI_BOT_TOKEN || secrets.GITHUB_TOKEN }}
             - name: Create or update CI failure issue
               if: always() && github.event_name == 'pull_request'
               id: ci_failure
@@ -451,13 +451,14 @@ jobs:
                       if [ -n "$ISSUE" ]; then
                           "$gh_bin" issue comment "$ISSUE" --body-file summary.md 2>&1 | tee -a gh_cli.log
                       else
-                          ISSUE_URL=$($gh_bin issue create --title "$ISSUE_TITLE" --body-file summary.md --label ci-failure | tee -a gh_cli.log)
+                          ISSUE_URL=$($gh_bin issue create --title "$ISSUE_TITLE" --body-file summary.md --label ci-failure --assignee "$CI_BOT_USERNAME" | tee -a gh_cli.log)
                           ISSUE=$(echo "$ISSUE_URL" | grep -oE '[0-9]+$')
                       fi
                   fi
                   echo "issue-number=$ISSUE" >> "$GITHUB_OUTPUT"
               env:
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GH_TOKEN: ${{ secrets.CI_BOT_TOKEN || secrets.GITHUB_TOKEN }}
+                  CI_BOT_USERNAME: ${{ vars.CI_BOT_USERNAME }}
             - name: Save CI failure issue number
               if: failure() && github.event_name == 'pull_request'
               run: echo "${{ steps.ci_failure.outputs.issue-number }}" > ci_failure_issue.txt
@@ -478,7 +479,7 @@ jobs:
                     "$gh_bin" issue close "$ISSUE" 2>&1 | tee -a gh_cli.log
                   done
               env:
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GH_TOKEN: ${{ secrets.CI_BOT_TOKEN || secrets.GITHUB_TOKEN }}
             - name: Upload CI logs
               if: always()
               uses: actions/upload-artifact@v4

--- a/.github/workflows/cleanup-ci-failure.yml
+++ b/.github/workflows/cleanup-ci-failure.yml
@@ -56,7 +56,7 @@ jobs:
                 gh api rate_limit
                 gh issue list --label ci-failure --state open | awk '{print $1}'
               env:
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GH_TOKEN: ${{ secrets.CI_BOT_TOKEN || secrets.GITHUB_TOKEN }}
               continue-on-error: true
 
             - name: Close ci-failure issues
@@ -81,4 +81,4 @@ jobs:
                 fi
                 echo "Closed $closed ci-failure issues"
               env:
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GH_TOKEN: ${{ secrets.CI_BOT_TOKEN || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- use `CI_BOT_TOKEN` with fallback to `GITHUB_TOKEN`
- assign CI failure issues to CI bot

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_687917fa4e6c8320bc6f33b00c2da296