### PR TITLE
CHORE(ci): pin tags-workflows refs to SHA (clean)

### DIFF
--- a/.github/workflows/ci-lite-two-lane.yml
+++ b/.github/workflows/ci-lite-two-lane.yml
@@ -7,8 +7,9 @@ name: CI Lite (Two-Lane via tags-workflows)
 #   Lane 1 (pr-validate): Untrusted PR code runs on GitHub-hosted, no secrets
 #   Lane 2 (main-ci): Trusted pushes to main run with full capabilities
 #
-# IMMUTABLE SHA: Pinned to v1.0.0 (5ab970b7f5b9dae8573b6043dad594222a58d593)
-# SHA verified: git -C tags-workflows rev-parse v1.0.0
+# SHA PIN: Pinned to tags-workflows commit for immutable references
+#
+# ALLOWLIST: theangrygamershowproductions org is allowlisted in actions-policy-enforcement.yml
 
 on:
   pull_request:
@@ -22,8 +23,7 @@ jobs:
   # Lane 1: Untrusted PR validation (GitHub-hosted, no secrets)
   pr-validate:
     if: github.event_name == 'pull_request'
-    # SHA = v1.0.0
-    uses: theangrygamershowproductions/tags-workflows/.github/workflows/ci-lite.yml@5ab970b7f5b9dae8573b6043dad594222a58d593
+    uses: theangrygamershowproductions/tags-workflows/.github/workflows/ci-lite.yml@ce3b63239d05403ecdf582c95fda779e0c33bf9e
     with:
       runner: ubuntu-latest
       trusted: false
@@ -31,9 +31,7 @@ jobs:
   # Lane 2: Trusted branch CI (self-hosted, secrets allowed)
   main-ci:
     if: github.event_name == 'push'
-    # SHA = v1.0.0
-    uses: theangrygamershowproductions/tags-workflows/.github/workflows/ci-lite.yml@5ab970b7f5b9dae8573b6043dad594222a58d593
-    with:
-      # Explicit values for clarity (matches tags-workflows defaults)
-      runner: '["self-hosted", "tagsdev"]'
-      trusted: true
+    uses: theangrygamershowproductions/tags-workflows/.github/workflows/ci-lite.yml@ce3b63239d05403ecdf582c95fda779e0c33bf9e
+    secrets: inherit
+    # runner defaults to [self-hosted, tagsdev] per workflow defaults
+    # trusted defaults to true

--- a/.github/workflows/ci-lite-two-lane.yml
+++ b/.github/workflows/ci-lite-two-lane.yml
@@ -8,7 +8,8 @@ name: CI Lite (Two-Lane via tags-workflows)
 #   Lane 2 (main-ci): Trusted pushes to main run with full capabilities
 #
 # SHA PIN: Pinned to tags-workflows commit for immutable references
-# TAGS-SHA-PIN: ce3b63239d05403ecdf582c95fda779e0c33bf9e (SHA-only policy; see ACTIONS_POLICY.md)
+# POLICY: SHA-only pinning is required (see ACTIONS_POLICY.md)
+# TAGS-SHA-PIN: tags-workflows/.github/workflows/ci-lite.yml@ce3b63239d05403ecdf582c95fda779e0c33bf9e
 # ALLOWLIST: theangrygamershowproductions org is allowlisted in actions-policy-enforcement.yml
 
 on:
@@ -23,7 +24,7 @@ jobs:
   # Lane 1: Untrusted PR validation (GitHub-hosted, no secrets)
   pr-validate:
     if: github.event_name == 'pull_request'
-    # TAGS-SHA-PIN: ci-lite.yml@ce3b63239d05403ecdf582c95fda779e0c33bf9e
+    # TAGS-SHA-PIN: ci-lite.yml@ce3b63239d05403ecdf582c95fda779e0c33bf9e (verified via git rev-parse)
     uses: theangrygamershowproductions/tags-workflows/.github/workflows/ci-lite.yml@ce3b63239d05403ecdf582c95fda779e0c33bf9e
     with:
       runner: ubuntu-latest
@@ -32,7 +33,7 @@ jobs:
   # Lane 2: Trusted branch CI (self-hosted, secrets allowed)
   main-ci:
     if: github.event_name == 'push'
-    # TAGS-SHA-PIN: ci-lite.yml@ce3b63239d05403ecdf582c95fda779e0c33bf9e
+    # TAGS-SHA-PIN: ci-lite.yml@ce3b63239d05403ecdf582c95fda779e0c33bf9e (verified via git rev-parse)
     uses: theangrygamershowproductions/tags-workflows/.github/workflows/ci-lite.yml@ce3b63239d05403ecdf582c95fda779e0c33bf9e
     with:
       runner: [self-hosted, tagsdev]

--- a/.github/workflows/ci-lite-two-lane.yml
+++ b/.github/workflows/ci-lite-two-lane.yml
@@ -8,7 +8,7 @@ name: CI Lite (Two-Lane via tags-workflows)
 #   Lane 2 (main-ci): Trusted pushes to main run with full capabilities
 #
 # SHA PIN: Pinned to tags-workflows commit for immutable references
-#
+# TAGS-SHA-PIN: ce3b63239d05403ecdf582c95fda779e0c33bf9e (SHA-only policy; see ACTIONS_POLICY.md)
 # ALLOWLIST: theangrygamershowproductions org is allowlisted in actions-policy-enforcement.yml
 
 on:
@@ -23,6 +23,7 @@ jobs:
   # Lane 1: Untrusted PR validation (GitHub-hosted, no secrets)
   pr-validate:
     if: github.event_name == 'pull_request'
+    # TAGS-SHA-PIN: ci-lite.yml@ce3b63239d05403ecdf582c95fda779e0c33bf9e
     uses: theangrygamershowproductions/tags-workflows/.github/workflows/ci-lite.yml@ce3b63239d05403ecdf582c95fda779e0c33bf9e
     with:
       runner: ubuntu-latest
@@ -31,7 +32,10 @@ jobs:
   # Lane 2: Trusted branch CI (self-hosted, secrets allowed)
   main-ci:
     if: github.event_name == 'push'
+    # TAGS-SHA-PIN: ci-lite.yml@ce3b63239d05403ecdf582c95fda779e0c33bf9e
     uses: theangrygamershowproductions/tags-workflows/.github/workflows/ci-lite.yml@ce3b63239d05403ecdf582c95fda779e0c33bf9e
-    secrets: inherit
-    # runner defaults to [self-hosted, tagsdev] per workflow defaults
-    # trusted defaults to true
+    with:
+      runner: [self-hosted, tagsdev]
+      trusted: true
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Resolve ci-lite-two-lane conflict and keep SHA-pinned tags-workflows refs
- Keep two-lane CI behavior intact (pr-validate + main-ci)

## Testing
- Not run (workflow-only change)

## Notes
- Supersedes #1951 (new clean branch with resolved conflict)
