### PR TITLE
Add CI resilience hardening docs link

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -876,3 +876,4 @@ dev`.
 -   chore(ci): log closed issue numbers in `cleanup-ci-failure.yml`
 -   docs(ci): add CI resilience hardening prompt for AutoFix
 -   docs(templates): add header to EnvVar Misalignment issue template
+-   docs(ci): link CI resilience hardening steps in failure issue guide and README

--- a/docs/README.md
+++ b/docs/README.md
@@ -139,6 +139,8 @@ platforms. Please report any issues you encounter on your operating system.
     &ndash; summary of tokens and other variables used by the workflows.
 -   [CI-first OpenAI API key policy](ci-first-policy.md)
     &ndash; explains why the OpenAI key only exists in CI.
+-   [CI resilience hardening steps](../codex/prompts/ci_resilience_hardening.md)
+    &ndash; quick checklist for analyzing failing runs.
 -   [Discord message templates](discord/discord-message-templates.md) &ndash; sample posts for the community.
 -   [Discord server configuration](discord/configuration.md) &ndash; enable the widget for status display.
 -   [Doc QA onboarding](doc-quality-onboarding.md) &ndash; quickstart for documentation checks.

--- a/docs/ci-failure-issues.md
+++ b/docs/ci-failure-issues.md
@@ -1,6 +1,12 @@
 # Managing CI Failure Issues
 
-When the CI workflow fails, it opens or updates an issue titled `CI Failure: PR #<number>` with a summary of the failing tests. The commit SHA is stored as an HTML comment in the issue body for reference. The workflow closes all open `ci-failure` issues once any CI run succeeds.
+When the CI workflow fails, it opens or updates an issue titled `CI Failure: PR #<number>`.
+It includes a short summary of the failing tests.
+The commit SHA is stored as an HTML comment in the issue body for reference.
+The workflow closes all open `ci-failure` issues once any CI run succeeds.
+
+See the [CI resilience hardening steps](../codex/prompts/ci_resilience_hardening.md).
+The file offers a quick way to analyze failing runs.
 
 ## Automatic Cleanup
 


### PR DESCRIPTION
## Summary
- link to the CI resilience hardening prompt from the CI failure issues guide
- reference the guide in docs README
- note docs change in the changelog

## Testing
- `bash scripts/check_potato_ignore.sh`
- `bash scripts/check_docs.sh`
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_687cb9103fd08320ace924853da738e0