### PR TITLE
Fix envvar misalignment template front matter

### DIFF
--- a/.github/ISSUE_TEMPLATE/envvar-misalignment.md
+++ b/.github/ISSUE_TEMPLATE/envvar-misalignment.md
@@ -1,9 +1,11 @@
-# EnvVar Misalignment
+---
 name: EnvVar Misalignment
 about: Report missing or extra environment variables
 title: "[EnvVar]"
 labels: ["ops"]
 ---
+
+# EnvVar Misalignment
 
 ## Missing variables
 <!-- List required variables that are absent -->


### PR DESCRIPTION
## Summary
- add opening front matter marker to envvar misalignment issue template
- keep title heading below the YAML block

## Testing
- `npx -y markdownlint-cli2 .github/ISSUE_TEMPLATE/envvar-misalignment.md` *(fails only on MD025, confirming MD003 passes)*

------
https://chatgpt.com/codex/tasks/task_e_687d38b622d88320a6d40529a5701510