### PR TITLE
Add CI checklist snippet

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be recorded in this file.
 -   docs(retros): introduce retrospective framework and audit workflow
 -   docs(retros): document `scripts/create-retro-file.sh` usage for new retrospectives
 -   docs(ci): note `OPENAI_API_KEY` secret requirement for `auto-fix.yml`
+-   docs(ci): add PR checklist snippet under `docs/checklists/` and reference it from README
 -   FEAT(ci): add Codex CI failure diagnoser script for auto-triage
 -   docs(ci): introduce CI-first OpenAI API key policy document
 -   chore(ci): use list_open_ci_issues script in cleanup workflow

--- a/docs/README.md
+++ b/docs/README.md
@@ -273,7 +273,8 @@ Pull requests must include the block from
 labeled **## Continuous Improvement Checklist**. The CI workflow fails when this
 heading is missing. See
 [`checklists/continuous-improvement.md`](checklists/continuous-improvement.md)
-for the items.
+for the items. If the GitHub UI does not preload the template, copy the snippet
+from [`checklists/ci-checklist-snippet.md`](checklists/ci-checklist-snippet.md).
 
 4. Review [sample-pr.md](sample-pr.md) for an end-to-end example.
 5. See the Codex CI Monitoring Policy in [../AGENTS.md](../AGENTS.md) for how failed CI jobs automatically create tasks.

--- a/docs/checklists/ci-checklist-snippet.md
+++ b/docs/checklists/ci-checklist-snippet.md
@@ -1,0 +1,4 @@
+## Continuous Improvement Checklist
+
+- [ ] `docs/checklists/continuous-improvement.md` reviewed and all items checked
+- [ ] Relevant retrospective updated under `docs/checklists/retros/`


### PR DESCRIPTION
## Summary
- add CI checklist snippet for copy/paste
- mention snippet in README
- note change in changelog

## Testing
- `bash scripts/check_docs.sh`

------
https://chatgpt.com/codex/tasks/task_e_687caebc0f1c832092007e627d01a38d