### PR TITLE
Add link to bot types doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The full recovery story lives in [docs/origin.md](docs/origin.md).
 - `archive/docker-compose.codex.yml` – Archived compose file for Codex runs.
 - `archive/docker-compose.override.yaml` – Archived overrides for the base compose file.
 - `bot/` – Discord bot written in TypeScript. Provides slash commands like `/verify`, `/dependency_inventory`, and `/qa_checklist`. This bot runs on its own and is not tied to Codex agents or CI workflows.
+  See [docs/bot-types.md](docs/bot-types.md) for details on how the Discord bot differs from Codex agents.
 - `frontend/` – Vite-based React application.
 - `auth/` – Environment files for the authentication service.
 - `plugins/` – Optional Python packages that extend functionality.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be recorded in this file.
 - docs(pr-template): add Codex policy checklist bullet to PR templates
 - docs(readme): mention `mise use` for installing Python 3.12
 - docs(bot): add `docs/bot-types.md` and update bot README and main README
+- docs(readme): link to `docs/bot-types.md` for Discord bot versus Codex agents
 - chore(setup): warn when Python < 3.12 in `setup-env.sh`
 - docs(retros): introduce retrospective framework and audit workflow
 - docs(retros): document `scripts/create-retro-file.sh` usage for new retrospectives


### PR DESCRIPTION
## Summary
- clarify Discord bot vs. Codex agents in README
- note the new reference in the changelog

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_687c29e4985483209f279d8bff7b4af6