### PR TITLE
Update PR checklist commenting

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -902,3 +902,4 @@ dev`.
 - docs(templates): add header to EnvVar Misalignment issue template
 - fix(ci): use dedicated token for PR checklist comments in `validate-permissions.yml`
 - docs(ci): link CI resilience hardening steps in failure issue guide and README
+- chore(ci): use `gh pr comment` in `validate_pr_checklist.sh` for posting checklists

--- a/scripts/validate_pr_checklist.sh
+++ b/scripts/validate_pr_checklist.sh
@@ -24,14 +24,14 @@ checklist_file="docs/checklists/continuous-improvement.md"
 checklist_content=$(cat "$checklist_file")
 
 comment_body=$(cat <<EOF
-\xE2\x9A\xA0\xEF\xB8\x8F **Continuous Improvement Checklist is missing or incomplete**
+⚠️ **Continuous Improvement Checklist is missing or incomplete**
 
 Please review and complete the following checklist before merging:
 
 ---
 
 <details>
-<summary>\xF0\x9F\x93\x8B Continuous Improvement Checklist</summary>
+<summary>📋 Continuous Improvement Checklist</summary>
 
 \`\`\`markdown
 $checklist_content
@@ -44,13 +44,10 @@ EOF
 )
 
 if command -v gh >/dev/null 2>&1; then
-  pr_id=$(gh pr view "$pr_number" --json id -q '.id' 2>/dev/null || echo "")
-  if [ -n "$pr_id" ]; then
-    # shellcheck disable=SC2016
-    gh api graphql -F subjectId="$pr_id" -F body="$comment_body" \
-      -f query='mutation($subjectId: ID!, $body: String!) { addComment(input:{subjectId:$subjectId, body:$body}) { commentEdge { node { url } } } }' \
-      >/dev/null || echo "warning: unable to comment on PR" >&2
-  fi
+  tmpfile=$(mktemp)
+  printf '%s\n' "$comment_body" > "$tmpfile"
+  gh pr comment "$pr_number" --body-file "$tmpfile" >/dev/null \
+    || echo "warning: unable to comment on PR" >&2
 fi
 
 exit 1

--- a/tests/test_validate_pr_checklist.py
+++ b/tests/test_validate_pr_checklist.py
@@ -4,7 +4,7 @@ import subprocess
 from pathlib import Path
 
 
-def setup_script(tmp_path: Path, body: str) -> tuple[Path, dict[str, str]]:
+def setup_script(tmp_path: Path, body: str) -> tuple[Path, dict[str, str], Path]:
     repo_root = Path(__file__).resolve().parents[1]
     script_src = repo_root / "scripts" / "validate_pr_checklist.sh"
     script_dst = tmp_path / "validate_pr_checklist.sh"
@@ -19,9 +19,11 @@ def setup_script(tmp_path: Path, body: str) -> tuple[Path, dict[str, str]]:
 
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
+    gh_calls = tmp_path / "gh_calls.log"
     gh_stub = bin_dir / "gh"
     gh_stub.write_text(
         "#!/bin/sh\n"
+        f"echo \"$@\" >>'{gh_calls}'\n"
         'if [ "$1" = "pr" ] && [ "$2" = "view" ]; then\n'
         f"  echo '{body}'\n"
         "  exit 0\n"
@@ -32,12 +34,12 @@ def setup_script(tmp_path: Path, body: str) -> tuple[Path, dict[str, str]]:
 
     env = os.environ.copy()
     env["PATH"] = str(bin_dir) + os.pathsep + env.get("PATH", "")
-    return script_dst, env
+    return script_dst, env, gh_calls
 
 
 def test_validate_pr_checklist_success(tmp_path: Path) -> None:
     body = "## Continuous Improvement Checklist\n- [ ] item"
-    script, env = setup_script(tmp_path, body)
+    script, env, gh_calls = setup_script(tmp_path, body)
     result = subprocess.run(
         [
             "bash",
@@ -48,10 +50,13 @@ def test_validate_pr_checklist_success(tmp_path: Path) -> None:
         env=env,
     )
     assert result.returncode == 0
+    calls = gh_calls.read_text().splitlines()
+    assert any("pr view" in call for call in calls)
+    assert not any("pr comment" in call for call in calls)
 
 
 def test_validate_pr_checklist_failure(tmp_path: Path) -> None:
-    script, env = setup_script(tmp_path, "missing")
+    script, env, gh_calls = setup_script(tmp_path, "missing")
     result = subprocess.run(
         ["bash", str(script), "1"],
         cwd=tmp_path,
@@ -62,3 +67,6 @@ def test_validate_pr_checklist_failure(tmp_path: Path) -> None:
     assert result.returncode == 1
     assert "Continuous Improvement Checklist missing or incomplete" in result.stderr
     assert "Retrospective for the sprint" in result.stderr
+    calls = gh_calls.read_text().splitlines()
+    assert any("pr view" in call for call in calls)
+    assert any("pr comment" in call for call in calls)


### PR DESCRIPTION
## Summary
- comment on PRs using `gh pr comment` instead of GraphQL
- ensure UTF‑8 characters are embedded directly in the checklist comment
- track `gh` invocations in checklist tests
- document the new approach in the changelog

## Testing
- `scripts/setup_tests.sh`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a45d266288320bb6e211e75a6e01a