### PR TITLE
Add EnvVar Manager docs

### DIFF
--- a/.codex/automation-tasks.md
+++ b/.codex/automation-tasks.md
@@ -67,3 +67,11 @@ This document outlines the automation checks Codex uses to keep the CI workflow 
 - Documentation for each agent lives under `/agents` and begins with a `codex-agent` YAML header.
 - Every agent must be listed in `codex/agents/index.json` and permissions are defined in `.codex/bot-permissions.yaml`.
 - CI regenerates environment variable tables with `scripts/regenerate_env_docs.py` and validates them with `scripts/check_env_docs.py`.
+
+## EnvVar Manager Integration
+
+- EnvVar Manager agent audits all ENVARS used in code, workflows, and agent docs.
+- Ensures .env.example files are present and correct in each project directory.
+- Notifies through `.github/workflows/notify.yml`.
+- Escalates via GitHub Issue if misalignment persists >24h.
+- Follows agent doc at agents/envvar-manager.md.

--- a/.codex/bot-permissions.yaml
+++ b/.codex/bot-permissions.yaml
@@ -28,3 +28,10 @@ orchestration_bot:
     - workflows: write
     - deployments: read
     - repository: read
+envvar_manager:
+  secret: ENVVAR_MANAGER_TOKEN
+  permissions:
+    - contents: read
+    - contents: write
+    - issues: write
+    - pull_requests: write

--- a/.github/ISSUE_TEMPLATE/envvar-misalignment.md
+++ b/.github/ISSUE_TEMPLATE/envvar-misalignment.md
@@ -1,0 +1,13 @@
+name: EnvVar Misalignment
+about: Report missing or extra environment variables
+title: "[EnvVar]"
+labels: ["ops"]
+---
+
+## Missing variables
+<!-- List required variables that are absent -->
+
+## Extra variables
+<!-- List variables present but not documented -->
+
+- [ ] Reviewed `agents/index.md` and all `.env.example` files

--- a/agents/envvar-manager.md
+++ b/agents/envvar-manager.md
@@ -1,0 +1,39 @@
+---
+codex-agent:
+  name: Agent.EnvVarManager
+  role: Audits and synchronizes environment variables across projects
+  scope: repo-wide
+  triggers: Workflow runs, scheduled checks, or manual dispatch
+  output: Updated `.env.example` files or issues for misaligned variables
+---
+
+# EnvVar Manager Agent
+
+**Status:** Proposed.
+
+**Purpose:**  
+Ensure every project directory maintains an up-to-date `.env.example` file that reflects the variables referenced in code, workflow YAMLs, and agent documentation. The agent scans for variable usage, compares it to existing `.env.example` files, and reports discrepancies.
+
+**Inputs:**  
+- Source code and workflow YAML files  
+- Existing `.env.example` files  
+- `agents/index.md` for the authoritative variable list
+
+**Outputs:**  
+- Updated `.env.example` files for each project directory  
+- GitHub issues summarizing missing or redundant variables
+
+**Environment:**  
+Requires read access to the repository and write/PR permissions to update example files or open issues.
+
+**Workflow:**  
+1. Parse environment variable references in code and workflows.  
+2. Map each variable to the directories that use it.  
+3. Update or generate `.env.example` files so that each directory reflects the variables it requires.  
+4. Open a PR (or issue) when variables are missing, unused, or duplicated.
+
+**Notification:**  
+Route alerts through `.github/workflows/notify.yml`.
+
+**Escalation:**  
+If environment misalignment persists longer than 24 hours, notify the DevOps lead.

--- a/agents/index.md
+++ b/agents/index.md
@@ -18,6 +18,7 @@ how it fits into the workflow.
 - [CI Helper Agent](ci-helper-agent.md)
 - [CI Bot](ci-bot.md)
 - [Diagnostics Bot](diagnostics-bot.md)
+- [EnvVar Manager](envvar-manager.md)
 
 Use the [template](templates/agent-spec-template.md) when documenting a new agent.
 ## Required Environment Variables

--- a/codex/agents/index.json
+++ b/codex/agents/index.json
@@ -146,6 +146,13 @@
       "path": "agents/diagnostics-bot.md",
       "triggers": "Invocation of `python -m diagnostics`",
       "output": "System check report"
+    },
+    {
+      "name": "Agent.EnvVarManager",
+      "role": "Audits and synchronizes environment variables across projects",
+      "path": "agents/envvar-manager.md",
+      "triggers": "Workflow runs, scheduled checks, or manual dispatch",
+      "output": "Updated `.env.example` files or issues for misaligned variables"
     }
   ]
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be recorded in this file.
 - docs(retros): document `scripts/create-retro-file.sh` usage for new retrospectives
 
 - docs(env): document `CI_BOT_TOKEN` variable
+- docs(agents): add EnvVar Manager agent and issue template
 
 - fix(ci): correct YAML indentation in Verify gh version step
 - chore(ci): reuse saved ci-failure issue number across runs


### PR DESCRIPTION
## Summary
- document new EnvVar Manager agent
- register agent in index docs and JSON
- authorize new bot in `.codex/bot-permissions.yaml`
- add envvar misalignment issue template
- document the automation in `.codex/automation-tasks.md`
- note the addition in `CHANGELOG`

## Testing
- `pre-commit` *(fails: could not fetch Prettier tag)*
- `pytest -q` *(fails: missing dependencies such as httpx, sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_68793cd3a2d483208b6b644931d697a0