### PR TITLE
Fix EnvVar issue template header

### DIFF
--- a/.github/ISSUE_TEMPLATE/envvar-misalignment.md
+++ b/.github/ISSUE_TEMPLATE/envvar-misalignment.md
@@ -1,3 +1,4 @@
+# EnvVar Misalignment
 name: EnvVar Misalignment
 about: Report missing or extra environment variables
 title: "[EnvVar]"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -865,3 +865,4 @@ dev`.
     in its output for easier debugging.
 -   chore(ci): log closed issue numbers in `cleanup-ci-failure.yml`
 -   docs(ci): add CI resilience hardening prompt for AutoFix
+-   docs(templates): add header to EnvVar Misalignment issue template


### PR DESCRIPTION
## Summary
- add markdown header to the EnvVar misalignment issue template
- document the change in the changelog

## Testing
- `bash scripts/run_tests.sh`
- `bash scripts/check_docs.sh`

------
https://chatgpt.com/codex/tasks/task_e_687c3dd0d1548320bf07baa0efc49df7