### PR TITLE
Update commit example capitalization

### DIFF
--- a/docs/git/Git.md
+++ b/docs/git/Git.md
@@ -248,7 +248,7 @@ Ensure clear, consistent commit messages that aid review and traceability.
 #### Example
 
 ```plaintext
-feat(api): add token validation logic
+FEAT(api): add token validation logic
 
 - Added JWT parsing
 - Included `express-jwt` middleware


### PR DESCRIPTION
## Summary
- fix commit example in docs to use uppercase type

## Testing
- `pre-commit run --files docs/git/Git.md` *(fails: shellcheck build failure)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_688a3fa9e49c83209c9363ff8d00747c