### PR TITLE
Add optional LanguageTool URL env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -89,6 +89,9 @@ OFFLINE_BADGE=
 # Path for JSON env audit results
 JSON_OUTPUT=
 
+# Optional: set this when running your own LanguageTool server
+LANGUAGETOOL_URL=
+
 # OpenAI integration for Codex
 OPENAI_API_KEY=
 

--- a/agents/index.md
+++ b/agents/index.md
@@ -55,6 +55,7 @@ The table below lists environment variables used across DevOnboarder agents. Kee
 | JSON_OUTPUT                   | Path to write audit_env_vars JSON summary |
 | JWT_ALGORITHM                 | Algorithm for JWT signing (default `HS256`) |
 | JWT_SECRET_KEY                | Secret key for JWT signing (required; service errors if empty or "secret" outside `development`) |
+| LANGUAGETOOL_URL              | Base URL for a local LanguageTool server (optional) |
 | LLAMA2_API_KEY                | API key for accessing the Llama2 service |
 | LLAMA2_API_TIMEOUT            | HTTP timeout in seconds for Llama2 API calls |
 | LLAMA2_URL                    | Base URL for the Llama2 API |

--- a/docs/README.md
+++ b/docs/README.md
@@ -74,7 +74,7 @@ check in CI. See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
     docker run -d --name languagetool -p 8010:8010 silviof/docker-languagetool
     ```
 
-    Then set `LANGUAGETOOL_URL=http://localhost:8010/v2`.
+    Then optionally set `LANGUAGETOOL_URL=http://localhost:8010/v2`.
 
 19. Lint shell scripts with `shellcheck scripts/*.sh`.
 
@@ -245,8 +245,8 @@ See [doc-quality-onboarding.md](doc-quality-onboarding.md) for a step-by-step gu
 - If the binary lives outside `PATH`, set the `VALE_BINARY` environment variable
   to its location so `scripts/check_docs.sh` can find it.
 - Install Python dev dependencies with `pip install -r requirements-dev.txt`.
-- Set `LANGUAGETOOL_URL` when running your own LanguageTool server if you want
-  local grammar checks. See the [LanguageTool HTTP server guide](https://dev.languagetool.org/http-server).
+- Optionally set `LANGUAGETOOL_URL` when running your own LanguageTool server
+  for local grammar checks. See the [LanguageTool HTTP server guide](https://dev.languagetool.org/http-server).
 - Markdown files must not exceed 120 characters per line (MD013). See
   [doc-quality-onboarding.md](doc-quality-onboarding.md) for details.
 

--- a/docs/doc-quality-onboarding.md
+++ b/docs/doc-quality-onboarding.md
@@ -66,6 +66,8 @@ docker run -d -p 8010:8010 --name languagetool \
 export LANGUAGETOOL_URL="http://localhost:8010"
 ```
 
+Set this variable if you run a local server; otherwise the public API is used.
+
 You can also download a LanguageTool release from <https://languagetool.org/download/> and run it with Java:
 
 ```bash
@@ -168,8 +170,8 @@ and commit the change with your documentation update.
 * **Vale not found:** install it as shown above or download the binary manually and set `VALE_BINARY` to its path.
 * **Python errors:** ensure `pip install -e .` (or `pip install -r requirements.txt`)
   and `pip install -r requirements-dev.txt` succeeded.
-* **LanguageTool API issues:** run a local server and set `LANGUAGETOOL_URL` to
-  its address if you want to run grammar checks.
+* **LanguageTool API issues:** run a local server and optionally set
+  `LANGUAGETOOL_URL` to its address for grammar checks.
 * **pytest fails:** double-check that all dev dependencies and the project itself are installed.
 
 ### Known Limitations


### PR DESCRIPTION
## Summary
- document optional `LANGUAGETOOL_URL` for local instances
- list `LANGUAGETOOL_URL` in agent env var table
- note optional LanguageTool setup in docs

## Testing
- `python scripts/check_env_docs.py`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6879bbe80fc88320a94f43e892e919b6