### PR TITLE
Update bot docs

### DIFF
--- a/.codex/automation-tasks.md
+++ b/.codex/automation-tasks.md
@@ -35,6 +35,7 @@ This document outlines the automation checks Codex uses to keep the CI workflow 
 
 - `scripts/check_docs.sh` runs `markdownlint-cli2` and Vale.
 - Results upload as the `vale-results` artifact and fail the build on errors.
+- Contributors should also review [docs/bot-types.md](../docs/bot-types.md) to understand how the Discord bot differs from Codex agents.
 
 ## 7. CI Failure Handling
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The full recovery story lives in [docs/origin.md](docs/origin.md).
 - `archive/docker-compose.yml` – Archived base compose file for generic deployments.
 - `archive/docker-compose.codex.yml` – Archived compose file for Codex runs.
 - `archive/docker-compose.override.yaml` – Archived overrides for the base compose file.
-- `bot/` – Discord bot written in TypeScript. Run `/dependency_inventory` to export dependencies.
+- `bot/` – Discord bot written in TypeScript. Provides slash commands like `/verify`, `/dependency_inventory`, and `/qa_checklist`. This bot runs on its own and is not tied to Codex agents or CI workflows.
 - `frontend/` – Vite-based React application.
 - `auth/` – Environment files for the authentication service.
 - `plugins/` – Optional Python packages that extend functionality.

--- a/bot/README.md
+++ b/bot/README.md
@@ -75,3 +75,6 @@ The repository provides the following built-in commands:
 - Sync verified roles back to the auth database.
 - Award XP for community participation.
 - Log quiz completion via slash commands.
+
+For a comparison of this bot and Codex agents, see [../docs/bot-types.md](../docs/bot-types.md).
+

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be recorded in this file.
 - docs(ci): outline CI enforcement tasks in `.codex/automation-tasks.md`
 - docs(pr-template): add Codex policy checklist bullet to PR templates
 - docs(readme): mention `mise use` for installing Python 3.12
+- docs(bot): add `docs/bot-types.md` and update bot README and main README
 - chore(setup): warn when Python < 3.12 in `setup-env.sh`
 - docs(retros): introduce retrospective framework and audit workflow
 - docs(retros): document `scripts/create-retro-file.sh` usage for new retrospectives

--- a/docs/bot-types.md
+++ b/docs/bot-types.md
@@ -1,0 +1,24 @@
+# Bot Types
+
+This document explains the difference between **Codex Agents** and the **Discord Bot** used in this repository.
+
+## Codex Agents
+
+Codex agents are small automation services orchestrated by Codex for project maintenance and monitoring.
+
+- **Purpose** – Perform focused tasks like closing stale issues or validating environment variables.
+- **Location** – Documentation lives under the top‑level [`agents/`](../agents/) folder.
+- **Execution** – Agents usually run within GitHub Actions or other CI jobs using Python scripts.
+- **Naming** – Agent documents begin with a `codex-agent` YAML header and each agent is listed in [`codex/agents/index.json`](../codex/agents/index.json).
+
+## Discord Bot
+
+The `bot/` directory contains a stand‑alone TypeScript bot built with `discord.js`.
+
+- **Purpose** – Provide interactive slash commands for the community, such as `/verify`, `/dependency_inventory`, and `/qa_checklist`.
+- **Location** – Source code and tests live entirely under [`bot/`](../bot/).
+- **Execution** – The bot runs independently of Codex and is not part of CI workflows. It can be started locally with `npm start` or via Docker.
+- **Naming** – Command files are named after their slash command and reside in `bot/src/commands`.
+
+Use this file as a reference when deciding whether a script should be a Codex agent or part of the Discord bot.
+


### PR DESCRIPTION
## Summary
- create docs/bot-types.md detailing Codex agents vs. Discord bot
- clarify README bot/ bullet on slash commands
- link to bot types doc in bot README
- reference bot types in automation tasks doc
- note bot types doc in changelog

## Testing
- `pytest -q`
- `npm run coverage` in `bot/`
- `npm run coverage` in `frontend/`
- `pre-commit run --files README.md bot/README.md .codex/automation-tasks.md docs/bot-types.md docs/CHANGELOG.md` *(fails: required domains unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687bca12a7d48320870be617172a0ad9