### PR TITLE
Add optional test extras and update docs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,7 +5,7 @@
 Refer to [doc-quality-onboarding.md](../docs/doc-quality-onboarding.md) for setup instructions.
 - Review [docs/QA_CHECKLIST.md](../docs/QA_CHECKLIST.md) for manual QA steps.
 
-- [ ] All Python and JS dependencies installed (`pip install -r requirements-dev.txt`, `npm ci` if needed)
+- [ ] All Python and JS dependencies installed (`pip install .[test]`, `npm ci` if needed)
 - [ ] Vale is installed locally (`vale --version`)
 - [ ] All Markdown docs pass checks (`bash scripts/check_docs.sh`)
 - [ ] All new or updated docs are clear, concise, and free of grammar issues

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
               uses: actions/cache@v3
               with:
                   path: ~/.cache/pip
-                  key: ${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('requirements-dev.txt') }}
+                  key: ${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}
                   restore-keys: |
                       ${{ runner.os }}-py${{ matrix.python-version }}-
             - name: Cache frontend node modules
@@ -121,7 +121,7 @@ jobs:
               run: mkdir -p ci-logs
             - name: Install dev dependencies
               run: |
-                  pip install -r requirements-dev.txt 2>&1 | tee ci-logs/pip-install.log || {
+                  pip install .[test] 2>&1 | tee ci-logs/pip-install.log || {
                       echo "Pip install failed. See docs/offline-setup.md for offline instructions." >&2
                       exit 1
                   }

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -44,7 +44,7 @@ jobs:
           node-version: "20"
       - name: Install Python dependencies
         run: |
-          pip install -r requirements-dev.txt
+          pip install .[test]
           pip install -e .
           pip install pip-audit
       - name: Install frontend dependencies

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,12 +16,10 @@ pre-commit install
 ```
 
 Install the Python and Node.js dependencies before running tests or any
-`pre-commit` commands. Run `pip install -e .` and
-`pip install -r requirements-dev.txt` before executing `pytest`:
+`pre-commit` commands. Run `pip install -e .[test]` before executing `pytest`:
 
 ```bash
-pip install -e .
-pip install -r requirements-dev.txt
+pip install -e .[test]
 npm ci --prefix bot
 npm ci --prefix frontend
 pre-commit install

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Workflow documentation lives under the [docs/](docs/) directory. New contributor
     `choco install vale` on Windows. You can also download it from the
     [Vale releases page](https://github.com/errata-ai/vale/releases).
     If the binary isn't in your `PATH`, set the `VALE_BINARY` environment variable
-    and install Python dependencies from `requirements-dev.txt` so the
+    and install the optional test dependencies with `pip install .[test]` so the
     documentation checks work locally.
 17. Browse the [agents overview](agents/index.md) for individual service specs.
     Codex reads the machine‑readable list in `.codex/agents/index.json` to
@@ -234,8 +234,7 @@ docker compose -f archive/docker-compose.prod.yaml --env-file .env.prod up -d
    Install Node.js packages with `npm ci` in each subdirectory:
 
     ```bash
-    pip install -e .  # or `pip install -r requirements.txt` if present
-    pip install -r requirements-dev.txt
+    pip install -e .[test]  # or `pip install -r requirements.txt` if present
     ruff check .
     pytest --cov=src --cov-fail-under=95
     npm ci --prefix bot && npm run coverage --prefix bot

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,7 +11,8 @@ All notable changes to this project will be recorded in this file.
 -   docs(potato): convert Easter egg line to heading
 
 -   docs(discord): specify `text` language for message templates
--   docs(readme, contributing): emphasize running `pip install -e .` and `pip install -r requirements-dev.txt` before `pytest`; add `scripts/setup_tests.sh`
+-   docs(readme, contributing): emphasize running `pip install -e .[test]` before `pytest`; add `scripts/setup_tests.sh`
+-   feat(project): add optional `test` extras and use `pip install .[test]` in CI
 
 -   chore(setup): ensure `setup-env.sh` installs Python 3.12 when Docker is unavailable
 -   chore(ci): validate bot permissions with `list-bots.py`

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -74,8 +74,7 @@ Install the project in editable mode before running the tests to ensure
 all dependencies are available:
 
 ```bash
-pip install -e .
-pip install -r requirements-dev.txt
+pip install -e .[test]
 ```
 
 Tests run only on **Python 3.12**. Run `mise use -g python 3.12`

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,14 +22,13 @@ check in CI. See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
    workflow runs the same script before building containers so your
    environment matches the pipeline.
 3. Build the service containers with `make deps`.
-4. Install the project in editable mode with `pip install -e .` so the
-   `devonboarder` package can be imported during tests. Then install the dev
-   requirements with `pip install -r requirements-dev.txt`.
-   These commands **must run before** you execute `pytest`. Run
+4. Install the project in editable mode with `pip install -e .[test]` so the
+   `devonboarder` package and its test dependencies are available.
+   This command **must run before** you execute `pytest`. Run
    `scripts/setup_tests.sh` to automate this step.
 
     Tests run only on **Python 3.12**. Use `mise use -g python 3.12`
-    (or `asdf install python 3.12`) before running `pip install -e .`.
+    (or `asdf install python 3.12`) before running `pip install -e .[test]`.
     Verify with `python3 --version`.
 
 5. Start services with `make up` or run
@@ -55,15 +54,14 @@ check in CI. See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
     After installing dependencies, run `npm run coverage` in the `frontend/`
     directory as well (see [../frontend/README.md](../frontend/README.md) for
     details).
-    Install the project and dev requirements with `pip install -e .` and
-    `pip install -r requirements-dev.txt` **before running `pytest`**. The
-    helper script `scripts/setup_tests.sh` runs both commands. Skipping
-    `pip install -e .` often leads to `ModuleNotFoundError` when
+    Install the project and test requirements with
+    `pip install -e .[test]` **before running `pytest`**. The helper
+    script `scripts/setup_tests.sh` runs this command. Skipping
+    `pip install -e .[test]` often leads to `ModuleNotFoundError` when
     `pytest` imports the `devonboarder` package:
 
     ```bash
-    pip install -e .  # or `pip install -r requirements.txt` if you have one
-    pip install -r requirements-dev.txt
+    pip install -e .[test]  # or `pip install -r requirements.txt` if you have one
     ```
 
     `pytest.ini` sets `pythonpath=src` so tests can locate the
@@ -260,7 +258,7 @@ See [doc-quality-onboarding.md](doc-quality-onboarding.md) for a step-by-step gu
     `vale` binary to a directory in your `PATH`.
 -   If the binary lives outside `PATH`, set the `VALE_BINARY` environment variable
     to its location so `scripts/check_docs.sh` can find it.
--   Install Python dev dependencies with `pip install -r requirements-dev.txt`.
+  -   Install Python dev dependencies with `pip install .[test]`.
 -   Optionally set `LANGUAGETOOL_URL` when running your own LanguageTool server
     for local grammar checks. See the [LanguageTool HTTP server guide](https://dev.languagetool.org/http-server).
 -   Markdown files must not exceed 120 characters per line (MD013). See

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,14 @@ dependencies = [
     "psycopg2-binary",
 ]
 
+[project.optional-dependencies]
+test = [
+    "pytest",
+    "pytest-cov",
+    "requests",
+    "pyyaml",
+]
+
 [project.scripts]
 devonboarder = "devonboarder.cli:main"
 devonboarder-server = "devonboarder.server:main"

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -3,12 +3,11 @@ set -euo pipefail
 
 # Always ensure development requirements are installed
 echo "Installing dev requirements..."
-pip install -r requirements-dev.txt
+pip install -e .[test]
 pip check
 
 # Ensure runtime dependencies are installed
 if [ -f pyproject.toml ]; then
-    pip install -e .
     pip check
 fi
 
@@ -27,9 +26,8 @@ set -e
 if grep -q "ModuleNotFoundError" "$pytest_log"; then
     echo
     echo "ModuleNotFoundError detected during tests."
-    echo "Make sure you've installed the project and development requirements:"
-    echo "  pip install -e ."
-    echo "  pip install -r requirements-dev.txt"
+    echo "Make sure you've installed the project and test requirements:"
+    echo "  pip install -e .[test]"
     echo "See the troubleshooting section in docs/README.md for details."
 fi
 

--- a/scripts/setup_tests.sh
+++ b/scripts/setup_tests.sh
@@ -2,8 +2,7 @@
 # Install Python dependencies required for running tests
 set -euo pipefail
 
-pip install -e .
-pip install -r requirements-dev.txt
+pip install -e .[test]
 pip check
 
 echo "Test dependencies installed ✅"

--- a/tests/README.md
+++ b/tests/README.md
@@ -5,8 +5,7 @@ so Python can resolve all imports. **These commands must run before invoking
 `pytest`.**
 
 ```bash
-pip install -e .
-pip install -r requirements-dev.txt
+pip install -e .[test]
 ```
 
 Then run `pytest` from the repository root with coverage enabled:


### PR DESCRIPTION
## Summary
- add `[project.optional-dependencies]` section for test extras
- update docs and contributor guides to use `pip install -e .[test]`
- adjust CI to install extras with `pip install .[test]`
- update helper scripts for new install command

## Testing
- `bash scripts/setup_tests.sh`
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_687e6306dfcc8320a5fefce5b38d68bf