### PR TITLE
Add markdownlint workflow and documentation

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,0 +1,19 @@
+name: Markdownlint
+
+on:
+  pull_request:
+  push:
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: DavidAnson/markdownlint-cli2-action@v20
+        with:
+          globs: '**/*.md'
+          fix: false
+          config: '.markdownlint.json'

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,4 +1,5 @@
 {
-  "MD029": { "style": "ordered" },
-  "MD013": { "line_length": 120 }
+  "default": true,
+  "MD013": false,
+  "MD007": { "indent": 4 }
 }

--- a/agents/envvar-manager.md
+++ b/agents/envvar-manager.md
@@ -37,3 +37,24 @@ Route alerts through `.github/workflows/notify.yml`.
 
 **Escalation:**  
 If environment misalignment persists longer than 24 hours, notify the DevOps lead.
+
+## \U0001F4CC Markdown Standards
+
+- We use [`markdownlint`](https://github.com/DavidAnson/markdownlint) v0.38+ to enforce style and consistency.
+- Configured via `.markdownlint.json` with all rules enabled by default.
+- File-specific rule overrides are applied using inline comments.
+- CI automatically runs linting via `markdownlint-cli2-action`.
+
+### Customizations:
+```json
+{
+  "MD013": false,
+  "MD007": { "indent": 4 }
+}
+```
+
+* To disable rules in a file, add:
+
+  ```markdown
+  <!-- markdownlint-disable-file MD### -->
+  ```

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,8 @@ All notable changes to this project will be recorded in this file.
 - docs(env): document `CI_BOT_TOKEN` variable
 - docs(env): document `CI_BOT_USERNAME` variable
 - docs(agents): add EnvVar Manager agent and issue template
+- chore(ci): add markdownlint workflow
+- docs(agents): document markdown standards for EnvVar Manager
 - docs(env): document CI-provided variables in `.env.example`
 - chore(security): add missing bots to `.codex/bot-permissions.yaml` and cross-link governance
 - chore(security): record permissions for additional agents and rename env_var_manager entry


### PR DESCRIPTION
## Summary
- enable default rules in `.markdownlint.json`
- integrate `markdownlint-cli2-action` via a new workflow
- document markdown standards in `Agent.EnvVarManager`
- record changes in `CHANGELOG`

## Testing
- `bash scripts/run_tests.sh` *(fails: Package 'devonboarder' requires Python >=3.12)*

------
https://chatgpt.com/codex/tasks/task_e_687ab483fdf083209d2cf4d885ff886e