### PR TITLE
Document CI_BUILD_OPENAPI secret

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be recorded in this file.
 
 - docs(env): document `CI_BOT_TOKEN` variable
 - docs(env): document `CI_BOT_USERNAME` variable
+- docs(env): document `CI_BUILD_OPENAPI` variable
 - docs(agents): add EnvVar Manager agent and issue template
 - chore(ci): add markdownlint workflow
 - docs(agents): document markdown standards for EnvVar Manager

--- a/docs/README.md
+++ b/docs/README.md
@@ -288,7 +288,7 @@ See [doc-quality-onboarding.md](doc-quality-onboarding.md) for a step-by-step gu
 13. The `auto-fix.yml` workflow runs when CI fails. It downloads the `ci-logs` artifact,
     asks OpenAI for a YAML patch using `yamllint` output, applies it, then requests a
     broader fix and opens a pull request with `peter-evans/create-pull-request`.
-    Add an `OPENAI_API_KEY` secret under **Settings → Secrets and variables → Actions**
+    Add a `CI_BUILD_OPENAPI` secret under **Settings → Secrets and variables → Actions** (or `OPENAI_API_KEY` if unavailable)
     so the workflow can request a patch from OpenAI.
 14. The `ci-monitor.yml` workflow scans CI logs for several rate-limit phrases.
     It quotes the first match and opens an issue using

--- a/docs/ci-env-vars.md
+++ b/docs/ci-env-vars.md
@@ -8,6 +8,7 @@ values when running CI jobs locally or configuring new workflows.
 | `AUTH_URL` | Workflow `env` block | n/a | Base URL for auth service during E2E tests | Set to `http://localhost:8002` in CI |
 | `CHECK_HEADERS_URL` | Workflow `env` block | n/a | Endpoint checked by `scripts/check_headers.py` | Defaults to the auth user endpoint |
 | `CI_BOT_USERNAME` | GitHub Actions variable | n/a | GitHub username used to assign CI failure issues | |
+| `CI_BUILD_OPENAPI` | GitHub Actions secret | n/a | OpenAI service account key used in CI | Use instead of `OPENAI_API_KEY` whenever present |
 | `CI_HELPER_AGENT_KEY` | GitHub Actions secret | n/a | Secret token for the CI Helper Agent | Used by `review-known-errors.yml` |
 | `CI_ISSUE_TOKEN` | GitHub Actions secret | `issues: write` | Token used to open rate-limit issues in `ci-monitor.yml` | Optional; falls back to `GITHUB_TOKEN` when unset |
 | `DEV_ORCHESTRATION_BOT_KEY` | GitHub Actions secret | n/a | Secret token for the dev orchestrator workflow | Passed as `ORCHESTRATION_KEY` |


### PR DESCRIPTION
## Summary
- list CI_BUILD_OPENAPI in CI env var reference
- mention CI_BUILD_OPENAPI in docs/README near auto-fix workflow instructions
- add changelog entry

## Testing
- `pre-commit run --files docs/ci-env-vars.md docs/README.md docs/CHANGELOG.md` *(fails: deb.nodesource.com blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687bb2b9ad90832089c9c3303545fce9