### PR TITLE
Update docs for inventory and CI audit outputs

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be recorded in this file.
 
 <!-- markdownlint-disable MD030 -->
 
+-   docs(prompts): clarify dependency inventory saved to `docs/dependency_inventory.xlsx` and CI audits to `audit.md`
+
 -   docs(potato): convert Easter egg line to heading
 
 -   docs(discord): specify `text` language for message templates

--- a/docs/README.md
+++ b/docs/README.md
@@ -240,7 +240,7 @@ The Discord bot exposes several slash commands documented in
 [bot/README.md](../bot/README.md). Use `/qa_checklist` to display the QA
 checklist from `docs/QA_CHECKLIST.md`; the command sends it back in ephemeral
 messages. Run `/dependency_inventory` to upload `dependency_inventory.xlsx` as a
-file for maintainers.
+file for maintainers. The exported spreadsheet now lives at `docs/dependency_inventory.xlsx`.
 
 ## Documentation Quality Checks
 
@@ -301,15 +301,16 @@ from [`checklists/ci-checklist-snippet.md`](checklists/ci-checklist-snippet.md).
    [ci-failure-issues.md#forked-pull-requests](ci-failure-issues.md#forked-pull-requests).
 10. A nightly job (`cleanup-ci-failure.yml`) logs token details, closes any open
     `ci-failure` issues, and opens a follow-up ticket if cleanup fails.
+11. Failing jobs run `scripts/ci_failure_diagnoser.py` to create an `audit.md` summary. The file uploads with the CI logs and is appended to any failure issue.
 
-11. A weekly job (`security-audit.yml`) runs dependency audits and uploads the report as an artifact.
-12. CODEOWNERS automatically requests reviews from the maintainer team.
-13. The `auto-fix.yml` workflow runs when CI fails. It downloads the `ci-logs` artifact,
+12. A weekly job (`security-audit.yml`) runs dependency audits and uploads the report as an artifact.
+13. CODEOWNERS automatically requests reviews from the maintainer team.
+14. The `auto-fix.yml` workflow runs when CI fails. It downloads the `ci-logs` artifact,
     asks OpenAI for a YAML patch using `yamllint` output, applies it, then requests a
     broader fix and opens a pull request with `peter-evans/create-pull-request`.
     Add a `CI_BUILD_OPENAPI` secret under **Settings → Secrets and variables → Actions** (or `OPENAI_API_KEY` if unavailable)
     so the workflow can request a patch from OpenAI.
-14. The `ci-monitor.yml` workflow scans CI logs for several rate-limit phrases.
+15. The `ci-monitor.yml` workflow scans CI logs for several rate-limit phrases.
     It quotes the first match and opens an issue using
     `${{ secrets.CI_ISSUE_TOKEN }}` or `${{ secrets.GITHUB_TOKEN }}` when that
     secret isn’t set. See [ci-env-vars.md](ci-env-vars.md) for details.


### PR DESCRIPTION
## Summary
- document new inventory output path in docs and changelog
- clarify the CI audit workflow

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_687d3659c3c08320b1d9836393d47254