### PR TITLE
Add debug logging for issue cleanup

### DIFF
--- a/.github/workflows/cleanup-ci-failure.yml
+++ b/.github/workflows/cleanup-ci-failure.yml
@@ -67,8 +67,10 @@ jobs:
                 issues=$($gh_bin issue list --label ci-failure --state open | awk '{print $1}') || failed=1
                 for n in $issues; do
                   if "$gh_bin" issue close "$n" --reason completed; then
+                    echo "::debug::Closed issue #$n"
                     closed=$((closed+1))
                   else
+                    echo "::warning::Failed to close issue #$n"
                     failed=1
                   fi
                 done

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -836,3 +836,4 @@ All notable changes to this project will be recorded in this file.
 - Added CI Bot metadata to codex agent index.
 - Introduced the CI Bot and updated workflows to route automation through it.
 - docs(env): document `ONBOARDING_AGENT_KEY`, `CI_HELPER_AGENT_KEY`, and `ENV_VAR_MANAGER_KEY` secrets
+- chore(ci): log closed issue numbers in `cleanup-ci-failure.yml`


### PR DESCRIPTION
## Summary
- confirm CI cleanup workflow has write permissions
- surface closed issue numbers with debug messages

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_687aaa2cfba88320bfb2860c5af60f47