### PR TITLE
Load auth env file

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -41,7 +41,8 @@ check in CI. See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
 10. Run `devonboarder-api` to start the user API at `http://localhost:8001`.
    This command requires `uvicorn`.
 11. Run `devonboarder-auth` to start the auth service at `http://localhost:8002`.
-    It stores data in a local SQLite database.
+    It stores data in a local SQLite database and automatically loads
+    environment variables from `auth/.env` when that file exists.
 12. Test the XP API with:
     `curl http://localhost:8001/api/user/onboarding-status`
     and `curl http://localhost:8001/api/user/level`.

--- a/src/devonboarder/auth_service.py
+++ b/src/devonboarder/auth_service.py
@@ -27,8 +27,10 @@ from jose import jwt, JWTError
 import os
 import time
 from dotenv import load_dotenv
+from pathlib import Path
 
-load_dotenv()
+# Load environment variables from the auth service's .env file when present
+load_dotenv(Path(__file__).resolve().parents[1] / '..' / 'auth' / '.env')
 
 SECRET_KEY = os.getenv("JWT_SECRET_KEY")
 APP_ENV = os.getenv("APP_ENV")


### PR DESCRIPTION
## Summary
- load auth service's `.env` if available
- mention the `.env` lookup in the docs

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_687bffecb3148320ac496a733b3cc1f6