### PR TITLE
fix(ci): exclude self from Slack webhook check

### DIFF
--- a/.github/workflows/validate-permissions.yml
+++ b/.github/workflows/validate-permissions.yml
@@ -47,7 +47,7 @@ jobs:
             echo "External notification script used" >&2
             exit 1
           fi
-          if grep -R "hooks.slack.com" .github/workflows; then
+          if grep -R "hooks.slack.com" .github/workflows | grep -v validate-permissions.yml; then
             echo "Direct Slack notification found" >&2
             exit 1
           fi

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be recorded in this file.
 -   docs(pr-template): add Codex policy checklist bullet to PR templates
 -   docs(readme): mention `mise use` for installing Python 3.12
 -   fix(ci): exclude self from notify-humans check in validate-permissions.yml
+-   fix(ci): exclude self from Slack webhook check in validate-permissions.yml
 -   docs(bot): add `docs/bot-types.md` and update bot README and main README
 -   docs(readme): link to `docs/bot-types.md` for Discord bot versus Codex agents
 -   chore(setup): warn when Python < 3.12 in `setup-env.sh`


### PR DESCRIPTION
## Summary
- ignore validate-permissions.yml when scanning for Slack webhooks
- note validation fix in changelog

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_687ca4c4014c8320a321f9db7ec827de