### PR TITLE
Update bot permission matrix

### DIFF
--- a/.codex/bot-permissions.yaml
+++ b/.codex/bot-permissions.yaml
@@ -35,3 +35,42 @@ envvar_manager:
     - contents: write
     - issues: write
     - pull_requests: write
+ci_bot:
+  secret: CI_BOT_TOKEN
+  permissions:
+    - issues: write
+
+ci_monitor:
+  secret: CI_ISSUE_TOKEN
+  permissions:
+    - issues: write
+
+auto_fix:
+  secret: OPENAI_API_KEY
+  permissions:
+    - contents: write
+    - pull_requests: write
+
+llama2_agile_helper:
+  secret: LLAMA2_API_KEY
+  permissions:
+    - contents: read
+
+ms_teams_integration:
+  secret: TEAMS_APP_PASSWORD
+  permissions: []
+
+dev_orchestrator:
+  secret: DEV_ORCHESTRATION_BOT_KEY
+  permissions:
+    - contents: read
+
+staging_orchestrator:
+  secret: STAGING_ORCHESTRATION_BOT_KEY
+  permissions:
+    - contents: read
+
+prod_orchestrator:
+  secret: PROD_ORCHESTRATION_BOT_KEY
+  permissions:
+    - contents: read

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be recorded in this file.
 - docs(env): document `CI_BOT_USERNAME` variable
 - docs(agents): add EnvVar Manager agent and issue template
 - docs(env): document CI-provided variables in `.env.example`
+- chore(security): add missing bots to `.codex/bot-permissions.yaml` and cross-link governance
 
 - fix(ci): correct YAML indentation in Verify gh version step
 - chore(ci): reuse saved ci-failure issue number across runs

--- a/docs/governance/bot_access_governance.md
+++ b/docs/governance/bot_access_governance.md
@@ -80,6 +80,7 @@
 | - [ ] Add human approval gates and permission review tasks to the project
   management backlog as recurring items. | Project Management Team |
 | - [ ] Link to relevant GitHub/Discord best practices and security docs. | Documentation Team |
+| - [ ] Keep the full matrix of bot secrets and permissions in `.codex/bot-permissions.yaml`. | Documentation Team |
 
 ---
 


### PR DESCRIPTION
## Summary
- record new bots and tokens in `.codex/bot-permissions.yaml`
- reference the bot permission matrix from governance docs
- note updated matrix in the changelog

## Testing
- `bash scripts/run_tests.sh`
- `bash scripts/validate-bot-permissions.sh`


------
https://chatgpt.com/codex/tasks/task_e_6879c9c677848320bfd476003d656ced