### PR TITLE
Fix Prettier tag in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
       hooks:
           - id: ruff
     - repo: https://github.com/pre-commit/mirrors-prettier
-      rev: v3.6.2
+      rev: v3.1.0
       hooks:
           - id: prettier
     - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
## Summary
- point `pre-commit` config at valid Prettier tag `v3.1.0`
- run `pre-commit clean && pre-commit install`

## Testing
- `pre-commit clean && pre-commit install`


------
https://chatgpt.com/codex/tasks/task_e_687a9a73663c83209f90908852b079f6