### PR TITLE
Add header reference to agent docs index

### DIFF
--- a/agents/index.md
+++ b/agents/index.md
@@ -3,6 +3,7 @@
 This directory documents the services and integrations that make up the
 DevOnboarder platform. Each agent has its own page describing the purpose and
 how it fits into the workflow.
+See [../.codex/Agents.md](../.codex/Agents.md) for header guidelines; every agent file must start with a `codex-agent` YAML header.
 
 ## Available Agents
 


### PR DESCRIPTION
## Summary
- mention `.codex/Agents.md` in the agent overview
- clarify that each agent doc needs a `codex-agent` YAML header

## Testing
- `bash scripts/validate.sh`


------
https://chatgpt.com/codex/tasks/task_e_687c31bc3ee88320ba92c4379b5dad4c