### PR TITLE
DOCS(git): clarify CHORE usage in commit examples

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be recorded in this file.
 - docs(potato): convert Easter egg line to heading
 
 - docs(discord): specify `text` language for message templates
+- docs(git): clarify CHORE usage in commit examples
 - docs(readme, contributing): emphasize running `pip install -e .[test]` before `pytest`; add `scripts/setup_tests.sh`
 - feat(project): add optional `test` extras and use `pip install .[test]` in CI
 - chore(ci): install package with test extras during setup

--- a/docs/git-guidelines.md
+++ b/docs/git-guidelines.md
@@ -31,8 +31,12 @@ Add login form UI
 Includes basic username and password fields.
 ```
 
-Commit types like `FEAT`, `FIX` and `DOCS` must be uppercase as shown in
-[AGENTS.md](../AGENTS.md).
+Commit types like `FEAT`, `FIX`, `DOCS`, and `CHORE` must be uppercase as shown in
+[AGENTS.md](../AGENTS.md). Use `CHORE` for routine maintenance or CI changes, e.g.:
+
+```text
+CHORE(ci): update Node version in workflow
+```
 
 See the **commit-message policy** in [../AGENTS.md](../AGENTS.md) for a detailed
 explanation of the required format and history rules.


### PR DESCRIPTION
## Summary
- clarify CHORE commit guidance in `docs/git-guidelines.md`
- note the update in `docs/CHANGELOG.md`

## Testing
- `bash scripts/validate.sh`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688a2b0c3d80832080b9e02c89ed0132