### PR TITLE
Add bot listing utility

### DIFF
--- a/.codex/automation-tasks.md
+++ b/.codex/automation-tasks.md
@@ -68,6 +68,11 @@ This document outlines the automation checks Codex uses to keep the CI workflow 
 - Every agent must be listed in `codex/agents/index.json` and permissions are defined in `.codex/bot-permissions.yaml`.
 - CI regenerates environment variable tables with `scripts/regenerate_env_docs.py` and validates them with `scripts/check_env_docs.py`.
 
+## 13. Bot Inventory
+
+- Run `python scripts/list-bots.py` to list all bots found in `.github/workflows` and `codex/agents/index.json`.
+- The script reports any agents missing from `.codex/bot-permissions.yaml`.
+
 ## EnvVar Manager Integration
 
 - EnvVar Manager agent audits all ENVARS used in code, workflows, and agent docs.

--- a/scripts/list-bots.py
+++ b/scripts/list-bots.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""List codex agents defined in workflows and index entries."""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Optional
+
+import yaml
+
+
+def to_snake(name: str) -> str:
+    """Convert CamelCase to snake_case."""
+    s = re.sub(r"(.)([A-Z][a-z]+)", r"\1_\2", name)
+    s = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", s)
+    return s.lower()
+
+
+def parse_header(path: Path) -> Optional[str]:
+    """Return the codex-agent name from ``path`` if present."""
+    try:
+        with path.open() as fh:
+            lines: list[str] = []
+            reading = False
+            for _ in range(20):
+                line = fh.readline()
+                if not line:
+                    break
+                if re.match(r"#?\s*---", line):
+                    if not reading:
+                        reading = True
+                        continue
+                    else:
+                        break
+                if reading:
+                    cleaned = re.sub(r"^#\s?", "", line.rstrip("\n"))
+                    lines.append(cleaned)
+            if not lines:
+                return None
+            data = yaml.safe_load("\n".join(lines)) or {}
+            agent = data.get("codex-agent", {})
+            if isinstance(agent, dict):
+                return agent.get("name")
+    except Exception:
+        return None
+    return None
+
+
+def scan_workflows() -> dict[str, str]:
+    bots: dict[str, str] = {}
+    for path in Path(".github/workflows").glob("*.yml"):
+        name = parse_header(path)
+        if name:
+            bots[name] = str(path)
+    return bots
+
+
+def scan_index() -> dict[str, str]:
+    bots: dict[str, str] = {}
+    index_path = Path("codex/agents/index.json")
+    if not index_path.exists():
+        return bots
+    data = json.loads(index_path.read_text())
+    for agent in data.get("agents", []):
+        f = Path(agent.get("path", ""))
+        if not f.exists():
+            continue
+        name = parse_header(f)
+        if name:
+            bots.setdefault(name, str(f))
+    return bots
+
+
+def load_permissions() -> set[str]:
+    file = Path(".codex/bot-permissions.yaml")
+    if not file.exists():
+        return set()
+    data = yaml.safe_load(file.read_text()) or {}
+    return set(data.keys())
+
+
+def main() -> None:
+    bots = scan_workflows()
+    bots.update(scan_index())
+    permissions = load_permissions()
+    summary = []
+    missing = []
+    for name, path in sorted(bots.items()):
+        key = to_snake(name.split(".")[-1])
+        has_perm = key in permissions
+        summary.append({"name": name, "file": path, "permissions": has_perm})
+        if not has_perm:
+            missing.append(name)
+    json.dump({"bots": summary, "missing_permissions": missing}, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `scripts/list-bots.py` to scan codex-agent headers
- document bot inventory task in `.codex/automation-tasks.md`

## Testing
- `ruff check scripts/list-bots.py`
- `python scripts/list-bots.py`
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6879c6ff87c483209de5be279dedfda3