### PR TITLE
Fix CI token environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,7 @@ jobs:
             (github.event_name == 'push' &&
              !contains(join(github.event.head_commit.message), '[no-ci]'))
         runs-on: ubuntu-latest
+        environment: ci
         strategy:
             matrix:
                 python-version: ["3.12"]

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be recorded in this file.
 - feat(docs): comprehensive ROADMAP.md and ROADMAP_SUMMARY.md for DevSecOps Manager review
 - fix(ci): added .markdownlintignore to prevent scanning of node_modules and dependencies
 - docs(retro): add retrospective for roadmap documentation project
+- fix(ci): declare CI environment for issue automation token
 
 - docs(agents): remove duplicate Agent Maintenance documentation entry
 


### PR DESCRIPTION
## Summary
- expose CI environment so jobs can access `CI_ISSUE_AUTOMATION_TOKEN`
- note CI environment key in changelog

## Testing
- `ruff check .`
- `pytest` *(fails: OperationalError)*

------
https://chatgpt.com/codex/tasks/task_e_688be59acb988320bbb5d85463cd0fbd

⚠️ **Continuous Improvement Checklist is missing or incomplete**

Please review and complete the following checklist before merging:

---

<details>
<summary>📋 Continuous Improvement Checklist</summary>

```markdown
# Continuous Improvement Checklist

Use this list to review regular retrospective and automation tasks. Mark completed items with `[x]`.

- [x] Retrospective for the sprint is documented in `docs/checklists/retros/`
- [x] All action items assigned with owners and dates
- [x] Unresolved items from previous retrospectives have issues or are carried over
- [x] CI workflow changes recorded in `docs/CHANGELOG.md`
```

</details>

Once completed, push an update or comment to rerun checks.