### PR TITLE
Add headings to agent stub docs

### DIFF
--- a/codex/agents/notify.md
+++ b/codex/agents/notify.md
@@ -7,4 +7,6 @@ codex-agent:
     output: TBD
 ---
 
+# Notify
+
 This agent is a stub and needs implementation.

--- a/codex/agents/review-known-errors.md
+++ b/codex/agents/review-known-errors.md
@@ -7,4 +7,6 @@ codex-agent:
     output: TBD
 ---
 
+# Review Known Errors
+
 This agent is a stub and needs implementation.

--- a/codex/agents/validate-permissions.md
+++ b/codex/agents/validate-permissions.md
@@ -7,4 +7,6 @@ codex-agent:
     output: TBD
 ---
 
+# Validate Permissions
+
 This agent is a stub and needs implementation.


### PR DESCRIPTION
## Summary
- add basic headings to Agent docs for Notify, Review Known Errors, and Validate Permissions

## Testing
- `pre-commit run --files codex/agents/notify.md codex/agents/review-known-errors.md codex/agents/validate-permissions.md` *(fails: Frontend ESLint couldn't find config)*
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_687c7796d130832099c1285d0d31b48b