### PR TITLE
Convert Potato line to heading

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be recorded in this file.
 
 ## [Unreleased]
 
+-   docs(potato): convert Easter egg line to heading
+
 -   chore(setup): ensure `setup-env.sh` installs Python 3.12 when Docker is unavailable
 -   chore(ci): validate bot permissions with `list-bots.py`
 -   chore(ci): route retrospective alerts through notify workflow

--- a/docs/about-potato.md
+++ b/docs/about-potato.md
@@ -8,21 +8,21 @@ every phase of the workflow: immortalized in `.gitignore`, `.dockerignore`,
 
 ### Why Potato?
 
-* **A Running Joke**
-  What started as an inside joke soon became a symbol of creativity, humility,
-  and perseverance in our engineering culture.
-* **A Guardian**
-  The presence of “Potato” and `Potato.md` in our ignore files reminds us never
-  to take ourselves too seriously—and that every line of code carries a bit of
-  our team’s story.
-* **A Check**
-  Our CI pipeline and pre-commit hooks protect Potato’s legacy, ensuring it is
-  never accidentally removed and continues to travel with every branch, PR, and
-  release.
+-   **A Running Joke**
+    What started as an inside joke soon became a symbol of creativity, humility,
+    and perseverance in our engineering culture.
+-   **A Guardian**
+    The presence of “Potato” and `Potato.md` in our ignore files reminds us never
+    to take ourselves too seriously—and that every line of code carries a bit of
+    our team’s story.
+-   **A Check**
+    Our CI pipeline and pre-commit hooks protect Potato’s legacy, ensuring it is
+    never accidentally removed and continues to travel with every branch, PR, and
+    release.
 
 ---
 
-### 🥚 Easter Egg: Who *is* Potato?
+### 🥚 Easter Egg: Who _is_ Potato?
 
 Nobody knows for sure.
 Is Potato a mischievous mascot?
@@ -30,6 +30,7 @@ A legendary coder who once hot-fixed production at midnight?
 Or just a humble vegetable with a dream?
 
 All we know is:
-**If you spot the Potato, you’re on the right path.**
 
-*(P.S. There might be a secret channel named after Potato. Ask a maintainer if you dare!)*
+### If you spot the Potato, you’re on the right path
+
+_(P.S. There might be a secret channel named after Potato. Ask a maintainer if you dare!)_


### PR DESCRIPTION
## Summary
- reformat the Potato Easter egg line in `about-potato.md` as a heading
- note the update in `docs/CHANGELOG.md`

## Testing
- `bash scripts/check_docs.sh` *(fails: Markdownlint issues found)*
- `pre-commit run --files docs/about-potato.md docs/CHANGELOG.md` *(fails: Markdownlint issues found)*

------
https://chatgpt.com/codex/tasks/task_e_687c8d1e3cfc8320a14f5d615aa626e6