### PR TITLE
Document OPENAI_API_KEY for auto-fix workflow

### DIFF
--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -5,6 +5,7 @@
 #   scope: .github/workflows/auto-fix.yml
 #   triggers: Completed CI workflow runs with failures
 #   output: Pull request suggesting patches
+#   note: Requires `OPENAI_API_KEY` secret
 # ---
 name: Auto Fix
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be recorded in this file.
 - docs(pr-template): add Codex policy checklist bullet to PR templates
 - docs(retros): introduce retrospective framework and audit workflow
 - docs(retros): document `scripts/create-retro-file.sh` usage for new retrospectives
+- docs(ci): note `OPENAI_API_KEY` secret requirement for `auto-fix.yml`
 
 - docs(env): document `CI_BOT_TOKEN` variable
 - docs(env): document `CI_BOT_USERNAME` variable

--- a/docs/README.md
+++ b/docs/README.md
@@ -284,6 +284,8 @@ See [doc-quality-onboarding.md](doc-quality-onboarding.md) for a step-by-step gu
 13. The `auto-fix.yml` workflow runs when CI fails. It downloads the `ci-logs` artifact,
     asks OpenAI for a YAML patch using `yamllint` output, applies it, then requests a
     broader fix and opens a pull request with `peter-evans/create-pull-request`.
+    Add an `OPENAI_API_KEY` secret under **Settings → Secrets and variables → Actions**
+    so the workflow can request a patch from OpenAI.
 14. The `ci-monitor.yml` workflow scans CI logs for several rate-limit phrases.
     It quotes the first match and opens an issue using
     `${{ secrets.CI_ISSUE_TOKEN }}` or `${{ secrets.GITHUB_TOKEN }}` when that


### PR DESCRIPTION
## Summary
- mention OPENAI_API_KEY secret requirement in auto-fix workflow header
- advise adding this secret in README
- record the documentation update in the changelog

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_687aa377a4f48320be873c44d3967de0