### PR TITLE
Update CI dependency install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,7 @@ jobs:
             - name: Setup environment
               run: ./scripts/setup-env.sh
             - name: Install package
-              run: pip install -e . 2>&1 | tee ci-logs/pip-install-editable.log
+              run: pip install -e .[test] 2>&1 | tee ci-logs/pip-install-editable.log
             - name: Enforce Potato ignore policy
               run: bash scripts/check_potato_ignore.sh
             - name: Generate OpenAPI spec

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be recorded in this file.
 -   docs(discord): specify `text` language for message templates
 -   docs(readme, contributing): emphasize running `pip install -e .[test]` before `pytest`; add `scripts/setup_tests.sh`
 -   feat(project): add optional `test` extras and use `pip install .[test]` in CI
+-   chore(ci): install package with test extras during setup
 
 -   chore(setup): ensure `setup-env.sh` installs Python 3.12 when Docker is unavailable
 -   chore(ci): validate bot permissions with `list-bots.py`

--- a/scripts/setup-env.sh
+++ b/scripts/setup-env.sh
@@ -65,9 +65,9 @@ EOF
     if [ -f requirements-dev.txt ]; then
         pip install -r requirements-dev.txt
     fi
-    # Install the project so runtime dependencies are available
+    # Install the project with test extras so runtime dependencies are available
     if [ -f pyproject.toml ]; then
-        pip install -e .
+        pip install -e .[test]
     fi
     if [ -d frontend ]; then
         cd frontend


### PR DESCRIPTION
## Summary
- install package with test extras during CI setup
- install extras in `setup-env.sh`

## Testing
- `bash scripts/setup_tests.sh`
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_687e701bc77c83208819ae949ddb5c03