### PR TITLE
CHORE(ci): use list_open_ci_issues script in cleanup workflow

### DIFF
--- a/.github/workflows/cleanup-ci-failure.yml
+++ b/.github/workflows/cleanup-ci-failure.yml
@@ -54,7 +54,7 @@ jobs:
               run: |
                 gh auth status
                 gh api rate_limit
-                gh issue list --label ci-failure --state open | awk '{print $1}'
+                python scripts/list_open_ci_issues.py
               env:
                   GH_TOKEN: ${{ secrets.CI_BOT_TOKEN || secrets.GITHUB_TOKEN }}
               continue-on-error: true

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be recorded in this file.
 -   docs(ci): note `OPENAI_API_KEY` secret requirement for `auto-fix.yml`
 -   FEAT(ci): add Codex CI failure diagnoser script for auto-triage
 -   docs(ci): introduce CI-first OpenAI API key policy document
+-   chore(ci): use list_open_ci_issues script in cleanup workflow
 -   chore(setup): ensure `setup-env.sh` installs Python 3.12 when Docker is unavailable
 -   chore(ci): validate bot permissions with `list-bots.py`
 -   chore(ci): route retrospective alerts through notify workflow

--- a/scripts/list_open_ci_issues.py
+++ b/scripts/list_open_ci_issues.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Print numbers of open ci-failure issues."""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+
+def main() -> int:
+    result = subprocess.run(
+        [
+            "gh",
+            "issue",
+            "list",
+            "--label",
+            "ci-failure",
+            "--state",
+            "open",
+            "--json",
+            "number",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    issues = json.loads(result.stdout)
+    for issue in issues:
+        print(issue["number"])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add list_open_ci_issues.py helper script
- use the helper in cleanup-ci-failure workflow
- document workflow script usage in changelog

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_687c813d4098832087421f5fd53e0181