### PR TITLE
Update agent index with maintenance doc

### DIFF
--- a/.codex/agents/index.json
+++ b/.codex/agents/index.json
@@ -170,6 +170,13 @@
             "output": "Updated agent registry"
         },
         {
+            "name": "Agent.AgentMaintenance",
+            "role": "Migrates and standardizes Codex agents",
+            "path": ".codex/agents/agent-maintenance.md",
+            "triggers": "Manual run",
+            "output": "Updated agent registry"
+        },
+        {
             "name": "Agent.ReviewKnownErrors",
             "role": "Placeholder for future implementation",
             "path": "codex/agents/review-known-errors.md",


### PR DESCRIPTION
## Summary
- register the Agent Maintenance documentation path in the agent index

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d8a12f4488320a876bb9e33a029f3