### PR TITLE
Ignore dependency inventory file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ Potato
 Potato.md
 *.potato
 *.potato.*
+dependency_inventory.xlsx

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+import pytest
+
+@pytest.fixture(autouse=True)
+def cleanup_dependency_inventory():
+    """Remove dependency_inventory.xlsx created during tests."""
+    yield
+    path = Path('dependency_inventory.xlsx')
+    if path.exists():
+        path.unlink()


### PR DESCRIPTION
## Summary
- ignore `dependency_inventory.xlsx`
- remove `dependency_inventory.xlsx` after tests run

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687a8409e1ec8320b914986204aa8dad