### PR TITLE
docs(env): align .env.example with undocumented variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,10 +63,26 @@ TEAMS_CHANNEL_ID_ONBOARD=
 # Llama2 Agile Helper
 LLAMA2_API_KEY=
 LLAMA2_API_TIMEOUT=10
+LLAMA2_URL=https://api.llama2.ai/generate
 
 # Orchestration bot keys
 DEV_ORCHESTRATION_BOT_KEY=
 STAGING_ORCHESTRATION_BOT_KEY=
 PROD_ORCHESTRATION_BOT_KEY=
 CI_BOT_TOKEN=
+
+# Orchestration
+# Base URL for orchestration service
+ORCHESTRATOR_URL=https://orchestrator.example.com
+# Bearer token used by orchestration scripts
+ORCHESTRATION_KEY=
+
+# Diagnostics
+# Skip coverage badge generation when offline
+OFFLINE_BADGE=
+# Path for JSON env audit results
+JSON_OUTPUT=
+
+# OpenAI integration for Codex
+OPENAI_API_KEY=
 

--- a/agents/index.md
+++ b/agents/index.md
@@ -50,11 +50,17 @@ The table below lists environment variables used across DevOnboarder agents. Kee
 | IS_FOUNDER                    | Enable founder-only routes |
 | JWT_ALGORITHM                 | Algorithm for JWT signing (default `HS256`) |
 | JWT_SECRET_KEY                | Secret key for JWT signing (required; service errors if empty or "secret" outside `development`) |
+| JSON_OUTPUT                   | Path to write audit_env_vars JSON summary |
 | LLAMA2_API_KEY                | API key for accessing the Llama2 service |
 | LLAMA2_API_TIMEOUT            | HTTP timeout in seconds for Llama2 API calls |
+| LLAMA2_URL                    | Base URL for the Llama2 API |
 | MILITARY_ROLE_ID              | Role for military members |
 | MODERATOR_ROLE_ID             | Discord role for moderators |
 | OWNER_ROLE_ID                 | Discord role for system owner |
+| OFFLINE_BADGE                  | Set to `1` to skip coverage badge generation |
+| OPENAI_API_KEY                 | Token for OpenAI requests |
+| ORCHESTRATION_KEY              | Secret used by orchestration scripts |
+| ORCHESTRATOR_URL               | Base URL for orchestration service |
 | PROD_ORCHESTRATION_BOT_KEY    | Secret token for production orchestrator |
 | STAGING_ORCHESTRATION_BOT_KEY | Secret token for staging orchestrator |
 | CI_BOT_TOKEN                  | GitHub token used by the CI bot |

--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -22,6 +22,8 @@ before workflows run.
 The orchestration scripts reference an `ORCHESTRATOR_URL` environment variable.
 Workflows set this variable when invoking the scripts. If not provided, the
 scripts default to `https://orchestrator.example.com`.
+The workflows also supply an `ORCHESTRATION_KEY` secret token used for
+authentication.
 
 ## API Key Management
 


### PR DESCRIPTION
## Summary
- document additional environment variables in `.env.example`
- sync env var table in `agents/index.md`
- clarify orchestration docs about `ORCHESTRATION_KEY`

## Testing
- `python scripts/check_env_docs.py`

------
https://chatgpt.com/codex/tasks/task_e_68795cac79208320a05d91dfb1235ebd