### PR TITLE
Include full checklist in missing-PR comment

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be recorded in this file.
 -   docs(bot): add `docs/bot-types.md` and update bot README and main README
 -   chore(ci): enforce PR checklist with `scripts/validate_pr_checklist.sh`
 -   fix(ci): ignore comment failures in `validate_pr_checklist.sh`
+-   fix(ci): include full checklist content in `validate_pr_checklist.sh` comments
 -   docs(readme): link to `docs/bot-types.md` for Discord bot versus Codex agents
 -   chore(setup): warn when Python < 3.12 in `setup-env.sh`
 -   docs(retros): introduce retrospective framework and audit workflow

--- a/scripts/validate_pr_checklist.sh
+++ b/scripts/validate_pr_checklist.sh
@@ -18,10 +18,26 @@ if [ "$has_heading" = "yes" ] && [ "$has_checkbox" = "yes" ]; then
 fi
 
 echo "Continuous Improvement Checklist missing or incomplete" >&2
-cat docs/checklists/ci-checklist-snippet.md >&2
+cat docs/checklists/continuous-improvement.md >&2
+
+checklist_file="docs/checklists/continuous-improvement.md"
+checklist_content=$(cat "$checklist_file")
+
+comment_body=$(cat <<EOF
+\xE2\x9A\xA0\xEF\xB8\x8F **Continuous Improvement Checklist is missing or incomplete**
+
+Please review and complete the following:
+
+```markdown
+$checklist_content
+```
+
+Once completed, push an update or comment to rerun checks.
+EOF
+)
 
 if command -v gh >/dev/null 2>&1; then
-  gh pr comment "$pr_number" -b "Please include the Continuous Improvement Checklist from docs/checklists/ci-checklist-snippet.md." \
+  gh pr comment "$pr_number" -b "$comment_body" \
     || echo "warning: unable to comment on PR" >&2
 fi
 

--- a/tests/test_validate_pr_checklist.py
+++ b/tests/test_validate_pr_checklist.py
@@ -1,0 +1,55 @@
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+
+def setup_script(tmp_path: Path, body: str) -> tuple[Path, dict[str, str]]:
+    repo_root = Path(__file__).resolve().parents[1]
+    script_src = repo_root / "scripts" / "validate_pr_checklist.sh"
+    script_dst = tmp_path / "validate_pr_checklist.sh"
+    shutil.copy(script_src, script_dst)
+
+    checklist_dir = tmp_path / "docs" / "checklists"
+    checklist_dir.mkdir(parents=True)
+    shutil.copy(
+        repo_root / "docs" / "checklists" / "continuous-improvement.md",
+        checklist_dir / "continuous-improvement.md",
+    )
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    gh_stub = bin_dir / "gh"
+    gh_stub.write_text(
+        f"#!/bin/sh\nif [ \"$1\" = \"pr\" ] && [ \"$2\" = \"view\" ]; then\n  echo '{body}'\n  exit 0\nfi\nexit 0\n"
+    )
+    gh_stub.chmod(0o755)
+
+    env = os.environ.copy()
+    env["PATH"] = str(bin_dir) + os.pathsep + env.get("PATH", "")
+    return script_dst, env
+
+
+def test_validate_pr_checklist_success(tmp_path: Path) -> None:
+    body = "## Continuous Improvement Checklist\n- [ ] item"
+    script, env = setup_script(tmp_path, body)
+    result = subprocess.run([
+        "bash",
+        str(script),
+        "1",
+    ], cwd=tmp_path, env=env)
+    assert result.returncode == 0
+
+
+def test_validate_pr_checklist_failure(tmp_path: Path) -> None:
+    script, env = setup_script(tmp_path, "missing")
+    result = subprocess.run(
+        ["bash", str(script), "1"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert result.returncode == 1
+    assert "Continuous Improvement Checklist missing or incomplete" in result.stderr
+    assert "Retrospective for the sprint" in result.stderr


### PR DESCRIPTION
## Summary
- embed `docs/checklists/continuous-improvement.md` content directly in the PR checklist reminder
- add tests for `validate_pr_checklist.sh`
- log change in `CHANGELOG`

## Testing
- `ruff check scripts/validate_pr_checklist.sh tests/test_validate_pr_checklist.py`
- `python3.12 -m venv /tmp/venv && source /tmp/venv/bin/activate && pip install -r requirements-dev.txt && pip install -e . && ruff check . && pytest --cov=src --cov-fail-under=95`

------
https://chatgpt.com/codex/tasks/task_e_687cc7538eb08320a5ac72fa4f2a6575