### PR TITLE
FEAT(ci): add Codex CI failure diagnoser script for auto-triage

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable changes to this project will be recorded in this file.
 -   docs(retros): introduce retrospective framework and audit workflow
 -   docs(retros): document `scripts/create-retro-file.sh` usage for new retrospectives
 -   docs(ci): note `OPENAI_API_KEY` secret requirement for `auto-fix.yml`
--   feat(ci): add `ci_failure_diagnoser.py` and update CI workflow
+-   FEAT(ci): add Codex CI failure diagnoser script for auto-triage
 -   docs(ci): introduce CI-first OpenAI API key policy document
 -   chore(setup): ensure `setup-env.sh` installs Python 3.12 when Docker is unavailable
 -   chore(ci): validate bot permissions with `list-bots.py`


### PR DESCRIPTION
## Summary
- update CHANGELOG entry for CI failure diagnoser to use uppercase `FEAT`

## Testing
- `./scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_687c3e30c7108320971e3bf598e4a8fc