### PR TITLE
Add dependency inventory command

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The full recovery story lives in [docs/origin.md](docs/origin.md).
 - `archive/docker-compose.yml` – Archived base compose file for generic deployments.
 - `archive/docker-compose.codex.yml` – Archived compose file for Codex runs.
 - `archive/docker-compose.override.yaml` – Archived overrides for the base compose file.
-- `bot/` – Discord bot written in TypeScript.
+- `bot/` – Discord bot written in TypeScript. Run `/dependency_inventory` to export dependencies.
 - `frontend/` – Vite-based React application.
 - `auth/` – Environment files for the authentication service.
 - `plugins/` – Optional Python packages that extend functionality.

--- a/bot/package-lock.json
+++ b/bot/package-lock.json
@@ -10,7 +10,9 @@
       "license": "MIT",
       "dependencies": {
         "discord.js": "^14.21.0",
-        "dotenv": "^17.2.0"
+        "dotenv": "^17.2.0",
+        "toml": "^3.0.0",
+        "xlsx": "^0.18.5"
       },
       "devDependencies": {
         "@types/jest": "^30.0.0",
@@ -1876,6 +1878,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -2198,6 +2209,19 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2328,6 +2352,15 @@
         "node": ">= 0.12.0"
       }
     },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/collect-v8-coverage": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz",
@@ -2367,6 +2400,18 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -2988,6 +3033,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/fs.realpath": {
@@ -4770,6 +4824,18 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/stack-utils": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
@@ -5028,6 +5094,12 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/toml": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
+      "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==",
+      "license": "MIT"
     },
     "node_modules/ts-jest": {
       "version": "29.4.0",
@@ -5298,6 +5370,24 @@
         "node": ">= 8"
       }
     },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -5436,6 +5526,27 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/y18n": {

