### PR TITLE
Add CI-first OpenAI key policy

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be recorded in this file.
 - docs(retros): introduce retrospective framework and audit workflow
 - docs(retros): document `scripts/create-retro-file.sh` usage for new retrospectives
 - docs(ci): note `OPENAI_API_KEY` secret requirement for `auto-fix.yml`
+- docs(ci): introduce CI-first OpenAI API key policy document
 
 - docs(env): document `CI_BOT_TOKEN` variable
 - docs(env): document `CI_BOT_USERNAME` variable

--- a/docs/README.md
+++ b/docs/README.md
@@ -135,6 +135,8 @@ platforms. Please report any issues you encounter on your operating system.
   &ndash; overview of job steps, caching, concurrency, and coverage requirements.
 - [CI environment variables](ci-env-vars.md)
   &ndash; summary of tokens and other variables used by the workflows.
+- [CI-first OpenAI API key policy](ci-first-policy.md)
+  &ndash; explains why the OpenAI key only exists in CI.
 - [Discord message templates](discord/discord-message-templates.md) &ndash; sample posts for the community.
 - [Discord server configuration](discord/configuration.md) &ndash; enable the widget for status display.
 - [Doc QA onboarding](doc-quality-onboarding.md) &ndash; quickstart for documentation checks.

--- a/docs/ci-first-policy.md
+++ b/docs/ci-first-policy.md
@@ -1,0 +1,3 @@
+# CI-First OpenAI API Key Policy
+
+The `OPENAI_API_KEY` secret is only available in GitHub Actions. Workflows use this key to request patches from OpenAI. Avoid storing it in `.env` files or committing it to the repository. Run automation that requires the key through CI so usage is auditable. For occasional local testing, export your own key temporarily and remove it afterward.


### PR DESCRIPTION
## Summary
- document CI-first policy for the OpenAI API key
- link the policy from the docs overview
- record the new policy document in the changelog

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_687ba9196d6483208af50258c29b4b84