### PR TITLE
Update bot permissions

### DIFF
--- a/.codex/bot-permissions.yaml
+++ b/.codex/bot-permissions.yaml
@@ -100,6 +100,11 @@ cleanup_ci_failure:
     permissions:
         - issues: write
 
+branch_cleanup:
+    secret: BRANCH_CLEANUP_TOKEN
+    permissions:
+        - contents: write
+
 close_codex_issues:
     secret: CLOSE_CODEX_ISSUES_KEY
     permissions:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be recorded in this file.
 -   chore(setup): ensure `setup-env.sh` installs Python 3.12 when Docker is unavailable
 -   chore(ci): validate bot permissions with `list-bots.py`
 -   chore(ci): route retrospective alerts through notify workflow
+-   chore(bots): record Branch Cleanup permissions in `.codex/bot-permissions.yaml`
 -   docs(ci): outline CI enforcement tasks in `.codex/automation-tasks.md`
 -   docs(ci): outline `markdown/fix-style-violations` task in `.codex/automation-tasks.md`
 -   docs(pr-template): add Codex policy checklist bullet to PR templates


### PR DESCRIPTION
## Summary
- add Branch Cleanup bot permissions
- note missing Branch Cleanup permissions in changelog

## Testing
- `bash scripts/check_docs.sh`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687e546ee7c4832085bbff7878809da8