--- a/bot/package.json
+++ b/bot/package.json
@@ -13,7 +13,9 @@
   },
   "dependencies": {
     "discord.js": "^14.21.0",
-    "dotenv": "^17.2.0"
+    "dotenv": "^17.2.0",
+    "toml": "^3.0.0",
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",

--- a/bot/src/commands/dependency_inventory.ts
+++ b/bot/src/commands/dependency_inventory.ts
@@ -1,0 +1,79 @@
+import { SlashCommandBuilder, ChatInputCommandInteraction, AttachmentBuilder } from 'discord.js';
+import { readFile } from 'fs/promises';
+import path from 'path';
+import * as XLSX from 'xlsx';
+import toml from 'toml';
+
+interface InventoryItem {
+  Type: string;
+  File: string;
+  Package: string;
+  Version: string;
+}
+
+async function parsePyproject(root: string): Promise<InventoryItem[]> {
+  const file = path.join(root, 'pyproject.toml');
+  const text = await readFile(file, 'utf8');
+  const data = toml.parse(text) as any;
+  const items: InventoryItem[] = [];
+  const deps: string[] = data?.project?.dependencies ?? [];
+  for (const dep of deps) {
+    const match = dep.match(/^([^\s<>=!]+)(.*)$/);
+    const name = match ? match[1] : dep;
+    const version = match && match[2] ? match[2] : '';
+    items.push({ Type: 'Python', File: 'pyproject.toml', Package: name, Version: version });
+  }
+  return items;
+}
+
+async function parseRequirements(root: string): Promise<InventoryItem[]> {
+  const file = path.join(root, 'requirements-dev.txt');
+  const items: InventoryItem[] = [];
+  const text = await readFile(file, 'utf8');
+  for (const line of text.split(/\r?\n/)) {
+    const trimmed = line.split('#')[0].trim();
+    if (!trimmed) continue;
+    const match = trimmed.match(/^([^=<>!]+)(.*)$/);
+    if (!match) continue;
+    const name = match[1];
+    const version = match[2] || '';
+    items.push({ Type: 'Python (dev)', File: 'requirements-dev.txt', Package: name, Version: version });
+  }
+  return items;
+}
+
+async function parsePackageJson(root: string, rel: string): Promise<InventoryItem[]> {
+  const file = path.join(root, rel, 'package.json');
+  const pkg = JSON.parse(await readFile(file, 'utf8'));
+  const items: InventoryItem[] = [];
+  for (const [name, version] of Object.entries(pkg.dependencies || {})) {
+    items.push({ Type: 'Node.js', File: path.join(rel, 'package.json'), Package: name, Version: String(version) });
+  }
+  for (const [name, version] of Object.entries(pkg.devDependencies || {})) {
+    items.push({ Type: 'Node.js (dev)', File: path.join(rel, 'package.json'), Package: name, Version: String(version) });
+  }
+  return items;
+}
+
+export const data = new SlashCommandBuilder()
+  .setName('dependency_inventory')
+  .setDescription('Generate a dependency inventory spreadsheet');
+
+export async function execute(interaction: ChatInputCommandInteraction) {
+  const root = path.resolve(__dirname, '../../..');
+  const items: InventoryItem[] = [];
+  items.push(...await parsePyproject(root));
+  items.push(...await parseRequirements(root));
+  items.push(...await parsePackageJson(root, '.'));
+  items.push(...await parsePackageJson(root, 'frontend'));
+  items.push(...await parsePackageJson(root, 'bot'));
+
+  const wb = XLSX.utils.book_new();
+  const sheet = XLSX.utils.json_to_sheet(items);
+  XLSX.utils.book_append_sheet(wb, sheet, 'Inventory');
+  const outPath = path.join(root, 'dependency_inventory.xlsx');
+  XLSX.writeFile(wb, outPath);
+
+  const attachment = new AttachmentBuilder(outPath);
+  await interaction.reply({ files: [attachment] });
+}

--- a/bot/tests/dependency_inventory.test.ts
+++ b/bot/tests/dependency_inventory.test.ts
@@ -1,0 +1,20 @@
+import { execute } from '../src/commands/dependency_inventory';
+import fs from 'fs';
+import path from 'path';
+import * as XLSX from 'xlsx';
+
+
+const interaction = { reply: jest.fn() } as any;
+
+test('dependency_inventory generates spreadsheet', async () => {
+  await execute(interaction);
+  const filePath = path.resolve(__dirname, '..', '..', 'dependency_inventory.xlsx');
+  expect(fs.existsSync(filePath)).toBe(true);
+  const wb = XLSX.readFile(filePath);
+  const sheet = wb.Sheets[wb.SheetNames[0]];
+  const rows = XLSX.utils.sheet_to_json<{ Package: string }>(sheet);
+  const packages = rows.map(r => r.Package);
+  expect(packages).toContain('httpx');
+  expect(packages).toContain('react');
+  if (fs.existsSync(filePath)) fs.unlinkSync(filePath);
+});

--- a/codex/prompts/dependency_inventory.md
+++ b/codex/prompts/dependency_inventory.md
@@ -1,0 +1,15 @@
+# Codex Task: Dependency Inventory to Excel
+
+Parse the following files in the DevOnboarder repo:
+- `pyproject.toml`
+- All `package.json` files (root, frontend, bot)
+
+For each dependency found, list:
+- Package name
+- Version
+- File source
+- Dependency type (runtime/dev, Python/Node)
+
+Generate a spreadsheet (`dependency_inventory.xlsx`) and store it in the repo or temp path.
+
+Log the results in `docs/codex-e2e-report.md` and post a summary to the Discord channel if applicable.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,8 @@ All notable changes to this project will be recorded in this file.
 
 - fix(ci): correct YAML indentation in Verify gh version step
 - chore(ci): reuse saved ci-failure issue number across runs
+- feat(bot): add `/dependency_inventory` command to export dependencies to Excel
+- docs(setup): highlight Python 3.12 requirement for tests
 - chore(ci): track CI failure issues by PR number and store the commit SHA in the issue body
 - chore(ci): validate `.codex/bot-permissions.yaml` via new script
 - chore(ci): add permissions validation workflow

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,8 @@ check in CI. See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
 4. Install the project in editable mode with `pip install -e .` so the
    `devonboarder` package can be imported during tests. Then install the dev
    requirements with `pip install -r requirements-dev.txt`.
+
+   Running tests requires **Python 3.12**. Verify with `python3 --version` before installing packages.
 5. Start services with `make up` or run
    `docker compose -f ../archive/docker-compose.dev.yaml --env-file .env.dev up -d`.
    This launches the auth, bot, XP API, frontend, and Postgres services.

--- a/docs/ubuntu-setup.md
+++ b/docs/ubuntu-setup.md
@@ -35,6 +35,8 @@ sudo add-apt-repository ppa:deadsnakes/ppa -y
 sudo apt-get update
 sudo apt-get install -y python3.12 python3.12-venv python3.12-dev
 ```
+python3 --version  # should print Python 3.12.x
+Running tests require Python 3.12.
 
 ## Install Project Dependencies
 


### PR DESCRIPTION
## Summary
- generate a dependency inventory Excel file via `/dependency_inventory`
- note Python 3.12 requirement in docs
- document new command in README and changelog
- add Codex prompt for dependency inventory

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_687a74ec41ec83209b614f2d62fbc15e