### PR TITLE
Fix self-grep in permission check

### DIFF
--- a/.github/workflows/validate-permissions.yml
+++ b/.github/workflows/validate-permissions.yml
@@ -43,7 +43,7 @@ jobs:
             echo "Direct gh issue command found" >&2
             exit 1
           fi
-          if grep -R "notify-humans.sh" .github/workflows; then
+          if grep -R "notify-humans.sh" .github/workflows | grep -v validate-permissions.yml; then
             echo "External notification script used" >&2
             exit 1
           fi

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be recorded in this file.
 -   docs(ci): outline `markdown/fix-style-violations` task in `.codex/automation-tasks.md`
 -   docs(pr-template): add Codex policy checklist bullet to PR templates
 -   docs(readme): mention `mise use` for installing Python 3.12
+-   fix(ci): exclude self from notify-humans check in validate-permissions.yml
 -   docs(bot): add `docs/bot-types.md` and update bot README and main README
 -   docs(readme): link to `docs/bot-types.md` for Discord bot versus Codex agents
 -   chore(setup): warn when Python < 3.12 in `setup-env.sh`


### PR DESCRIPTION
## Summary
- ignore validate-permissions workflow file when scanning for `notify-humans.sh`
- document change in changelog

## Testing
- `bash scripts/check_docs.sh` *(fails: Markdownlint issues, missing Vale)*
- `pytest -q` *(fails: ModuleNotFoundError: httpx, requests, yaml)*

------
https://chatgpt.com/codex/tasks/task_e_687c91cdd15c83209af6f0d7b701a6fb