### PR TITLE
Add branch cleanup automation

### DIFF
--- a/.github/workflows/branch-cleanup.yml
+++ b/.github/workflows/branch-cleanup.yml
@@ -1,0 +1,33 @@
+# ---
+# codex-agent:
+#   name: Agent.BranchCleanup
+#   role: Deletes stale merged branches
+#   scope: .github/workflows/branch-cleanup.yml
+#   triggers: Nightly schedule or label
+#   output: Deleted branch log
+# ---
+name: Branch Cleanup
+
+on:
+    schedule:
+        - cron: "0 1 * * *"
+    issues:
+        types: [labeled]
+    pull_request:
+        types: [labeled]
+
+permissions:
+    contents: write
+
+jobs:
+    run:
+        runs-on: ubuntu-latest
+        if: github.event_name == 'schedule' || github.event.label.name == 'codex:cleanup'
+        steps:
+            - uses: actions/checkout@v3
+              with:
+                  fetch-depth: 0
+            - name: Run cleanup script
+              env:
+                  DRY_RUN: ${DRY_RUN:-true}
+              run: bash scripts/cleanup_branches.sh

--- a/agents/branch-cleanup.md
+++ b/agents/branch-cleanup.md
@@ -1,0 +1,35 @@
+---
+codex-agent:
+  name: Agent.BranchCleanup
+  role: Deletes stale merged branches
+  scope: repository maintenance
+  triggers: Nightly schedule or `codex:cleanup` label
+  output: Deleted branch log
+---
+
+# Branch Cleanup Agent
+
+**Status:** Proposed.
+
+**Purpose:** Remove merged branches that haven't been updated in the last 30 days.
+This keeps the remote namespace tidy and prevents confusion over old feature
+branches.
+
+**Inputs:**
+- Remote git history
+- Environment variables controlling branch selection
+
+**Outputs:**
+- Log of deleted branches or a dry-run summary
+
+**Environment:**
+- `DRY_RUN` – when `true`, list branches without deleting (default `true`)
+- `BASE_BRANCH` – branch used to check merge status (default `main`)
+- `DAYS_STALE` – age threshold in days before deletion (default `30`)
+
+**Workflow:**
+The nightly workflow runs `scripts/cleanup_branches.sh`. Maintainers can also
+trigger it by adding the `codex:cleanup` label to an issue or pull request.
+The script excludes protected branches like `main`, `dev` and `release/*`.
+
+**Notification:** Any failures are sent through `.github/workflows/notify.yml`.

--- a/agents/index.md
+++ b/agents/index.md
@@ -19,6 +19,7 @@ how it fits into the workflow.
 - [CI Bot](ci-bot.md)
 - [Diagnostics Bot](diagnostics-bot.md)
 - [EnvVar Manager](envvar-manager.md)
+- [Branch Cleanup](branch-cleanup.md)
 
 Use the [template](templates/agent-spec-template.md) when documenting a new agent.
 ## Required Environment Variables

--- a/codex/agents/index.json
+++ b/codex/agents/index.json
@@ -154,6 +154,13 @@
       "path": "agents/envvar-manager.md",
       "triggers": "Workflow runs, scheduled checks, or manual dispatch",
       "output": "Updated `.env.example` files or issues for misaligned variables"
+    },
+    {
+      "name": "Agent.BranchCleanup",
+      "role": "Deletes stale merged branches",
+      "path": "agents/branch-cleanup.md",
+      "triggers": "Nightly schedule or label",
+      "output": "Deleted branch log"
     }
   ]
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be recorded in this file.
 - docs(env): document CI-provided variables in `.env.example`
 - chore(security): add missing bots to `.codex/bot-permissions.yaml` and cross-link governance
 - chore(security): record permissions for additional agents and rename env_var_manager entry
+- chore(ci): add branch cleanup script and workflow
 - docs(env): rename `ENVVAR_MANAGER_TOKEN` to `ENV_VAR_MANAGER_KEY`
 - docs(readme): highlight tests require Python 3.12
 - chore(scripts): warn when Python version < 3.12

--- a/docs/README.md
+++ b/docs/README.md
@@ -154,6 +154,7 @@ platforms. Please report any issues you encounter on your operating system.
 - [Founders log](../FOUNDERS.md) &ndash; record core contributors and how they help.
 - [Frontend README](../frontend/README.md) &ndash; instructions for running the React app.
 - [Git guidelines](git-guidelines.md) &ndash; branch naming, commit messages and the pre‑PR checklist.
+- [Branch cleanup workflow](git-guidelines.md#stale-branch-cleanup) &ndash; nightly script for removing old branches.
 - [Marketing site home](../frontend/index.html) &ndash; early look at the public landing page.
 - [Merge checklist](merge-checklist.md) &ndash; steps maintainers use before merging.
 - [Network troubleshooting](network-troubleshooting.md#pre-commit-nodeenv-ssl-errors)

--- a/docs/git-guidelines.md
+++ b/docs/git-guidelines.md
@@ -98,3 +98,10 @@ pytest --cov=src --cov-fail-under=95
 - Update `docs/CHANGELOG.md` with a short summary of your change.
 - Update any other relevant documentation under `docs/`.
 - Follow the pull request template in `.github/pull_request_template.md`.
+
+## Stale Branch Cleanup
+
+The `cleanup_branches.sh` script removes merged branches that haven't changed in
+30 days. The nightly `branch-cleanup.yml` workflow runs this task with
+`DRY_RUN=true` by default. To delete branches immediately, set `DRY_RUN=false`
+when triggering the workflow with the `codex:cleanup` label.

--- a/scripts/cleanup_branches.sh
+++ b/scripts/cleanup_branches.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DRY_RUN="${DRY_RUN:-true}"
+BASE_BRANCH="${BASE_BRANCH:-main}"
+DAYS_STALE="${DAYS_STALE:-30}"
+
+if ! command -v git >/dev/null 2>&1; then
+  echo "git not found" >&2
+  exit 1
+fi
+
+echo "Fetching remote branches..."
+# prune deleted remote refs
+git fetch origin --prune
+
+cutoff=$(date -d "${DAYS_STALE} days ago" +%s)
+
+# List merged branches
+while read -r branch; do
+  b=${branch#origin/}
+  [[ "$b" == "$BASE_BRANCH" ]] && continue
+  [[ "$b" == "HEAD" ]] && continue
+  [[ "$b" == "dev" ]] && continue
+  [[ "$b" == release/* ]] && continue
+  if git merge-base --is-ancestor "origin/$b" "origin/$BASE_BRANCH"; then
+    ts=$(git show -s --format=%ct "origin/$b")
+    if [ "$ts" -lt "$cutoff" ]; then
+      if [ "$DRY_RUN" = "true" ]; then
+        echo "Would delete $b"
+      else
+        git push origin --delete "$b" && echo "Deleted $b"
+      fi
+    fi
+  fi
+done < <(git branch -r --merged "origin/$BASE_BRANCH")


### PR DESCRIPTION
## Summary
- add script for removing stale branches
- document how to trigger it in git-guidelines and link from docs README
- describe new Branch Cleanup agent
- register agent in docs and codex index
- schedule nightly workflow to run cleanup script
- mention automation in changelog

## Testing
- `ruff check .`
- `bash scripts/check_docs.sh`
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_687ab8295f208320a78ffa0438142f16