### PR TITLE
Document bot secrets in CI env vars

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -828,3 +828,4 @@ All notable changes to this project will be recorded in this file.
 - Added CI Bot agent documentation and updated agent index.
 - Added CI Bot metadata to codex agent index.
 - Introduced the CI Bot and updated workflows to route automation through it.
+- docs(env): document `ONBOARDING_AGENT_KEY`, `CI_HELPER_AGENT_KEY`, and `ENVVAR_MANAGER_TOKEN` secrets

--- a/docs/ci-env-vars.md
+++ b/docs/ci-env-vars.md
@@ -5,32 +5,22 @@ values when running CI jobs locally or configuring new workflows.
 
 | Variable | Where to set | Required scopes | Purpose | Notes |
 | -------- | ------------ | --------------- | ------- | ----- |
-| `GITHUB_TOKEN` | Auto-injected by GitHub | Determined by `permissions` in the
-  workflow | Authenticate API requests and push commits during CI | Provided
-  automatically; expires after each job |
-| `GH_TOKEN` | GitHub Actions secret or local environment | `issues: write`,
-  `pull_requests: write` if used for cross-repo operations | Token consumed by
-  the GitHub CLI to comment on PRs and manage issues | Usually set to `${{ secrets.GITHUB_TOKEN }}` in workflows |
-| `CI_ISSUE_TOKEN` | GitHub Actions secret | `issues: write` | Token used to open rate-limit issues in `ci-monitor.yml` | Optional; falls back to `GITHUB_TOKEN` when unset |
+| `AUTH_URL` | Workflow `env` block | n/a | Base URL for auth service during E2E tests | Set to `http://localhost:8002` in CI |
+| `CHECK_HEADERS_URL` | Workflow `env` block | n/a | Endpoint checked by `scripts/check_headers.py` | Defaults to the auth user endpoint |
 | `CI_BOT_USERNAME` | GitHub Actions variable | n/a | GitHub username used to assign CI failure issues | |
-| `NPM_TOKEN` | GitHub Actions secret | `publish` (npm) | Authenticate `npm
-  publish` when releasing packages | Not currently used but reserved for future
-  publishing steps |
+| `CI_HELPER_AGENT_KEY` | GitHub Actions secret | n/a | Secret token for the CI Helper Agent | Used by `review-known-errors.yml` |
+| `CI_ISSUE_TOKEN` | GitHub Actions secret | `issues: write` | Token used to open rate-limit issues in `ci-monitor.yml` | Optional; falls back to `GITHUB_TOKEN` when unset |
 | `DEV_ORCHESTRATION_BOT_KEY` | GitHub Actions secret | n/a | Secret token for the dev orchestrator workflow | Passed as `ORCHESTRATION_KEY` |
-| `STAGING_ORCHESTRATION_BOT_KEY` | GitHub Actions secret | n/a | Secret token for the staging orchestrator workflow | Passed as `ORCHESTRATION_KEY` |
+| `ENVVAR_MANAGER_TOKEN` | GitHub Actions secret | n/a | Token for the EnvVar Manager to open misalignment issues | Used by `secrets-alignment.yml` |
+| `GH_TOKEN` | GitHub Actions secret or local environment | `issues: write`, `pull_requests: write` if used for cross-repo operations | Token consumed by the GitHub CLI to comment on PRs and manage issues | Usually set to `${{ secrets.GITHUB_TOKEN }}` in workflows |
+| `GITHUB_REPOSITORY` | Auto-injected by GitHub | n/a | `owner/repo` string identifying the project | Used by `post_coverage_comment.py` |
+| `GITHUB_RUN_ID` | Auto-injected by GitHub | n/a | Unique ID for the workflow run | Used when generating coverage links |
+| `GITHUB_SERVER_URL` | Auto-injected by GitHub | n/a | Hostname for the current GitHub instance | Used by `post_coverage_comment.py` |
+| `GITHUB_TOKEN` | Auto-injected by GitHub | Determined by `permissions` in the workflow | Authenticate API requests and push commits during CI | Provided automatically; expires after each job |
+| `NPM_TOKEN` | GitHub Actions secret | `publish` (npm) | Authenticate `npm publish` when releasing packages | Not currently used but reserved for future publishing steps |
+| `ONBOARDING_AGENT_KEY` | GitHub Actions secret | n/a | Secret token for the Onboarding Agent | Used by the onboarding-agent workflow |
 | `PROD_ORCHESTRATION_BOT_KEY` | GitHub Actions secret | n/a | Secret token for the production orchestrator workflow | Passed as `ORCHESTRATION_KEY` |
-| `VALE_VERSION` | Workflow `env` block or local environment | n/a | Choose the
-  Vale linter version for docs checks | Defaults to `3.12.0` |
-| `TRIVY_VERSION` | Workflow `env` block | n/a | Selects the Trivy version for
-  container scanning | Defaults to `0.47.0` |
-| `AUTH_URL` | Workflow `env` block | n/a | Base URL for auth service during E2E
-  tests | Set to `http://localhost:8002` in CI |
-| `CHECK_HEADERS_URL` | Workflow `env` block | n/a | Endpoint checked by
-  `scripts/check_headers.py` | Defaults to the auth user endpoint |
-| `GITHUB_SERVER_URL` | Auto-injected by GitHub | n/a | Hostname for the current
-  GitHub instance | Used by `post_coverage_comment.py` |
-| `GITHUB_REPOSITORY` | Auto-injected by GitHub | n/a | `owner/repo` string
-  identifying the project | Used by `post_coverage_comment.py` |
-| `GITHUB_RUN_ID` | Auto-injected by GitHub | n/a | Unique ID for the workflow
-  run | Used when generating coverage links |
+| `STAGING_ORCHESTRATION_BOT_KEY` | GitHub Actions secret | n/a | Secret token for the staging orchestrator workflow | Passed as `ORCHESTRATION_KEY` |
+| `TRIVY_VERSION` | Workflow `env` block | n/a | Selects the Trivy version for container scanning | Defaults to `0.47.0` |
+| `VALE_VERSION` | Workflow `env` block or local environment | n/a | Choose the Vale linter version for docs checks | Defaults to `3.12.0` |
 


### PR DESCRIPTION
## Summary
- add CI Helper, Onboarding Agent, and EnvVar Manager secrets to CI env docs
- alphabetize the env var table
- note new secrets in CHANGELOG

## Testing
- `python scripts/check_env_docs.py`
- `pre-commit run --files docs/ci-env-vars.md docs/CHANGELOG.md` *(failed: tag not found)*
- `bash scripts/validate.sh` *(failed: markdownlint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_687a6ec042548320b6ff25f78ac74a2c