### PR TITLE
FIX(ci): Skip PR Issue Automation for dependabot PRs

### DIFF
--- a/.github/workflows/pr-issue-automation.yml
+++ b/.github/workflows/pr-issue-automation.yml
@@ -43,7 +43,7 @@ concurrency:
 jobs:
     create-pr-tracking-issue:
         runs-on: ubuntu-latest
-        if: ${{ !github.event.pull_request.draft }}
+        if: ${{ !github.event.pull_request.draft && github.actor != 'dependabot[bot]' }}
 
         permissions:
             contents: read


### PR DESCRIPTION
## Problem
Dependabot PRs are failing CI because the PR Issue Automation workflow requires secrets (AAR_BOT_TOKEN, CI_ISSUE_AUTOMATION_TOKEN, CI_BOT_TOKEN) that are not accessible to dependabot PRs for security reasons.

## Solution  
- Add condition to skip PR Issue Automation for dependabot PRs
- Dependabot PRs don't need tracking issues anyway
- This unblocks all 10 pending dependabot dependency updates

## Impact
- ✅ Fixes CI blocking issue for dependabot PRs
- ✅ Maintains security by not exposing secrets to dependabot
- ✅ Allows dependency updates to proceed normally
- ✅ No impact on regular PRs (they still get tracking issues)

## Testing
This PR itself should pass CI and demonstrate the fix working.