### PR TITLE
DOCS(readme): fix Phase 1 status from Active to Complete - resolves #1341

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ DevOnboarder uses a comprehensive three-project structure for optimal organizati
 
 | Phase | Timeline | Milestone | Status |
 |-------|----------|-----------|---------|
-| **Phase 1** | Weeks 1-2 | [Foundation Stabilization](https://github.com/theangrygamershowproductions/DevOnboarder/issues/1088) | 🔄 Active |
+| **Phase 1** | Weeks 1-2 | [Foundation Stabilization](https://github.com/theangrygamershowproductions/DevOnboarder/issues/1088) | ✅ Complete |
 | **Phase 2** | Weeks 3-4 | [Feature Completion](https://github.com/theangrygamershowproductions/DevOnboarder/issues/1089) | ⏳ Planned |
 | **Phase 3** | Weeks 5-6 | [MVP Finalization](https://github.com/theangrygamershowproductions/DevOnboarder/issues/1090) | ⏳ Planned |
 


### PR DESCRIPTION
## 📋 Overview

Critical documentation accuracy fix for Phase 1 status in README.md project management section.

## 🔍 Problem

User investigation revealed README.md contains incorrect Phase 1 status that contradicts GitHub milestone reality:
- ❌ **README.md**: Shows Phase 1 as `🔄 Active` 
- ✅ **GitHub**: [Milestone #1088](https://github.com/theangrygamershowproductions/DevOnboarder/milestone/1) shows **CLOSED** status

## 🛠️ Solution

**Single Line Change:**
```diff
- | **Phase 1** | Weeks 1-2 | [Foundation Stabilization](https://github.com/theangrygamershowproductions/DevOnboarder/issues/1088) | 🔄 Active |
+ | **Phase 1** | Weeks 1-2 | [Foundation Stabilization](https://github.com/theangrygamershowproductions/DevOnboarder/issues/1088) | ✅ Complete |
```

## ✅ Verification

```bash
# Verify milestone is actually closed
gh api repos/theangrygamershowproductions/DevOnboarder/milestones/1 --jq '.state'
# Returns: "closed"

# Verify README now shows correct status
grep "Phase 1.*Complete" README.md
```

## 🔗 Related Issues

- **Resolves**: #1341 (Comprehensive documentation integrity review)
- **Context**: User identified documentation inaccuracies during post-PR cleanup investigation
- **Related**: #1261 (Milestone documentation standardization - Phase 1 COMPLETE)

## 📊 Impact

- **Credibility**: Documentation now accurately reflects project reality
- **User Experience**: No confusion about current project phase status
- **Team Coordination**: Accurate status supports proper milestone tracking

## 🎯 Testing

- [x] Pre-commit hooks pass (markdownlint, codespell, etc.)
- [x] Change verified against GitHub milestone status
- [x] No breaking changes to documentation structure
- [x] Links remain functional

---

**Type**: Documentation accuracy fix  
**Priority**: Critical (user-identified credibility issue)  
**Scope**: Single line status correction