### PR TITLE
Rename envvar manager docs

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be recorded in this file.
 - docs(env): document CI-provided variables in `.env.example`
 - chore(security): add missing bots to `.codex/bot-permissions.yaml` and cross-link governance
 - chore(security): record permissions for additional agents and rename env_var_manager entry
+- docs(env): rename `ENVVAR_MANAGER_TOKEN` to `ENV_VAR_MANAGER_KEY`
 
 - fix(ci): correct YAML indentation in Verify gh version step
 - chore(ci): reuse saved ci-failure issue number across runs
@@ -828,4 +829,4 @@ All notable changes to this project will be recorded in this file.
 - Added CI Bot agent documentation and updated agent index.
 - Added CI Bot metadata to codex agent index.
 - Introduced the CI Bot and updated workflows to route automation through it.
-- docs(env): document `ONBOARDING_AGENT_KEY`, `CI_HELPER_AGENT_KEY`, and `ENVVAR_MANAGER_TOKEN` secrets
+- docs(env): document `ONBOARDING_AGENT_KEY`, `CI_HELPER_AGENT_KEY`, and `ENV_VAR_MANAGER_KEY` secrets

--- a/docs/ci-env-vars.md
+++ b/docs/ci-env-vars.md
@@ -11,7 +11,7 @@ values when running CI jobs locally or configuring new workflows.
 | `CI_HELPER_AGENT_KEY` | GitHub Actions secret | n/a | Secret token for the CI Helper Agent | Used by `review-known-errors.yml` |
 | `CI_ISSUE_TOKEN` | GitHub Actions secret | `issues: write` | Token used to open rate-limit issues in `ci-monitor.yml` | Optional; falls back to `GITHUB_TOKEN` when unset |
 | `DEV_ORCHESTRATION_BOT_KEY` | GitHub Actions secret | n/a | Secret token for the dev orchestrator workflow | Passed as `ORCHESTRATION_KEY` |
-| `ENVVAR_MANAGER_TOKEN` | GitHub Actions secret | n/a | Token for the EnvVar Manager to open misalignment issues | Used by `secrets-alignment.yml` |
+| `ENV_VAR_MANAGER_KEY` | GitHub Actions secret | n/a | Token for the EnvVar Manager to open misalignment issues | Used by `secrets-alignment.yml` |
 | `GH_TOKEN` | GitHub Actions secret or local environment | `issues: write`, `pull_requests: write` if used for cross-repo operations | Token consumed by the GitHub CLI to comment on PRs and manage issues | Usually set to `${{ secrets.GITHUB_TOKEN }}` in workflows |
 | `GITHUB_REPOSITORY` | Auto-injected by GitHub | n/a | `owner/repo` string identifying the project | Used by `post_coverage_comment.py` |
 | `GITHUB_RUN_ID` | Auto-injected by GitHub | n/a | Unique ID for the workflow run | Used when generating coverage links |


### PR DESCRIPTION
## Summary
- update env var manager secret name in docs
- record the rename in the changelog

## Testing
- `bash scripts/run_tests.sh`
- `python scripts/list-bots.py`

------
https://chatgpt.com/codex/tasks/task_e_687a71bcecd883208dea0bde0a0038dc