### PR TITLE
Add agent_maintenance bot permissions

### DIFF
--- a/.codex/bot-permissions.yaml
+++ b/.codex/bot-permissions.yaml
@@ -135,6 +135,12 @@ notify:
     permissions:
         - issues: write
 
+agent_maintenance:
+    secret: AGENT_MAINTENANCE_KEY
+    permissions:
+        - repo: write
+        - contents: read
+
 review_known_errors:
     secret: REVIEW_KNOWN_ERRORS_KEY
     permissions:


### PR DESCRIPTION
## Summary
- register `agent_maintenance` bot permissions
- run yamllint and attempted bot-permission validation

## Testing
- `yamllint -c .github/.yamllint-config .codex/bot-permissions.yaml`
- `scripts/validate-bot-permissions.sh` *(fails: JSONDecodeError)*

------
https://chatgpt.com/codex/tasks/task_e_687dd113b13483208a87deb6f40eed25