### PR TITLE
Emphasize pip installs before pytest

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,16 +16,19 @@ pre-commit install
 ```
 
 Install the Python and Node.js dependencies before running tests or any
-`pre-commit` commands:
+`pre-commit` commands. Run `pip install -e .` and
+`pip install -r requirements-dev.txt` before executing `pytest`:
 
 ```bash
+pip install -e .
 pip install -r requirements-dev.txt
 npm ci --prefix bot
 npm ci --prefix frontend
 pre-commit install
 ```
 
-You can run `scripts/dev_setup.sh` to perform these steps automatically.
+You can run `scripts/dev_setup.sh` to perform these steps automatically, or
+`scripts/setup_tests.sh` to install only the Python requirements.
 See [docs/dependencies.md](docs/dependencies.md) for the Dependabot update workflow.
 
 See [.codex/Agents.md](.codex/Agents.md) for agent YAML guidelines and notification rules.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be recorded in this file.
 -   docs(potato): convert Easter egg line to heading
 
 -   docs(discord): specify `text` language for message templates
+-   docs(readme, contributing): emphasize running `pip install -e .` and `pip install -r requirements-dev.txt` before `pytest`; add `scripts/setup_tests.sh`
 
 -   chore(setup): ensure `setup-env.sh` installs Python 3.12 when Docker is unavailable
 -   chore(ci): validate bot permissions with `list-bots.py`

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,8 @@ check in CI. See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
 4. Install the project in editable mode with `pip install -e .` so the
    `devonboarder` package can be imported during tests. Then install the dev
    requirements with `pip install -r requirements-dev.txt`.
+   These commands **must run before** you execute `pytest`. Run
+   `scripts/setup_tests.sh` to automate this step.
 
     Tests run only on **Python 3.12**. Use `mise use -g python 3.12`
     (or `asdf install python 3.12`) before running `pip install -e .`.
@@ -53,8 +55,10 @@ check in CI. See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
     After installing dependencies, run `npm run coverage` in the `frontend/`
     directory as well (see [../frontend/README.md](../frontend/README.md) for
     details).
-    Install the project and dev requirements **before running the tests**.
-    Skipping `pip install -e .` often leads to `ModuleNotFoundError` when
+    Install the project and dev requirements with `pip install -e .` and
+    `pip install -r requirements-dev.txt` **before running `pytest`**. The
+    helper script `scripts/setup_tests.sh` runs both commands. Skipping
+    `pip install -e .` often leads to `ModuleNotFoundError` when
     `pytest` imports the `devonboarder` package:
 
     ```bash

--- a/scripts/setup_tests.sh
+++ b/scripts/setup_tests.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Install Python dependencies required for running tests
+set -euo pipefail
+
+pip install -e .
+pip install -r requirements-dev.txt
+pip check
+
+echo "Test dependencies installed ✅"
+


### PR DESCRIPTION
## Summary
- instruct running `pip install -e .` and `pip install -r requirements-dev.txt` before tests
- create `scripts/setup_tests.sh` helper script
- note the new step in CONTRIBUTING and docs
- update changelog

## Testing
- `bash scripts/setup_tests.sh`
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_687cb90036cc83209a9618c1dc9aa613