### PR TITLE
Highlight Python 3.12 requirement

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,8 @@ All notable changes to this project will be recorded in this file.
 - chore(security): add missing bots to `.codex/bot-permissions.yaml` and cross-link governance
 - chore(security): record permissions for additional agents and rename env_var_manager entry
 - docs(env): rename `ENVVAR_MANAGER_TOKEN` to `ENV_VAR_MANAGER_KEY`
+- docs(readme): highlight tests require Python 3.12
+- chore(scripts): warn when Python version < 3.12
 - docs(readme): document `/dependency_inventory` uploads `dependency_inventory.xlsx`
 
 - fix(ci): correct YAML indentation in Verify gh version step

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,8 @@ running and where to find documentation about our workflow.
 
 If you're setting up a fresh Ubuntu machine, follow
 [ubuntu-setup.md](ubuntu-setup.md) for the commands that install Docker, Docker
-Compose, Node.js 20, and Python 3.12.
+Compose, Node.js 20, and Python 3.12. Running tests requires Python **3.12** or
+newer.
 
 After cloning the repository, run `bash scripts/install_commit_msg_hook.sh` to
 install a `commit-msg` hook. This ensures your commit messages pass the lint
@@ -58,7 +59,8 @@ check in CI. See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
 
     `pytest.ini` sets `pythonpath=src` so tests can locate the
     `devonboarder` package. Installing the project still ensures
-    dependencies like **FastAPI** are available.
+    dependencies like **FastAPI** are available. The test suite only runs on
+    Python **3.12** or newer.
 
 15. Run `npm run coverage` in both the `bot/` and `frontend/` directories to collect test coverage.
     The CI workflow fails if coverage drops below **95%**.

--- a/scripts/check_dependencies.sh
+++ b/scripts/check_dependencies.sh
@@ -26,6 +26,16 @@ if ! command -v vale >/dev/null 2>&1; then
     missing=1
 fi
 
+# Verify Python version
+if ! python - <<'PY'
+import sys
+sys.exit(0 if sys.version_info >= (3, 12) else 1)
+PY
+then
+    echo "Python 3.12 or newer is required to run tests."
+    missing=1
+fi
+
 check_python_module() {
     local module=$1
     local hint=$2


### PR DESCRIPTION
## Summary
- mention Python 3.12 as the minimum test version in docs
- warn in check_dependencies.sh when Python is too old
- note these updates in the changelog

## Testing
- `bash scripts/check_docs.sh`
- `bash scripts/check_dependencies.sh` *(fails: missing optional deps)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a8f1fb3f08320ba16184408b0aa29