### PR TITLE
Fix markdownlint issues in docs

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -812,6 +812,7 @@ dev`.
     check the GitHub CLI version and fall back to `awk` parsing when searches fail.
 -   Fixed YAML indentation in `ci.yml` for the Python dependency audit step.
 -   docs(ci): expand automation tasks with 12-section outline referencing bot permissions and notify workflow
+-   docs: fix markdownlint warnings in about-potato, offline setup, and invite emails
 
 ## [0.1.0] - 2025-06-14
 

--- a/docs/about-potato.md
+++ b/docs/about-potato.md
@@ -1,4 +1,4 @@
-## 🥔 About Potato
+# 🥔 About Potato
 
 **Potato** isn’t just a root vegetable—it’s the heart and legend of this
 project. “Potato” honors the founder’s unique spirit and the original spark
@@ -6,18 +6,18 @@ behind DevOnboarder. From humble beginnings, the Potato has been woven into
 every phase of the workflow: immortalized in `.gitignore`, `.dockerignore`,
 `.codespell-ignore`, and more.
 
-### Why Potato?
+## Why Potato?
 
--   **A Running Joke**
-    What started as an inside joke soon became a symbol of creativity, humility,
-    and perseverance in our engineering culture.
--   **A Guardian**
-    The presence of “Potato” and `Potato.md` in our ignore files reminds us never
-    to take ourselves too seriously—and that every line of code carries a bit of
-    our team’s story.
--   **A Check**
-    Our CI pipeline and pre-commit hooks protect Potato’s legacy, ensuring it is
-    never accidentally removed and continues to travel with every branch, PR, and
+- **A Running Joke**
+  What started as an inside joke soon became a symbol of creativity, humility,
+  and perseverance in our engineering culture.
+- **A Guardian**
+  The presence of “Potato” and `Potato.md` in our ignore files reminds us never
+  to take ourselves too seriously—and that every line of code carries a bit of
+  our team’s story.
+- **A Check**
+  Our CI pipeline and pre-commit hooks protect Potato’s legacy, ensuring it is
+  never accidentally removed and continues to travel with every branch, PR, and
     release.
 
 ---
@@ -33,4 +33,4 @@ All we know is:
 
 ### If you spot the Potato, you’re on the right path
 
-_(P.S. There might be a secret channel named after Potato. Ask a maintainer if you dare!)_
+(P.S. There might be a secret channel named after Potato. Ask a maintainer if you dare!)

--- a/docs/offline-setup.md
+++ b/docs/offline-setup.md
@@ -95,9 +95,7 @@ command works offline:
     tar -xzf ~/devonboarder-offline/trivy/trivy.tar.gz -C ~/devonboarder-offline/trivy
     ```
 
-# `scripts/trivy_scan.sh` fetches this tarball automatically when network access is available
-
-````
+    `scripts/trivy_scan.sh` fetches this tarball automatically when network access is available.
 
 2. Copy the `devonboarder-offline` folder to your offline machine.
 
@@ -105,7 +103,7 @@ command works offline:
 
 ```bash
 sudo install -m 755 /path/to/devonboarder-offline/trivy/trivy /usr/local/bin/trivy
-````
+```
 
 Use `scripts/trivy_scan.sh` to scan the images built with `docker-compose.ci.yaml`.
 

--- a/emails/founders_invite.md
+++ b/emails/founders_invite.md
@@ -1,4 +1,6 @@
-Hello <Name>,
+# Founders Invite
+
+Hello &lt;Name&gt;,
 
 Welcome to the Founder's Circle! Your insight will help steer our roadmap.
 

--- a/emails/invite_alpha_email.md
+++ b/emails/invite_alpha_email.md
@@ -1,4 +1,6 @@
-Hello <Name>,
+# Founders Invite
+
+Hello &lt;Name&gt;,
 
 Thanks for joining our alpha! We're excited to hear what you think.
 


### PR DESCRIPTION
## Summary
- add missing H1 headers in documentation and email templates
- replace stray quad fences and adjust list formatting
- fix heading levels and inline HTML issues
- summarize lint fixes in changelog

## Testing
- `markdownlint-cli2 docs/about-potato.md emails/founders_invite.md emails/invite_alpha_email.md docs/offline-setup.md docs/governance/bot_access_governance.md`

------
https://chatgpt.com/codex/tasks/task_e_687e5ea463a88320824f56e64e078834