### PR TITLE
Document Python 3.12 requirement

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be recorded in this file.
 - chore(ci): route retrospective alerts through notify workflow
 - docs(ci): outline CI enforcement tasks in `.codex/automation-tasks.md`
 - docs(pr-template): add Codex policy checklist bullet to PR templates
+- docs(readme): mention `mise use` for installing Python 3.12
+- chore(setup): warn when Python < 3.12 in `setup-env.sh`
 - docs(retros): introduce retrospective framework and audit workflow
 - docs(retros): document `scripts/create-retro-file.sh` usage for new retrospectives
 - docs(ci): note `OPENAI_API_KEY` secret requirement for `auto-fix.yml`

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -78,6 +78,9 @@ pip install -e .
 pip install -r requirements-dev.txt
 ```
 
+Tests run only on **Python 3.12**. Run `mise use -g python 3.12`
+(or `asdf install python 3.12`) before installing packages.
+
 If Vale or the optional LanguageTool cannot run due to network errors, Codex
 marks the documentation step as a "⚠️ Docs: Lint skipped" warning. LanguageTool
 only runs when `LANGUAGETOOL_URL` is set. You can still merge if all other

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,8 +5,7 @@ running and where to find documentation about our workflow.
 
 If you're setting up a fresh Ubuntu machine, follow
 [ubuntu-setup.md](ubuntu-setup.md) for the commands that install Docker, Docker
-Compose, Node.js 20, and Python 3.12. Running tests requires Python **3.12** or
-newer.
+Compose, Node.js 20, and Python 3.12. Running tests requires Python **3.12**.
 
 After cloning the repository, run `bash scripts/install_commit_msg_hook.sh` to
 install a `commit-msg` hook. This ensures your commit messages pass the lint
@@ -27,7 +26,9 @@ check in CI. See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
    `devonboarder` package can be imported during tests. Then install the dev
    requirements with `pip install -r requirements-dev.txt`.
 
-   Running tests requires **Python 3.12**. Verify with `python3 --version` before installing packages.
+   Tests run only on **Python 3.12**. Use `mise use -g python 3.12`
+   (or `asdf install python 3.12`) before running `pip install -e .`.
+   Verify with `python3 --version`.
 5. Start services with `make up` or run
    `docker compose -f ../archive/docker-compose.dev.yaml --env-file .env.dev up -d`.
    This launches the auth, bot, XP API, frontend, and Postgres services.
@@ -62,7 +63,7 @@ check in CI. See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
     `pytest.ini` sets `pythonpath=src` so tests can locate the
     `devonboarder` package. Installing the project still ensures
     dependencies like **FastAPI** are available. The test suite only runs on
-    Python **3.12** or newer.
+    Python **3.12**.
 
 15. Run `npm run coverage` in both the `bot/` and `frontend/` directories to collect test coverage.
     The CI workflow fails if coverage drops below **95%**.

--- a/scripts/setup-env.sh
+++ b/scripts/setup-env.sh
@@ -31,6 +31,13 @@ else
     fi
 
     py_cmd="python3"
+    if ! python3 - <<'EOF'
+import sys
+sys.exit(0 if sys.version_info >= (3, 12) else 1)
+EOF
+    then
+        echo "::warning file=scripts/setup-env.sh,line=$LINENO::Active Python $(python3 --version 2>&1) is below 3.12" >&2
+    fi
     if ! python3 --version 2>/dev/null | grep -q "3.12"; then
         if command -v python3.12 >/dev/null 2>&1; then
             py_cmd="python3.12"


### PR DESCRIPTION
## Summary
- mention installing Python 3.12 with `mise use` or `asdf install`
- warn in `setup-env.sh` if Python is too old

## Testing
- `bash scripts/validate.sh` *(fails: Markdownlint issues found)*
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_687aa9ae363c8320b8a1a2b4da7243c0