### PR TITLE
FIX(ci): enhance post-merge cleanup with better error handling for already-closed issues

### DIFF
--- a/docs/troubleshooting/POST_MERGE_CLEANUP_EXIT_CODES.md
+++ b/docs/troubleshooting/POST_MERGE_CLEANUP_EXIT_CODES.md
@@ -1,0 +1,69 @@
+# Post-Merge Cleanup Exit Code Troubleshooting
+
+## Overview
+
+The Post-Merge Cleanup workflow (`post-merge-cleanup.yml`) automates the closure of CI failure issues after successful PR merges. This document covers common exit code failures and their resolutions.
+
+## Common Exit Code Issues
+
+### Exit Code 1: GitHub CLI Operation Failure
+
+**Symptom**: Post-Merge Cleanup fails with exit code 1, but logs show successful operations.
+
+**Common Causes**:
+
+1. **Already Closed Issue**: Attempting to close an issue that's already been closed
+2. **Permission Issues**: Insufficient token permissions for issue operations
+3. **Network Timeouts**: GitHub API timeouts during operations
+
+### Issue Already Closed (Most Common)
+
+**Pattern**:
+
+```text
+Found PR number: 1339
+Closing issue #1344...
+SUCCESS: Added resolution comment to issue #1344
+FAILED: Failed to close issue #1344
+```
+
+**Root Cause**: The issue was closed between script execution start and the close operation.
+
+**Resolution**: This is expected behavior when issues are closed by other processes (manual closure, other automation). The script should be enhanced to handle this gracefully.
+
+**Temporary Workaround**: Re-run the cleanup or ignore the failure if the comment was added successfully.
+
+### Permission Issues
+
+**Pattern**:
+
+```text
+FAILED: Failed to comment on issue #1344
+FAILED: Failed to close issue #1344
+```
+
+**Root Cause**: Token lacks `issues: write` permission.
+
+**Resolution**: Verify token hierarchy:
+
+- `CI_ISSUE_AUTOMATION_TOKEN` (preferred)
+- `CI_BOT_TOKEN` (fallback)
+- `GITHUB_TOKEN` (default)
+
+### Network/API Issues
+
+**Pattern**: Intermittent failures with timeout messages.
+
+**Resolution**: Retry the operation or check GitHub API status.
+
+## Prevention
+
+- Add issue state checking before close operations
+- Implement graceful handling for already-closed issues
+- Add retry logic for transient failures
+
+## Related Documentation
+
+- [CI Issue Automation Token Failures](./CI_ISSUE_AUTOMATION_TOKEN_FAILURES.md)
+- [Post-Merge Cleanup Workflow](../.github/workflows/post-merge-cleanup.yml)
+- [Issue Management Script](../scripts/manage_ci_failure_issues.sh)

--- a/scripts/manage_ci_failure_issues.sh
+++ b/scripts/manage_ci_failure_issues.sh
@@ -172,8 +172,12 @@ EOF
                 echo "${RED}FAILED: Failed to comment on issue #$issue_number${NC}"
             fi
 
-            # Close the issue
-            if gh issue close "$issue_number" --reason completed; then
+            # Close the issue (check if already closed first)
+            current_state=$(gh issue view "$issue_number" --json state --jq .state 2>/dev/null || echo "unknown")
+            if [[ "$current_state" == "CLOSED" ]]; then
+                echo "${YELLOW}INFO:  Issue #$issue_number already closed, skipping${NC}"
+                ((closed_count++))
+            elif gh issue close "$issue_number" --reason completed; then
                 echo "${GREEN}SUCCESS: Closed issue #$issue_number${NC}"
                 ((closed_count++))
             else


### PR DESCRIPTION
## Problem

The Post-Merge Cleanup workflow was failing when trying to close CI failure issues that were already closed by other processes. This caused exit code 1 failures even when the operation was functionally successful.

## Root Cause

- Issue #1344 was already closed when Post-Merge Cleanup for PR #1339 tried to close it
- The script didn't check issue state before attempting to close
- GitHub CLI returns an error when trying to close an already-closed issue

## Solution

1. **Enhanced Script Logic**: Added issue state checking before close operations
2. **Documentation**: Created comprehensive troubleshooting guide in `docs/troubleshooting/POST_MERGE_CLEANUP_EXIT_CODES.md`
3. **Graceful Handling**: Script now detects already-closed issues and counts them as successful

## Changes

- **scripts/manage_ci_failure_issues.sh**: Added state checking with `gh issue view` before close
- **docs/troubleshooting/POST_MERGE_CLEANUP_EXIT_CODES.md**: New troubleshooting documentation

## Testing

- Pre-commit hooks passed
- Enhanced error handling prevents false failures
- Documentation follows markdown standards

Fixes the issue identified in CI run https://github.com/theangrygamershowproductions/DevOnboarder/actions/runs/17622307065