### PR TITLE
FIX(ci): fix yamllint glob pattern in 11 workflows

### DIFF
--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -37,7 +37,7 @@ jobs:
               run: pip install yamllint==1.35.1
 
             - name: Lint YAML files
-              run: yamllint -c .github/.yamllint-config '.github/workflows/**/*.yml'
+              run: yamllint -c .github/.yamllint-config .github/workflows/
     fix:
         needs: validate-yaml
         if: github.event.workflow_run.conclusion == 'failure'

--- a/.github/workflows/ci-health.yml
+++ b/.github/workflows/ci-health.yml
@@ -37,7 +37,7 @@ jobs:
               run: pip install yamllint==1.35.1
 
             - name: Lint YAML files
-              run: yamllint -c .github/.yamllint-config '.github/workflows/**/*.yml'
+              run: yamllint -c .github/.yamllint-config .github/workflows/
 
     branches:
         needs: validate-yaml

--- a/.github/workflows/ci-monitor.yml
+++ b/.github/workflows/ci-monitor.yml
@@ -32,7 +32,7 @@ jobs:
               run: pip install yamllint==1.35.1
 
             - name: Lint YAML files
-              run: yamllint -c .github/.yamllint-config '.github/workflows/**/*.yml'
+              run: yamllint -c .github/.yamllint-config .github/workflows/
     report-rate-limit:
         needs: validate-yaml
         if: github.event.workflow_run.conclusion == 'failure'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         run: pip install yamllint==1.35.1
 
       - name: Lint YAML files
-        run: yamllint -c .github/.yamllint-config '.github/workflows/**/*.yml'
+        run: yamllint -c .github/.yamllint-config .github/workflows/
   filter:
     needs: validate-yaml
     runs-on: ubuntu-latest

--- a/.github/workflows/cleanup-ci-failure.yml
+++ b/.github/workflows/cleanup-ci-failure.yml
@@ -37,7 +37,7 @@ jobs:
 
             - name: Lint YAML files and save log
               run: |
-                  yamllint -c .github/.yamllint-config '.github/workflows/**/*.yml' | tee yamllint.log || true
+                  yamllint -c .github/.yamllint-config .github/workflows/ | tee yamllint.log || true
 
             - name: Upload yamllint log
               if: always()

--- a/.github/workflows/close-codex-issues.yml
+++ b/.github/workflows/close-codex-issues.yml
@@ -30,7 +30,7 @@ jobs:
               run: pip install yamllint==1.35.1
 
             - name: Lint YAML files
-              run: yamllint -c .github/.yamllint-config '.github/workflows/**/*.yml'
+              run: yamllint -c .github/.yamllint-config .github/workflows/
     close:
         needs: validate-yaml
         if: github.event.pull_request.merged == true

--- a/.github/workflows/env-doc-alignment.yml
+++ b/.github/workflows/env-doc-alignment.yml
@@ -37,7 +37,7 @@ jobs:
               run: pip install yamllint==1.35.1
 
             - name: Lint YAML files
-              run: yamllint -c .github/.yamllint-config '.github/workflows/**/*.yml'
+              run: yamllint -c .github/.yamllint-config .github/workflows/
     audit:
         needs: validate-yaml
         if: github.event.workflow_run.conclusion == 'failure'

--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -33,7 +33,7 @@ jobs:
               run: pip install yamllint==1.35.1
 
             - name: Lint YAML files
-              run: yamllint -c .github/.yamllint-config '.github/workflows/**/*.yml'
+              run: yamllint -c .github/.yamllint-config .github/workflows/
     process:
         needs: validate-yaml
         runs-on: ubuntu-latest

--- a/.github/workflows/secrets-alignment.yml
+++ b/.github/workflows/secrets-alignment.yml
@@ -40,7 +40,7 @@ jobs:
               run: pip install yamllint==1.35.1
 
             - name: Lint YAML files
-              run: yamllint -c .github/.yamllint-config '.github/workflows/**/*.yml'
+              run: yamllint -c .github/.yamllint-config .github/workflows/
     audit:
         needs: validate-yaml
         if: github.event_name == 'schedule' || github.event.workflow_run.conclusion == 'failure'

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -31,7 +31,7 @@ jobs:
               run: pip install yamllint==1.35.1
 
             - name: Lint YAML files
-              run: yamllint -c .github/.yamllint-config '.github/workflows/**/*.yml'
+              run: yamllint -c .github/.yamllint-config .github/workflows/
     audit:
         needs: validate-yaml
         runs-on: ubuntu-latest

--- a/.github/workflows/validate-permissions.yml
+++ b/.github/workflows/validate-permissions.yml
@@ -35,7 +35,7 @@ jobs:
               run: pip install yamllint==1.35.1
 
             - name: Lint YAML files
-              run: yamllint -c .github/.yamllint-config '.github/workflows/**/*.yml'
+              run: yamllint -c .github/.yamllint-config .github/workflows/
     check:
         needs: validate-yaml
         runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Fixes the `validate-yaml` CI failures affecting **all PRs** in DevOnboarder by correcting the glob pattern syntax in 11 workflow files.

## Root Cause

The yamllint command used a single-quoted glob pattern:
```bash
yamllint -c .github/.yamllint-config '.github/workflows/**/*.yml'
```

Single quotes prevent bash glob expansion, causing yamllint to receive the literal string `.github/workflows/**/*.yml` instead of expanded file paths. This results in:
```
[Errno 2] No such file or directory: '.github/workflows/**/*.yml'
```

## Solution

Changed to directory-based scanning (yamllint traverses directories natively):
```bash
yamllint -c .github/.yamllint-config .github/workflows/
```

## Affected Workflows (11)

| Workflow | Job |
|----------|-----|
| auto-fix.yml | validate-yaml |
| ci-health.yml | validate-yaml |
| ci-monitor.yml | validate-yaml |
| ci.yml | validate-yaml |
| cleanup-ci-failure.yml | validate-yaml |
| close-codex-issues.yml | validate-yaml |
| env-doc-alignment.yml | validate-yaml |
| notify.yml | validate-yaml |
| secrets-alignment.yml | validate-yaml |
| security-audit.yml | validate-yaml |
| validate-permissions.yml | validate-yaml |

## Unblocks

- PR #1941 (dependabot: lodash-es bump)
- PR #1939 (dependabot: tar bump)
- All future PRs affected by `validate-yaml` failures

## Testing

Verified locally:
```bash
yamllint -c .github/.yamllint-config .github/workflows/
# Now works - finds and lints all YAML files
```
