### PR TITLE
Add CI resilience hardening prompt

### DIFF
--- a/codex/agents/index.json
+++ b/codex/agents/index.json
@@ -74,6 +74,7 @@
       "name": "Agent.AutoFix",
       "role": "Proposes fixes for failed CI runs",
       "path": ".github/workflows/auto-fix.yml",
+      "prompt": "codex/prompts/ci_resilience_hardening.md",
       "triggers": "Completed CI workflow runs with failures",
       "output": "Pull request suggesting patches"
     },

--- a/codex/prompts/ci_resilience_hardening.md
+++ b/codex/prompts/ci_resilience_hardening.md
@@ -1,0 +1,9 @@
+# Codex Task: CI Resilience Hardening
+
+Follow these steps when investigating a failed CI run:
+
+1. Detect which jobs failed by inspecting the workflow summary and step results.
+2. Gather relevant log excerpts that show stack traces or error messages.
+3. Generate a concise Markdown summary highlighting root causes.
+4. Suggest minimal patches to resolve the failure, such as lint fixes or test adjustments.
+5. Output the summary and patch suggestion for maintainers to review.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -837,3 +837,4 @@ All notable changes to this project will be recorded in this file.
 - Introduced the CI Bot and updated workflows to route automation through it.
 - docs(env): document `ONBOARDING_AGENT_KEY`, `CI_HELPER_AGENT_KEY`, and `ENV_VAR_MANAGER_KEY` secrets
 - chore(ci): log closed issue numbers in `cleanup-ci-failure.yml`
+- docs(ci): add CI resilience hardening prompt for AutoFix


### PR DESCRIPTION
## Summary
- document CI resilience hardening steps for AutoFix
- link new prompt in codex agent index
- mention change in changelog

## Testing
- `pre-commit run --files codex/prompts/ci_resilience_hardening.md codex/agents/index.json docs/CHANGELOG.md` *(fails: markdownlint issues found)*
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_687aad994f788320ae14f8a0943cdbdf