### PR TITLE
Fix YAML block spacing in AGENTS protocol

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,6 +145,7 @@ If you notice that CI failure issues (`ci-failure` or `ci-health`) are not being
   env:
     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   ```
+
 * Ensure all steps that use the `gh` CLI have access to this variable.
 
 ### 3. Confirm Token Permissions
@@ -168,6 +169,7 @@ If you notice that CI failure issues (`ci-failure` or `ci-health`) are not being
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   ```
+
 * Ensure:
   * The `gh` CLI commands are not being skipped (check any `if:` conditions).
   * The filter logic (labels, state, etc.) matches the actual issues.


### PR DESCRIPTION
## Summary
- add missing blank lines after closing YAML fences in `AGENTS.md`
- ensure each fenced block has spacing before and after

## Testing
- `pip install -e .`
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c3ff4b1ac8320848e9d952e763d49