### PR TITLE
Update agent docs with codex-agent headers

### DIFF
--- a/.codex/agents/index.json
+++ b/.codex/agents/index.json
@@ -163,6 +163,13 @@
             "output": "Deleted branch log"
         },
         {
+            "name": "Agent.AgentMaintenance",
+            "role": "Migrates and standardizes Codex agents",
+            "path": "agents/agent-maintenance.md",
+            "triggers": "Manual run",
+            "output": "Updated agent registry"
+        },
+        {
             "name": "Agent.ReviewKnownErrors",
             "role": "Placeholder for future implementation",
             "path": "codex/agents/review-known-errors.md",

--- a/agents/agent-maintenance.md
+++ b/agents/agent-maintenance.md
@@ -1,9 +1,10 @@
 ---
-agent: agent-maintenance
-purpose: Migrates and standardizes Codex agents
-trigger: manual
-environment: local or CI
-output: .codex/logs/agent-maintenance.log
+codex-agent:
+  name: Agent.AgentMaintenance
+  role: Migrates and standardizes Codex agents
+  scope: local or CI
+  triggers: manual
+  output: .codex/logs/agent-maintenance.log
 permissions:
   - repo:write
   - contents:read

--- a/agents/ai-mentor.md
+++ b/agents/ai-mentor.md
@@ -1,9 +1,10 @@
 ---
-agent: ai-mentor
-purpose: Provides automated mentorship and resource guidance to new contributors
-trigger: on_question_received
-environment: any
-output: .codex/logs/ai-mentor.log
+codex-agent:
+  name: Agent.AiMentor
+  role: Provides automated mentorship and resource guidance to new contributors
+  scope: onboarding assistance
+  triggers: on_question_received
+  output: .codex/logs/ai-mentor.log
 permissions:
   - repo:read
 ---

--- a/agents/dev-orchestrator.md
+++ b/agents/dev-orchestrator.md
@@ -1,9 +1,10 @@
 ---
-agent: dev-orchestrator
-purpose: Orchestrates development environment deployments
-trigger: on_push_to_dev
-environment: CI
-output: .codex/logs/dev-orchestrator.log
+codex-agent:
+  name: Agent.DevOrchestrator
+  role: Orchestrates development environment deployments
+  scope: .github/workflows/dev-orchestrator.yml
+  triggers: Push to dev or manual dispatch
+  output: Deployment job logs
 permissions:
   - workflows:write
 ---

--- a/agents/diagnostics-bot.md
+++ b/agents/diagnostics-bot.md
@@ -1,9 +1,10 @@
 ---
-agent: diagnostics-bot
-purpose: Collects environment diagnostics and system health info
-trigger: manual or `python -m diagnostics`
-environment: any
-output: .codex/logs/diagnostics-bot.log
+codex-agent:
+  name: Agent.DiagnosticsBot
+  role: Collects environment diagnostics and system health info
+  scope: repo utilities
+  triggers: manual or `python -m diagnostics`
+  output: .codex/logs/diagnostics-bot.log
 permissions:
   - repo:read
   - actions:read


### PR DESCRIPTION
## Summary
- switch several agent docs to `codex-agent` header format
- list `Agent.AgentMaintenance` in `.codex/agents/index.json`

## Testing
- `bash scripts/run_tests.sh`
- `python3 scripts/list-bots.py`

------
https://chatgpt.com/codex/tasks/task_e_687d7d27f3908320be987a43cbf0ad6a