### PR TITLE
feat(openapi): scaffold spec, CI linting, docs, and tests (phase 2 placeholder)

### DIFF
--- a/.github/workflows/openapi-validate.yml
+++ b/.github/workflows/openapi-validate.yml
@@ -1,0 +1,34 @@
+name: openapi-validate
+on:
+  pull_request:
+  push:
+    branches: [ main, develop, feat/openapi-phase-2 ]
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install CLI tools
+        run: |
+          npm i -g @redocly/cli @stoplight/spectral-cli
+
+      - name: Spectral Lint
+        run: spectral lint "openapi/**/*.yaml"
+
+      - name: Redocly Lint
+        run: redocly lint "openapi/**/*.yaml"
+
+  preview:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm i -g @redocly/cli
+      - name: Bundle HTML docs
+        run: redocly build-docs openapi/devonboarder.ci.yaml -o openapi-preview.html
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: openapi-preview
+          path: openapi-preview.html

--- a/.redocly.yaml
+++ b/.redocly.yaml
@@ -1,0 +1,6 @@
+aspis:
+  devonboarder:
+    root: openapi/devonboarder.ci.yaml
+lint:
+  extends:
+    - recommended

--- a/.spectral.json
+++ b/.spectral.json
@@ -1,0 +1,7 @@
+{
+  "extends": ["spectral:oas", "spectral:asyncapi"],
+  "rules": {
+    "operation-summary": "warn",
+    "operation-description": "off"
+  }
+}

--- a/docs/openapi.md
+++ b/docs/openapi.md
@@ -1,0 +1,42 @@
+---
+title: "OpenAPI in DevOnboarder"
+description: "How we author, validate, mock, and consume OpenAPI contracts."
+author: "TAGS Engineering"
+created_at: "2025-09-04"
+updated_at: "2025-09-04"
+tags: ["docs", "openapi", "contracts"]
+project: "DevOnboarder"
+document_type: "guide"
+status: "draft"
+visibility: "internal"
+codex_scope: "tags"
+codex_role: "cto"
+codex_type: "documentation"
+---
+
+## Why
+OpenAPI complements our YAML front-matter governance by defining machine-readable HTTP contracts for internal and external services.
+
+## Where
+Specs live under `/openapi/*.yaml`. Governance mirrors via `x-codex`.
+
+## Validate
+- Local: `make openapi-lint`
+- CI: `.github/workflows/openapi-validate.yml` (Spectral + Redocly)
+
+## Mock
+- Local: `make openapi-mock` (Prism on port 4010 by default)
+- Wire tests against the mock to stabilize agent behavior.
+
+## Generate Clients (optional)
+- `make openapi-client-python` → outputs to `/clients/python`
+- Pin generator version in CI to avoid drift.
+
+## Authoring Guidelines
+- Use 3.1 format when possible.
+- Prefer component schemas with enums for stability.
+- Use `x-codex` to preserve our governance metadata.
+- Keep breaking changes behind feature branches; PR must update version.
+
+## Versioning
+- Bump `info.version` using SemVer when paths/schemas change.

--- a/openapi/devonboarder.ci.yaml
+++ b/openapi/devonboarder.ci.yaml
@@ -1,0 +1,78 @@
+openapi: 3.1.0
+info:
+  title: "DevOnboarder CI Diagnostics API"
+  description: "Read-only endpoints for CI health, logs, and triage hints."
+  version: "0.1.0"
+  contact:
+    name: "TAGS Engineering"
+    url: "https://github.com/theangrygamershowproductions"
+x-codex:
+  project: "DevOnboarder"
+  codex_scope: "tags"
+  codex_role: "cto"
+  codex_type: "service-contract"
+  author: "TAGS Engineering"
+  created_at: "2025-09-04"
+  updated_at: "2025-09-04"
+  tags: ["ci", "diagnostics", "automation"]
+servers:
+  - url: https://api.example.local/ci
+paths:
+  /health:
+    get:
+      summary: "Liveness probe"
+      tags: ["health"]
+      responses:
+        "200":
+          description: "OK"
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    enum: ["ok"]
+  /triage/findings:
+    get:
+      summary: "Latest CI findings"
+      tags: ["triage"]
+      parameters:
+        - in: query
+          name: since
+          description: "ISO8601 timestamp; return findings updated since this time."
+          schema:
+            type: string
+            format: date-time
+      responses:
+        "200":
+          description: "List of findings"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Finding"
+components:
+  schemas:
+    Finding:
+      type: object
+      required:
+        - id
+        - severity
+        - message
+      properties:
+        id:
+          type: string
+        severity:
+          type: string
+          enum:
+            - low
+            - medium
+            - high
+            - critical
+        message:
+          type: string
+        evidence_url:
+          type: string
+          format: uri

--- a/tests/test_openapi_client_smoke.py
+++ b/tests/test_openapi_client_smoke.py
@@ -1,0 +1,8 @@
+import importlib
+
+
+def test_client_imports():
+    try:
+        importlib.import_module("devonboarder_ci_client")
+    except Exception as e:
+        raise AssertionError(f"Client import failed: {e}")


### PR DESCRIPTION
# PR Review Checklist
Adds OpenAPI scaffold with x-codex metadata, Spectral/Redocly CI linting, preview artifact, docs, Spectral rules, and a client import smoke test. This sets the stage for Phase 2 API contracts but does not impact the current MVP. See issue #1231 for context.


## Documentation & QA Checklist

Refer to [doc-quality-onboarding.md](../docs/doc-quality-onboarding.md) for setup instructions.

- Review [docs/QA_CHECKLIST.md](../docs/QA_CHECKLIST.md) for manual QA steps.

- [ ] All Python and JS dependencies installed (`pip install .[test]`, `npm ci` if needed)
- [ ] Vale is installed locally (`vale --version`)
- [ ] All Markdown docs pass checks (`bash scripts/check_docs.sh`)
- [ ] All new or updated docs are clear, concise, and free of grammar issues
- [ ] pytest and other test suites pass
- [ ] Pre-commit hooks installed (`pre-commit install`)
- [ ] If doc checks failed, issues are resolved before requesting review

## Code Checklist

- [ ] All code passes automated lint, type, test, and security checks
- [ ] **Terminal Output Policy**: No emojis, command substitution, or multi-line echo in workflows
- [ ] **Markdown Standards**: All documentation follows MD022 and MD032 linting rules
- [ ] OpenAPI, contract, and migration checks pass
- [ ] All FastAPI endpoints include docstrings and documentation
- [ ] CORS and security headers validated
- [ ] No secrets or sensitive data are present in commits
- [ ] Did Codex introduce any direct commits to `main`?
- [ ] Are all Codex changes covered by tests and docs?
- [ ] Coverage does not decrease (see CI summary)
- [ ] This PR updates `.codex/automation-tasks.md`. I have reviewed the automation impact and notified reviewers.

## Reviewer Sign-Off

- [ ] I confirm all checklist items are complete.

## Continuous Improvement Checklist

- [ ] `docs/checklists/continuous-improvement.md` reviewed and all items checked
- [ ] Relevant retrospective updated under `docs/checklists/retros/`
